### PR TITLE
feat: add friendly release notes generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .venv/
 site/
+dist/
 __pycache__/
 .pytest_cache/

--- a/README.md
+++ b/README.md
@@ -101,11 +101,18 @@ The repository includes:
 - issue and pull request templates
 - CODEOWNERS support for review routing
 - backlog import automation from the source planning docs
+- a release notes generator for future tag-based release automation
 
 Create or sync the GitHub epic/story backlog with:
 
 ```bash
 python3 scripts/bootstrap_github_backlog.py --repo phamhungptithcm/gia-pha
+```
+
+Generate friendly release notes for a tagged release:
+
+```bash
+RELEASE_TAG=v0.1.0 node scripts/generate_release_notes.mjs
 ```
 
 ## Workflow

--- a/docs/05-devops/ci-cd.md
+++ b/docs/05-devops/ci-cd.md
@@ -59,3 +59,25 @@ When application code is added, extend CI with:
 - Flutter formatting, analysis, and tests
 - Firebase Functions linting and tests
 - emulator-backed integration checks for critical paths
+
+## Release notes automation
+
+The repository now includes a helper script for friendly release notes:
+
+```bash
+RELEASE_TAG=v0.1.0 node scripts/generate_release_notes.mjs
+```
+
+Expected environment variables:
+
+- `RELEASE_TAG` required, for example `v0.1.0`
+- `RELEASE_VERSION` optional override for the displayed version
+- `RELEASE_NOTES_PATH` optional output path, defaults to `dist/release-notes.md`
+- `RELEASE_PRODUCT_NAME` optional product title override
+
+This is intended for future release CI/CD flows that:
+
+1. bump the app version
+2. create a Git tag
+3. generate release notes from commit history
+4. attach those notes to the GitHub release and app store delivery step

--- a/docs/GITHUB_AUTOMATION_AI_PIPELINE.md
+++ b/docs/GITHUB_AUTOMATION_AI_PIPELINE.md
@@ -204,6 +204,12 @@ Steps:
 - deploy prod functions/rules
 - create release notes
 
+Release note generation can be scripted with:
+
+```bash
+RELEASE_TAG=v0.1.0 node scripts/generate_release_notes.mjs
+```
+
 ## 11. AI-Specific Guardrails
 
 AI agents should:

--- a/scripts/generate_release_notes.mjs
+++ b/scripts/generate_release_notes.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { execSync } from "node:child_process";
+
+const releaseTag = process.env.RELEASE_TAG;
+const releaseVersion = process.env.RELEASE_VERSION || releaseTag?.replace(/^v/, "");
+const outputPath = process.env.RELEASE_NOTES_PATH || "dist/release-notes.md";
+const productName = process.env.RELEASE_PRODUCT_NAME || "Gia Pha";
+
+if (!releaseTag) {
+  console.error("Missing RELEASE_TAG");
+  process.exit(1);
+}
+
+function run(command) {
+  return execSync(command, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function listSemverTags() {
+  return run("git tag --list 'v*'")
+    .split("\n")
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag))
+    .sort((a, b) =>
+      a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" })
+    );
+}
+
+function previousTagFor(currentTag, tags) {
+  const index = tags.indexOf(currentTag);
+  if (index <= 0) {
+    return "";
+  }
+  return tags[index - 1];
+}
+
+function parseType(subject) {
+  const match = subject.match(/^([a-z]+)(\([^)]+\))?!?:/i);
+  return match ? match[1].toLowerCase() : "update";
+}
+
+function cleanSubject(subject) {
+  let text = subject
+    .replace(/^([a-z]+)(\([^)]+\))?!?:\s*/i, "")
+    .replace(/\s*\(#\d+\)\s*$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!text) {
+    return "";
+  }
+
+  if (/^cut v\d+\.\d+\.\d+$/i.test(text)) {
+    return "";
+  }
+
+  text = text
+    .replace(/\bci\/cd\b/gi, "delivery workflow")
+    .replace(/\bci\b/gi, "automation")
+    .replace(/\bcicd\b/gi, "delivery workflow")
+    .replace(/\bui\b/gi, "interface")
+    .replace(/\bgithub\b/g, "GitHub")
+    .replace(/\bflutter\b/g, "Flutter")
+    .replace(/\bios\b/gi, "iOS")
+    .replace(/\bandroid\b/gi, "Android")
+    .replace(/[_/]/g, " ");
+
+  text = text.charAt(0).toUpperCase() + text.slice(1);
+  if (!/[.!?]$/.test(text)) {
+    text += ".";
+  }
+
+  return text;
+}
+
+const verbByType = {
+  feat: "Added",
+  fix: "Improved",
+  perf: "Made faster",
+  refactor: "Improved",
+  docs: "Updated guides",
+  ci: "Improved delivery",
+  chore: "Polished",
+  build: "Updated release pipeline",
+  test: "Improved confidence",
+};
+
+const tags = listSemverTags();
+const previousTag = previousTagFor(releaseTag, tags);
+const logRange = previousTag ? `${previousTag}..HEAD` : "HEAD";
+
+const rawSubjects = run(`git log --no-merges --pretty=format:%s ${logRange}`)
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean)
+  .filter((subject) => !/^\s*merge\b/i.test(subject))
+  .filter((subject) => !/^chore\(release\):\s*cut v\d+\.\d+\.\d+$/i.test(subject));
+
+const friendlyBullets = rawSubjects
+  .map((subject) => {
+    const type = parseType(subject);
+    const cleaned = cleanSubject(subject);
+    if (!cleaned) {
+      return "";
+    }
+    const verb = verbByType[type] || "Updated";
+    return `- ${verb}: ${cleaned}`;
+  })
+  .filter(Boolean)
+  .slice(0, 10);
+
+if (friendlyBullets.length === 0) {
+  friendlyBullets.push(
+    "- Improved overall stability, release readiness, and day-to-day experience."
+  );
+}
+
+const lines = [
+  `# ${productName} v${releaseVersion}`,
+  "",
+  `Thanks for using ${productName}.`,
+  "",
+  "## What is new for you",
+  ...friendlyBullets,
+  "",
+  "## Why this release matters",
+  "This update improves reliability, delivery quality, and the day-to-day experience for family and clan management.",
+  "",
+  "## Update rollout",
+  "- Staging builds can be verified before production promotion.",
+  "- Production users will receive the update after release publish completes.",
+];
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${lines.join("\n")}\n`, "utf8");
+console.log(`Friendly release notes written to ${outputPath}`);


### PR DESCRIPTION
## Summary
- add a Node-based script to generate friendly release notes from conventional commits and semantic version tags
- ignore generated dist artifacts from local release-note generation
- document how the script fits into future tag-based release CI/CD

## Verification
- RELEASE_TAG=v0.1.0 RELEASE_NOTES_PATH=dist/test-release-notes.md node scripts/generate_release_notes.mjs
- mkdocs build --strict