### PR TITLE
ci: add release promotion and branch governance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,9 @@ Describe the scope in 2-4 bullets.
 
 Closes #
 
+Use a closing keyword here so the production release workflow can automatically close
+the delivered story after it reaches `main`.
+
 ## What changed
 
 - 

--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -1,0 +1,67 @@
+name: Branch CI
+
+on:
+  pull_request:
+    branches:
+      - staging
+      - main
+  push:
+    branches:
+      - staging
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: branch-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci-docs:
+    name: ci-docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+  ci-mobile:
+    name: ci-mobile
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: mobile/befam
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Analyze Flutter app
+        run: flutter analyze
+
+      - name: Run Flutter tests
+        run: flutter test

--- a/.github/workflows/release-issue-closure.yml
+++ b/.github/workflows/release-issue-closure.yml
@@ -1,0 +1,32 @@
+name: Release Issue Closure
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-released-work:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Close released stories and epics
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/close_released_issues.py \
+            --repo "${GITHUB_REPOSITORY}" \
+            --release-pr "${{ github.event.pull_request.number }}"

--- a/.github/workflows/weekly-release-promotion.yml
+++ b/.github/workflows/weekly-release-promotion.yml
@@ -1,0 +1,71 @@
+name: Weekly Release Promotion
+
+on:
+  schedule:
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: weekly-release-promotion
+  cancel-in-progress: false
+
+jobs:
+  promote-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or refresh release pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          repo="${GITHUB_REPOSITORY}"
+          compare_json="$(gh api "repos/${repo}/compare/main...staging")"
+          ahead_by="$(jq -r '.ahead_by' <<<"${compare_json}")"
+          existing_pr="$(gh pr list --repo "${repo}" --base main --head staging --state open --json number --jq '.[0].number // empty')"
+
+          if [ "${ahead_by}" = "0" ] && [ -z "${existing_pr}" ]; then
+            echo "No release delta between staging and main."
+            exit 0
+          fi
+
+          body_file="$(mktemp)"
+          release_date="$(date -u +%Y-%m-%d)"
+
+          {
+            echo "## Summary"
+            echo
+            echo "Automated weekly promotion from \`staging\` to \`main\`."
+            echo
+            echo "- Generated on ${release_date}"
+            echo "- Approval and Branch CI checks are still required before production merge"
+            echo "- Auto-merge is armed so the PR merges as soon as approval and checks are both satisfied"
+            echo
+            echo "## Included commits"
+            echo
+            jq -r '.commits[:20][] | "- `" + (.sha[0:7]) + "` " + (.commit.message | split("\n")[0])' <<<"${compare_json}"
+          } > "${body_file}"
+
+          if [ -n "${existing_pr}" ]; then
+            gh pr edit "${existing_pr}" \
+              --repo "${repo}" \
+              --title "release: promote staging to main" \
+              --body-file "${body_file}" \
+              --add-label release
+            pr_number="${existing_pr}"
+          else
+            pr_url="$(gh pr create \
+              --repo "${repo}" \
+              --base main \
+              --head staging \
+              --title "release: promote staging to main" \
+              --body-file "${body_file}" \
+              --label release)"
+            pr_number="${pr_url##*/}"
+          fi
+
+          gh pr merge "${pr_number}" --repo "${repo}" --auto --merge

--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ flutter run -d ios
 The repository includes:
 
 - docs validation on pull requests
+- required branch CI for `staging` and `main`
 - GitHub Pages deployment from `main`
+- weekly release promotion pull requests from `staging` to `main`
+- post-release story and epic closure after production merges
 - issue and pull request templates
 - CODEOWNERS support for review routing
 - backlog import automation from the source planning docs
@@ -117,8 +120,9 @@ RELEASE_TAG=v0.1.0 node scripts/generate_release_notes.mjs
 
 ## Workflow
 
-1. Create a short-lived branch from `main`.
+1. Create a short-lived branch from `staging`.
 2. Make the required documentation or implementation changes.
 3. Run local verification where applicable.
-4. Open a pull request.
-5. Merge to `main` after review and successful checks.
+4. Open a pull request to `staging`.
+5. Merge to `staging` after review and successful checks.
+6. Review and approve the weekly `staging` to `main` release pull request for production.

--- a/docs/05-devops/branching-strategy.md
+++ b/docs/05-devops/branching-strategy.md
@@ -1,11 +1,12 @@
 # Branching Strategy
 
-The repository uses `main` as the default protected branch and favors short-lived
-topic branches.
+The repository uses `staging` for day-to-day development and `main` for production
+releases.
 
 ## Branch types
 
-- `main`: stable branch and GitHub Pages deployment source
+- `staging`: default development branch and integration branch
+- `main`: protected production branch and GitHub Pages deployment source
 - `codex/<slug>`: Codex-created implementation branches
 - `feat/<issue-id>-<slug>`: feature delivery
 - `fix/<issue-id>-<slug>`: bug fixes
@@ -13,10 +14,12 @@ topic branches.
 
 ## Rules
 
-- branch from the latest `main`
+- branch from the latest `staging`
 - keep changes scoped to one issue or one closely related set of issues
-- open a pull request before merge
-- avoid long-lived integration branches unless the team later adds `develop`
+- open a pull request to `staging` before merge
+- require one approval and passing Branch CI before merge to `staging` or `main`
+- promote `staging` to `main` through the weekly release PR
+- use merge commits for the `staging` to `main` promotion so release history stays aligned
 
 ## Example
 

--- a/docs/05-devops/ci-cd.md
+++ b/docs/05-devops/ci-cd.md
@@ -1,9 +1,23 @@
 # CI/CD
 
-The repository uses GitHub Actions to validate documentation changes and publish the
-MkDocs site to GitHub Pages.
+The repository uses GitHub Actions to validate pull requests, promote approved weekly
+releases, close delivered backlog items after production, and publish the MkDocs site
+to GitHub Pages.
 
 ## Workflows
+
+### `branch-ci.yml`
+
+Runs on pull requests and pushes to `staging` and `main`.
+
+Checks performed:
+
+- install Python 3.12 and run `mkdocs build --strict`
+- install Flutter and run `flutter analyze`
+- run `flutter test`
+
+The `ci-docs` and `ci-mobile` jobs are required status checks in the branch rulesets
+for both protected branches.
 
 ### `docs-ci.yml`
 
@@ -37,6 +51,30 @@ Deploy flow:
 5. upload the `site/` artifact
 6. publish via `actions/deploy-pages`
 
+### `weekly-release-promotion.yml`
+
+Runs on:
+
+- weekly schedule every Monday at `14:00 UTC`
+- manual `workflow_dispatch`
+
+Release flow:
+
+1. compare `staging` against `main`
+2. create or refresh the release PR if there is anything to promote
+3. enable auto-merge using a merge commit
+4. wait for required approval and Branch CI checks
+
+### `release-issue-closure.yml`
+
+Runs after a merged pull request lands on `main`.
+
+Post-release flow:
+
+1. scan the release PR and included pull requests for `Closes #123` style issue links
+2. comment on released story issues and close them
+3. close the parent epic once all of its linked stories are closed
+
 ## Local preview
 
 ```bash
@@ -54,9 +92,8 @@ mkdocs serve
 
 ## Future expansion
 
-When application code is added, extend CI with:
+Future expansion:
 
-- Flutter formatting, analysis, and tests
 - Firebase Functions linting and tests
 - emulator-backed integration checks for critical paths
 

--- a/docs/05-devops/github-workflow.md
+++ b/docs/05-devops/github-workflow.md
@@ -1,23 +1,25 @@
 # GitHub Workflow
 
-This repository follows a docs-first workflow that is ready to scale into app and
-backend delivery.
+This repository follows a `staging` to `main` delivery model with GitHub-managed
+reviews, CI, and release promotion.
 
 ## Delivery loop
 
-1. start from `main`
+1. start from `staging`
 2. create a short-lived branch
 3. implement changes
 4. run local verification
-5. open a pull request
+5. open a pull request to `staging`
 6. let GitHub Actions validate docs and code
-7. merge to `main`
-8. publish docs from `main`
+7. merge to `staging` after approval
+8. let the weekly release workflow open the `staging` to `main` production PR
+9. approve the release PR and let auto-merge finish the production promotion
+10. publish docs from `main` and close released stories and epics
 
 ## Pull request checklist
 
 - explain scope clearly
-- link the related issue or epic
+- link the related story with a closing keyword such as `Closes #123`
 - note testing performed
 - call out schema or contract changes
 - include screenshots when UI content changes

--- a/scripts/close_released_issues.py
+++ b/scripts/close_released_issues.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Close released stories and epics after a production merge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+
+CLOSING_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:issue\s+)?"
+    r"(?:#|https://github\.com/[^/]+/[^/]+/issues/)(\d+)\b",
+    re.IGNORECASE,
+)
+EPIC_RE = re.compile(r"^#(\d+)\s+-\s+.+$", re.MULTILINE)
+
+
+def run(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, check=True, text=True, capture_output=True)
+    return result.stdout.strip()
+
+
+def gh(args: list[str]) -> str:
+    return run(["gh", *args])
+
+
+def gh_json(args: list[str]) -> object:
+    payload = gh(args)
+    return json.loads(payload) if payload else None
+
+
+def list_repo_issues(repo: str) -> dict[int, dict[str, object]]:
+    pages = gh_json(
+        [
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{repo}/issues?state=all&per_page=100",
+        ]
+    )
+    issues: dict[int, dict[str, object]] = {}
+    for page in pages or []:
+        for issue in page:
+            if "pull_request" in issue:
+                continue
+            issues[int(issue["number"])] = issue
+    return issues
+
+
+def extract_issue_numbers(text: str | None) -> set[int]:
+    if not text:
+        return set()
+    return {int(match) for match in CLOSING_RE.findall(text)}
+
+
+def parent_epic_number(story_body: str | None) -> int | None:
+    if not story_body:
+        return None
+    match = EPIC_RE.search(story_body)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def associated_pr_numbers(repo: str, release_pr_number: int) -> set[int]:
+    numbers = {release_pr_number}
+    commits = gh_json(["api", f"repos/{repo}/pulls/{release_pr_number}/commits?per_page=100"]) or []
+    for commit in commits:
+        commit_sha = commit["sha"]
+        commit_prs = gh_json(["api", f"repos/{repo}/commits/{commit_sha}/pulls"]) or []
+        for pull_request in commit_prs:
+            numbers.add(int(pull_request["number"]))
+    return numbers
+
+
+def pr_details(repo: str, pr_number: int) -> dict[str, object]:
+    return gh_json(["api", f"repos/{repo}/pulls/{pr_number}"]) or {}
+
+
+def add_comment(repo: str, issue_number: int, body: str, dry_run: bool) -> None:
+    if dry_run:
+        print(f"DRY RUN: comment on issue #{issue_number}")
+        return
+    gh(
+        [
+            "api",
+            "-X",
+            "POST",
+            f"repos/{repo}/issues/{issue_number}/comments",
+            "-f",
+            f"body={body}",
+        ]
+    )
+
+
+def close_issue(repo: str, issue_number: int, dry_run: bool) -> None:
+    if dry_run:
+        print(f"DRY RUN: close issue #{issue_number}")
+        return
+    gh(
+        [
+            "api",
+            "-X",
+            "PATCH",
+            f"repos/{repo}/issues/{issue_number}",
+            "-f",
+            "state=closed",
+        ]
+    )
+
+
+def issue_labels(issue: dict[str, object]) -> set[str]:
+    return {label["name"] for label in issue.get("labels", [])}
+
+
+def release_comment(pr_number: int, pr_url: str) -> str:
+    return (
+        f"Released to production via PR #{pr_number} ({pr_url}). "
+        "Closing this story as delivered."
+    )
+
+
+def epic_comment(pr_number: int, pr_url: str, story_numbers: list[int]) -> str:
+    story_list = ", ".join(f"#{number}" for number in sorted(story_numbers))
+    return (
+        f"All linked stories in this epic are now released to production via PR "
+        f"#{pr_number} ({pr_url}). Closed stories in this release: {story_list}. "
+        "Closing the epic."
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="GitHub repository in OWNER/REPO format.")
+    parser.add_argument("--release-pr", required=True, type=int, help="Merged production release PR number.")
+    parser.add_argument("--dry-run", action="store_true", help="Print planned actions without editing issues.")
+    args = parser.parse_args()
+
+    issues = list_repo_issues(args.repo)
+    release_pr = pr_details(args.repo, args.release_pr)
+    if not release_pr:
+        print(f"Release PR #{args.release_pr} was not found.", file=sys.stderr)
+        return 1
+
+    prs_to_scan = associated_pr_numbers(args.repo, args.release_pr)
+    story_issue_numbers: set[int] = set()
+
+    for pr_number in sorted(prs_to_scan):
+        pull_request = pr_details(args.repo, pr_number)
+        story_issue_numbers.update(extract_issue_numbers(pull_request.get("body")))
+
+    commits = gh_json(["api", f"repos/{args.repo}/pulls/{args.release_pr}/commits?per_page=100"]) or []
+    for commit in commits:
+        story_issue_numbers.update(extract_issue_numbers(commit["commit"]["message"]))
+
+    if not story_issue_numbers:
+        print("No releasable story references found in the release PR or included pull requests.")
+        return 0
+
+    newly_closed_story_numbers: list[int] = []
+    candidate_epics: dict[int, list[int]] = defaultdict(list)
+
+    for issue_number in sorted(story_issue_numbers):
+        issue = issues.get(issue_number)
+        if issue is None:
+            print(f"Skipping missing issue #{issue_number}")
+            continue
+
+        labels = issue_labels(issue)
+        if "story" not in labels:
+            print(f"Skipping non-story issue #{issue_number}")
+            continue
+
+        if issue.get("state") == "open":
+            add_comment(
+                args.repo,
+                issue_number,
+                release_comment(args.release_pr, str(release_pr["html_url"])),
+                args.dry_run,
+            )
+            close_issue(args.repo, issue_number, args.dry_run)
+            issue["state"] = "closed"
+            newly_closed_story_numbers.append(issue_number)
+
+        epic_number = parent_epic_number(issue.get("body"))
+        if epic_number is not None:
+            candidate_epics[epic_number].append(issue_number)
+
+    if not newly_closed_story_numbers:
+        print("No open story issues needed closing.")
+        return 0
+
+    for epic_number, released_story_numbers in sorted(candidate_epics.items()):
+        epic = issues.get(epic_number)
+        if epic is None:
+            continue
+
+        if "epic" not in issue_labels(epic) or epic.get("state") != "open":
+            continue
+
+        related_stories = [
+            issue
+            for issue in issues.values()
+            if "story" in issue_labels(issue) and parent_epic_number(issue.get("body")) == epic_number
+        ]
+        if not related_stories:
+            continue
+
+        if any(issue.get("state") != "closed" for issue in related_stories):
+            continue
+
+        add_comment(
+            args.repo,
+            epic_number,
+            epic_comment(args.release_pr, str(release_pr["html_url"]), released_story_numbers),
+            args.dry_run,
+        )
+        close_issue(args.repo, epic_number, args.dry_run)
+        epic["state"] = "closed"
+
+    print(f"Closed story issues: {', '.join(f'#{number}' for number in newly_closed_story_numbers)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add required branch CI for pull requests into `staging` and `main`
- add weekly release promotion automation from `staging` to `main`
- add post-release story and epic closure automation plus docs updates for the new flow

## Verification
- `python3 -m py_compile scripts/close_released_issues.py`
- `python3 scripts/close_released_issues.py --repo phamhungptithcm/gia-pha --release-pr 179 --dry-run`
- `./.venv/bin/mkdocs build --strict`
- `cd mobile/befam && flutter analyze`
- `cd mobile/befam && flutter test`