### PR TITLE
chore: add docs deployment and github backlog tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,31 @@
+---
+name: Bug
+about: Report a defect or regression.
+title: "[BUG] "
+labels:
+  - bug
+---
+
+## Summary
+
+What is broken?
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+What should have happened?
+
+## Actual behavior
+
+What happened instead?
+
+## Notes
+
+- Environment:
+- Screenshots:
+- Related issue:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Project documentation
+    url: https://github.com/phamhungptithcm/gia-pha/tree/main/docs
+    about: Review the planning and architecture docs before opening a new issue.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,21 @@
+---
+name: Documentation
+about: Improve product, architecture, or process documentation.
+title: "[DOCS] "
+labels:
+  - docs
+---
+
+## Documentation gap
+
+What is missing, outdated, or unclear?
+
+## Proposed update
+
+Describe the improvement.
+
+## Done when
+
+- [ ] Docs are accurate
+- [ ] Navigation is updated if needed
+- [ ] Examples or references are included where helpful

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,32 @@
+---
+name: Epic
+about: Define a multi-story delivery slice.
+title: "Epic: "
+labels:
+  - epic
+  - ai-agent
+---
+
+## Problem
+
+Describe the user or business problem this epic solves.
+
+## Scope
+
+- In scope:
+- Out of scope:
+
+## Success criteria
+
+- [ ] Business outcome is defined
+- [ ] Delivery boundaries are clear
+- [ ] Child stories are identified
+
+## Supporting docs
+
+- `AI_BUILD_MASTER_DOC.md`
+- `AI_AGENT_TASKS_150_ISSUES.md`
+
+## Child stories
+
+- [ ] Add linked stories here

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,32 @@
+---
+name: Story
+about: Track a user-facing delivery slice under an epic.
+title: "[STORY-ID] "
+labels:
+  - story
+---
+
+## User story
+
+As a ...
+I want ...
+So that ...
+
+## Parent epic
+
+Link the epic issue number here.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Technical notes
+
+- Constraints:
+- Dependencies:
+
+## Supporting docs
+
+- `AI_BUILD_MASTER_DOC.md`
+- `AI_AGENT_TASKS_150_ISSUES.md`

--- a/.github/ISSUE_TEMPLATE/technical-task.md
+++ b/.github/ISSUE_TEMPLATE/technical-task.md
@@ -1,0 +1,26 @@
+---
+name: Technical task
+about: Capture implementation work that supports a story or epic.
+title: "[TASK] "
+labels:
+  - task
+---
+
+## Objective
+
+Describe the engineering task.
+
+## Why now
+
+Explain the dependency, risk reduction, or enablement value.
+
+## Definition of done
+
+- [ ] Implementation complete
+- [ ] Tests or verification updated
+- [ ] Docs updated if behavior changed
+
+## Related work
+
+- Parent issue:
+- Linked docs:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Summary
+
+Describe the scope in 2-4 bullets.
+
+## Linked issue
+
+Closes #
+
+## What changed
+
+- 
+
+## Why
+
+Explain the user, product, or technical reason for the change.
+
+## Test plan
+
+- [ ] Local verification completed
+- [ ] CI should pass
+- [ ] Screenshots attached if UI changed
+
+## Risks
+
+- 
+
+## Rollback
+
+How would we revert or disable this safely?
+
+## Checklist
+
+- [ ] Docs updated where needed
+- [ ] Acceptance criteria covered
+- [ ] No secrets or environment changes were committed

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,60 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/deploy-docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,42 @@
+name: Docs CI
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/docs-ci.yml"
+      - ".github/workflows/deploy-docs.yml"
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/docs-ci.yml"
+      - ".github/workflows/deploy-docs.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build docs
+        run: mkdocs build --strict

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Default ownership stays with the repository owner until more reviewers are added.
+* @phamhungptithcm
+
+/docs/ @phamhungptithcm
+/.github/ @phamhungptithcm
+/scripts/ @phamhungptithcm

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Gia Pha
+
+Planning and delivery repository for the Family Clan App documentation set.
+
+## Local docs preview
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-docs.txt
+mkdocs serve
+```
+
+## GitHub Pages
+
+The repository publishes the MkDocs site through GitHub Actions using the workflow in
+`.github/workflows/deploy-docs.yml`.
+
+## GitHub backlog bootstrap
+
+```bash
+python3 scripts/bootstrap_github_backlog.py --repo phamhungptithcm/gia-pha
+```
+
+The script reads `AI_AGENT_TASKS_150_ISSUES.md` and creates epics plus story issues in
+GitHub with consistent labels.

--- a/docs/05-devops/branching-strategy.md
+++ b/docs/05-devops/branching-strategy.md
@@ -1,3 +1,28 @@
 # Branching Strategy
 
-This page is a supporting document for the Family Clan App.
+The repository uses `main` as the default protected branch and favors short-lived
+topic branches.
+
+## Branch types
+
+- `main`: stable branch and GitHub Pages deployment source
+- `codex/<slug>`: Codex-created implementation branches
+- `feat/<issue-id>-<slug>`: feature delivery
+- `fix/<issue-id>-<slug>`: bug fixes
+- `docs/<issue-id>-<slug>`: documentation-only changes
+
+## Rules
+
+- branch from the latest `main`
+- keep changes scoped to one issue or one closely related set of issues
+- open a pull request before merge
+- avoid long-lived integration branches unless the team later adds `develop`
+
+## Example
+
+```text
+codex/docs-pages-and-backlog
+docs/BOOT-010-mkdocs-setup
+feat/AUTH-001-login-method-selection
+fix/SEC-003-branch-admin-guard
+```

--- a/docs/05-devops/ci-cd.md
+++ b/docs/05-devops/ci-cd.md
@@ -1,3 +1,61 @@
 # CI/CD
 
-This page is a supporting document for the Family Clan App.
+The repository uses GitHub Actions to validate documentation changes and publish the
+MkDocs site to GitHub Pages.
+
+## Workflows
+
+### `docs-ci.yml`
+
+Runs on pull requests and non-`main` pushes when any of the following change:
+
+- `docs/**`
+- `mkdocs.yml`
+- `requirements-docs.txt`
+- `.github/workflows/docs-ci.yml`
+- `.github/workflows/deploy-docs.yml`
+
+Checks performed:
+
+- install Python 3.12
+- install `mkdocs-material==9.*`
+- run `mkdocs build --strict`
+
+### `deploy-docs.yml`
+
+Runs on:
+
+- pushes to `main`
+- manual `workflow_dispatch`
+
+Deploy flow:
+
+1. checkout repository
+2. configure GitHub Pages
+3. install docs dependencies
+4. build the static site with `mkdocs build --strict`
+5. upload the `site/` artifact
+6. publish via `actions/deploy-pages`
+
+## Local preview
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-docs.txt
+mkdocs serve
+```
+
+## GitHub requirements
+
+- GitHub Actions must be enabled for the repository
+- GitHub Pages must use GitHub Actions as its publishing source
+- if the repository stays private, GitHub Pages availability depends on the account plan
+
+## Future expansion
+
+When application code is added, extend CI with:
+
+- Flutter formatting, analysis, and tests
+- Firebase Functions linting and tests
+- emulator-backed integration checks for critical paths

--- a/docs/05-devops/github-backlog.md
+++ b/docs/05-devops/github-backlog.md
@@ -1,0 +1,50 @@
+# GitHub Backlog
+
+This repository keeps planning in markdown and mirrors delivery work into GitHub
+issues.
+
+## Source documents
+
+- `AI_BUILD_MASTER_DOC.md`
+- `AI_AGENT_TASKS_150_ISSUES.md`
+- `GITHUB_AUTOMATION_AI_PIPELINE.md`
+
+## Backlog structure
+
+- epics become GitHub issues labeled `epic`
+- stories become GitHub issues labeled `story`
+- epic issues are updated with checklists that link to their child stories
+- domain labels such as `flutter`, `firebase`, `genealogy`, and `funds` help filter work
+
+## Bootstrap command
+
+Run the importer after cloning the repository and authenticating with GitHub CLI:
+
+```bash
+python3 scripts/bootstrap_github_backlog.py --repo phamhungptithcm/gia-pha
+```
+
+Useful flags:
+
+- `--dry-run` prints the actions without creating issues
+- `--limit 10` creates only the first 10 stories for testing
+
+## Current epic groups
+
+- Project Bootstrap
+- Authentication
+- Clan Management
+- Member Profiles
+- Relationship Management
+- Genealogy Read Model
+- Genealogy UI
+- Events
+- Notifications
+- Funds
+- Scholarship Programs
+- Search and Discovery
+- Profile and Settings
+- Permissions and Security
+- Cloud Functions Integration
+- Observability and Analytics
+- Release Hardening

--- a/docs/05-devops/github-workflow.md
+++ b/docs/05-devops/github-workflow.md
@@ -1,3 +1,44 @@
 # GitHub Workflow
 
-This page is a supporting document for the Family Clan App.
+This repository follows a docs-first workflow that is ready to scale into app and
+backend delivery.
+
+## Delivery loop
+
+1. start from `main`
+2. create a short-lived branch
+3. implement changes
+4. run local verification
+5. open a pull request
+6. let GitHub Actions validate docs and code
+7. merge to `main`
+8. publish docs from `main`
+
+## Pull request checklist
+
+- explain scope clearly
+- link the related issue or epic
+- note testing performed
+- call out schema or contract changes
+- include screenshots when UI content changes
+
+## Repository scaffolding
+
+The GitHub setup includes:
+
+- issue templates for epic, story, docs, bug, and technical task intake
+- a pull request template
+- CODEOWNERS for review routing
+- labels for epics, stories, domains, and agent-driven work
+- a backlog bootstrap script that creates GitHub issues from the source planning doc
+
+## Backlog source of truth
+
+Planning starts from:
+
+- `AI_BUILD_MASTER_DOC.md`
+- `AI_AGENT_TASKS_150_ISSUES.md`
+- `GITHUB_AUTOMATION_AI_PIPELINE.md`
+
+Use `scripts/bootstrap_github_backlog.py` to project those planning artifacts into
+GitHub issues without losing the original markdown source.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,10 @@
 site_name: Family Clan App
 site_description: Digital genealogy and clan management platform documentation
 site_author: Family Clan App Team
+site_url: https://phamhungptithcm.github.io/gia-pha/
+repo_url: https://github.com/phamhungptithcm/gia-pha
+repo_name: phamhungptithcm/gia-pha
+edit_uri: edit/main/docs/
 theme:
   name: material
   features:
@@ -49,6 +53,7 @@ nav:
       - CI/CD: 05-devops/ci-cd.md
       - GitHub Workflow: 05-devops/github-workflow.md
       - Branching Strategy: 05-devops/branching-strategy.md
+      - GitHub Backlog: 05-devops/github-backlog.md
   - Security:
       - Privacy Model: 06-security/privacy-model.md
       - Firebase Rules: 06-security/firebase-rules.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,1 @@
+mkdocs-material==9.*

--- a/scripts/bootstrap_github_backlog.py
+++ b/scripts/bootstrap_github_backlog.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Create GitHub epics and stories from the markdown backlog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+EPIC_RE = re.compile(r"^## EPIC (\d+) - (.+)$")
+STORY_RE = re.compile(r"^### \d+\.\s+([A-Z0-9-]+)\s+(.+)$")
+GOAL_RE = re.compile(r"^Goal:\s*(.+)$")
+ACCEPTANCE_RE = re.compile(r"^Acceptance:\s*(.+)$")
+
+
+LABELS = {
+    "epic": ("5319E7", "Top-level delivery slice"),
+    "story": ("1D76DB", "User-facing implementation story"),
+    "task": ("0E8A16", "Technical delivery task"),
+    "bug": ("D73A49", "Something is not working"),
+    "docs": ("0366D6", "Documentation work"),
+    "security": ("B60205", "Security-related work"),
+    "flutter": ("02569B", "Flutter mobile work"),
+    "firebase": ("FFCA28", "Firebase or Cloud Functions work"),
+    "genealogy": ("7F52FF", "Family tree and relationship domain"),
+    "notifications": ("FB8C00", "Notifications and reminders"),
+    "funds": ("2DA44E", "Fund and ledger features"),
+    "scholarship": ("8B5CF6", "Scholarship program features"),
+    "performance": ("C2410C", "Performance and observability"),
+    "ai-agent": ("6F42C1", "AI-friendly workflow or issue"),
+    "release": ("A371F7", "Release hardening work"),
+}
+
+
+PREFIX_LABELS = {
+    "BOOT": ["docs", "ai-agent"],
+    "AUTH": ["flutter", "firebase"],
+    "CLAN": ["flutter"],
+    "MEMBER": ["flutter"],
+    "REL": ["genealogy"],
+    "TREE": ["genealogy"],
+    "TREEUI": ["genealogy", "flutter"],
+    "EVENT": ["flutter", "notifications"],
+    "NOTIF": ["notifications", "firebase"],
+    "FUND": ["funds"],
+    "SCH": ["scholarship"],
+    "SEARCH": ["flutter"],
+    "PROF": ["flutter"],
+    "SEC": ["security", "firebase"],
+    "CF": ["firebase"],
+    "OPS": ["performance"],
+    "REL-RELEASE": ["release"],
+}
+
+
+@dataclass
+class Story:
+    story_id: str
+    title: str
+    goal: str = ""
+    acceptance: str = ""
+    epic_number: int = 0
+    epic_title: str = ""
+
+
+@dataclass
+class Epic:
+    number: int
+    title: str
+    stories: list[Story] = field(default_factory=list)
+
+
+def run(cmd: list[str], *, capture: bool = True) -> str:
+    result = subprocess.run(
+        cmd,
+        check=True,
+        text=True,
+        capture_output=capture,
+    )
+    return result.stdout if capture else ""
+
+
+def gh(cmd: list[str], *, capture: bool = True) -> str:
+    return run(["gh", *cmd], capture=capture)
+
+
+def parse_backlog(path: Path) -> list[Epic]:
+    epics: list[Epic] = []
+    current_epic: Epic | None = None
+    current_story: Story | None = None
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        epic_match = EPIC_RE.match(line)
+        if epic_match:
+            current_epic = Epic(number=int(epic_match.group(1)), title=epic_match.group(2))
+            epics.append(current_epic)
+            current_story = None
+            continue
+
+        story_match = STORY_RE.match(line)
+        if story_match and current_epic is not None:
+            current_story = Story(
+                story_id=story_match.group(1),
+                title=story_match.group(2),
+                epic_number=current_epic.number,
+                epic_title=current_epic.title,
+            )
+            current_epic.stories.append(current_story)
+            continue
+
+        if current_story is None:
+            continue
+
+        goal_match = GOAL_RE.match(line)
+        if goal_match:
+            current_story.goal = goal_match.group(1)
+            continue
+
+        acceptance_match = ACCEPTANCE_RE.match(line)
+        if acceptance_match:
+            current_story.acceptance = acceptance_match.group(1)
+
+    return epics
+
+
+def default_repo() -> str:
+    return gh(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]).strip()
+
+
+def load_existing_issues(repo: str) -> dict[str, dict[str, str | int]]:
+    payload = gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "all",
+            "--limit",
+            "500",
+            "--json",
+            "number,title,url",
+        ]
+    )
+    issues = json.loads(payload)
+    return {issue["title"]: issue for issue in issues}
+
+
+def ensure_labels(repo: str, dry_run: bool) -> None:
+    for name, (color, description) in LABELS.items():
+        cmd = [
+            "label",
+            "create",
+            name,
+            "--repo",
+            repo,
+            "--color",
+            color,
+            "--description",
+            description,
+            "--force",
+        ]
+        if dry_run:
+            print("DRY RUN:", " ".join(["gh", *cmd]))
+            continue
+        gh(cmd, capture=False)
+
+
+def labels_for_story(story: Story) -> list[str]:
+    labels = ["story"]
+    for prefix, extra_labels in PREFIX_LABELS.items():
+        if story.story_id.startswith(prefix):
+            labels.extend(extra_labels)
+            break
+    return sorted(set(labels))
+
+
+def labels_for_epic(epic: Epic) -> list[str]:
+    labels = ["epic", "ai-agent"]
+    if epic.stories:
+        labels.extend(labels_for_story(epic.stories[0]))
+    return sorted(set(label for label in labels if label != "story"))
+
+
+def issue_body_for_epic(epic: Epic, story_refs: list[str] | None = None) -> str:
+    story_lines = story_refs or ["- [ ] Stories will be linked after import"]
+    lines = [
+        "## Scope",
+        "",
+        f"Backlog epic generated from `AI_AGENT_TASKS_150_ISSUES.md` for **{epic.title}**.",
+        "",
+        "## Success criteria",
+        "",
+        "- Stories in this epic are created, linked, and tracked in GitHub",
+        "- Supporting documentation remains aligned with implementation",
+        "- Pull requests reference the correct story or epic",
+        "",
+        "## Story checklist",
+        "",
+        *story_lines,
+        "",
+        "## Source",
+        "",
+        "- `AI_AGENT_TASKS_150_ISSUES.md`",
+        "- `AI_BUILD_MASTER_DOC.md`",
+        "- `GITHUB_AUTOMATION_AI_PIPELINE.md`",
+    ]
+    return "\n".join(lines)
+
+
+def issue_body_for_story(story: Story, epic_issue_number: int) -> str:
+    goal = story.goal or "Complete the implementation slice described by the story title."
+    acceptance = story.acceptance or "Use the story title and linked docs as the minimum acceptance baseline."
+    lines = [
+        "## Parent epic",
+        "",
+        f"#{epic_issue_number} - {story.epic_title}",
+        "",
+        "## Goal",
+        "",
+        goal,
+        "",
+        "## Acceptance summary",
+        "",
+        acceptance,
+        "",
+        "## Supporting docs",
+        "",
+        "- `AI_AGENT_TASKS_150_ISSUES.md`",
+        "- `AI_BUILD_MASTER_DOC.md`",
+        "",
+        "## Delivery notes",
+        "",
+        "- Update documentation if schema, workflow, or behavior changes",
+        "- Link the pull request back to this issue",
+    ]
+    return "\n".join(lines)
+
+
+def create_issue(
+    repo: str,
+    title: str,
+    body: str,
+    labels: list[str],
+    dry_run: bool,
+) -> dict[str, str | int]:
+    if dry_run:
+        print(f"DRY RUN: create issue {title} labels={','.join(labels)}")
+        return {"number": 0, "title": title, "url": ""}
+
+    with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as handle:
+        handle.write(body)
+        temp_path = handle.name
+
+    try:
+        cmd = ["issue", "create", "--repo", repo, "--title", title, "--body-file", temp_path]
+        for label in labels:
+            cmd.extend(["--label", label])
+        output = gh(cmd).strip()
+    finally:
+        Path(temp_path).unlink(missing_ok=True)
+
+    match = re.search(r"/issues/(\d+)$", output)
+    if not match:
+        raise RuntimeError(f"Could not parse issue number from output: {output}")
+    return {"number": int(match.group(1)), "title": title, "url": output}
+
+
+def update_issue_body(repo: str, issue_number: int, body: str, dry_run: bool) -> None:
+    if dry_run:
+        print(f"DRY RUN: update issue #{issue_number}")
+        return
+
+    with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as handle:
+        handle.write(body)
+        temp_path = handle.name
+
+    try:
+        gh(["issue", "edit", str(issue_number), "--repo", repo, "--body-file", temp_path], capture=False)
+    finally:
+        Path(temp_path).unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repository in OWNER/REPO format. Defaults to the current gh repo.",
+    )
+    parser.add_argument(
+        "--source",
+        default="AI_AGENT_TASKS_150_ISSUES.md",
+        help="Path to the markdown backlog source file.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Create only the first N stories for a trial import.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print actions without creating or editing GitHub issues.",
+    )
+    args = parser.parse_args()
+
+    repo = args.repo or default_repo()
+    source_path = Path(args.source)
+    if not source_path.exists():
+        print(f"Backlog source not found: {source_path}", file=sys.stderr)
+        return 1
+
+    epics = parse_backlog(source_path)
+    story_limit = args.limit
+    if story_limit is not None:
+        remaining = story_limit
+        limited_epics: list[Epic] = []
+        for epic in epics:
+            if remaining <= 0:
+                break
+            stories = epic.stories[:remaining]
+            remaining -= len(stories)
+            limited_epics.append(Epic(number=epic.number, title=epic.title, stories=stories))
+        epics = limited_epics
+
+    print(f"Preparing GitHub backlog for {repo}")
+    print(f"Epics: {len(epics)}")
+    print(f"Stories: {sum(len(epic.stories) for epic in epics)}")
+
+    ensure_labels(repo, args.dry_run)
+    existing = load_existing_issues(repo) if not args.dry_run else {}
+
+    epic_issue_numbers: dict[int, int] = {}
+    story_refs_by_epic: dict[int, list[str]] = {epic.number: [] for epic in epics}
+
+    for epic in epics:
+        title = f"Epic: {epic.title}"
+        issue = existing.get(title)
+        if issue is None:
+            print(f"Creating epic: {title}")
+            issue = create_issue(repo, title, issue_body_for_epic(epic), labels_for_epic(epic), args.dry_run)
+            existing[title] = issue
+        else:
+            print(f"Reusing epic: {title} #{issue['number']}")
+        epic_issue_numbers[epic.number] = int(issue["number"])
+
+    for epic in epics:
+        epic_issue_number = epic_issue_numbers[epic.number]
+        for story in epic.stories:
+            title = f"[{story.story_id}] {story.title}"
+            issue = existing.get(title)
+            if issue is None:
+                print(f"Creating story: {title}")
+                issue = create_issue(
+                    repo,
+                    title,
+                    issue_body_for_story(story, epic_issue_number),
+                    labels_for_story(story),
+                    args.dry_run,
+                )
+                existing[title] = issue
+            else:
+                print(f"Reusing story: {title} #{issue['number']}")
+            story_refs_by_epic[epic.number].append(f"- [ ] #{issue['number']} - [{story.story_id}] {story.title}")
+
+    for epic in epics:
+        epic_number = epic_issue_numbers[epic.number]
+        body = issue_body_for_epic(epic, story_refs_by_epic[epic.number])
+        print(f"Updating epic checklist: #{epic_number}")
+        update_issue_body(repo, epic_number, body, args.dry_run)
+
+    print("Backlog sync complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add GitHub Actions for docs validation and GitHub Pages deployment
- add GitHub issue templates, PR template, CODEOWNERS, and docs for the GitHub workflow
- add a backlog bootstrap script to create epic and story issues from the planning markdown

## Testing
- python3 -m py_compile scripts/bootstrap_github_backlog.py
- python3 scripts/bootstrap_github_backlog.py --repo phamhungptithcm/gia-pha --limit 3 --dry-run
- ./.venv/bin/mkdocs build --strict