### PR TITLE
docs: align mkdocs config with material site template

### DIFF
--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -1,0 +1,18 @@
+document$.subscribe(() => {
+  if (!window.mermaid) {
+    return;
+  }
+
+  window.mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: "loose",
+    theme: "default",
+  });
+
+  const diagrams = document.querySelectorAll(".mermaid");
+  if (diagrams.length > 0) {
+    window.mermaid.run({
+      nodes: diagrams,
+    });
+  }
+});

--- a/docs/javascripts/release-sync.js
+++ b/docs/javascripts/release-sync.js
@@ -1,0 +1,34 @@
+document$.subscribe(async () => {
+  const releaseNodes = document.querySelectorAll("[data-release-version], [data-release-tag], [data-release-link]");
+  if (releaseNodes.length === 0) {
+    return;
+  }
+
+  try {
+    const response = await fetch("https://api.github.com/repos/phamhungptithcm/gia-pha/releases/latest");
+    if (!response.ok) {
+      return;
+    }
+
+    const release = await response.json();
+    const tagName = release.tag_name || "";
+    const version = tagName.replace(/^v/, "");
+    const releaseUrl = release.html_url || "https://github.com/phamhungptithcm/gia-pha/releases";
+
+    document.querySelectorAll("[data-release-version]").forEach((node) => {
+      node.textContent = version || "Unreleased";
+    });
+
+    document.querySelectorAll("[data-release-tag]").forEach((node) => {
+      node.textContent = tagName || "No release tag";
+    });
+
+    document.querySelectorAll("[data-release-link]").forEach((node) => {
+      if (node.tagName === "A") {
+        node.setAttribute("href", releaseUrl);
+      }
+    });
+  } catch {
+    // Leave the static page content unchanged if release metadata is unavailable.
+  }
+});

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,58 @@
+:root {
+  --md-primary-fg-color: #30364f;
+  --md-primary-fg-color--light: #46506f;
+  --md-primary-fg-color--dark: #23283c;
+  --md-accent-fg-color: #8f6a2f;
+  --md-accent-fg-color--transparent: rgba(143, 106, 47, 0.12);
+}
+
+[data-md-color-scheme="default"] {
+  --md-default-bg-color: #fbfaf5;
+  --md-default-fg-color: #26303c;
+  --md-default-fg-color--light: #5a6472;
+  --md-typeset-a-color: #7a5d2c;
+}
+
+.md-header {
+  border-bottom: 1px solid rgba(48, 54, 79, 0.08);
+  box-shadow: 0 8px 24px rgba(48, 54, 79, 0.08);
+}
+
+.md-tabs {
+  background: linear-gradient(90deg, rgba(48, 54, 79, 0.98), rgba(67, 77, 111, 0.96));
+}
+
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3 {
+  letter-spacing: -0.02em;
+}
+
+.md-typeset code {
+  border-radius: 0.35rem;
+}
+
+.md-typeset .admonition,
+.md-typeset details {
+  border-radius: 0.8rem;
+  box-shadow: 0 10px 30px rgba(48, 54, 79, 0.06);
+}
+
+.md-typeset .mermaid {
+  overflow-x: auto;
+  padding: 1rem 0;
+}
+
+.release-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(48, 54, 79, 0.08);
+  color: var(--md-primary-fg-color);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,11 +8,37 @@ edit_uri: edit/main/docs/
 theme:
   name: material
   features:
+    - navigation.tabs
     - navigation.sections
     - navigation.expand
     - content.code.copy
     - search.suggest
-    - search.highlight
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+copyright: "© 2026 Gia Pha. All rights reserved."
+
+extra_css:
+  - stylesheets/extra.css
+
+extra_javascript:
+  - https://unpkg.com/mermaid@10/dist/mermaid.min.js
+  - javascripts/mermaid-init.js
+  - javascripts/release-sync.js
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary
- align mkdocs.yml with the preferred Material configuration pattern
- add Mermaid support, extra CSS, and project JavaScript assets
- keep the current site nav and project branding while matching the requested template

## Verification
- ./.venv/bin/mkdocs build --strict