### PR TITLE
[NOTIF-001] Configure FCM token registration

### DIFF
--- a/docs/04-backend/notifications.md
+++ b/docs/04-backend/notifications.md
@@ -9,6 +9,8 @@ that supports both foreground and system-opened deep links.
 
 1. Authenticated app starts push service in `AppShellPage`.
 2. Device token is registered through callable `registerDeviceToken`.
+   - token sync runs on first bootstrap and whenever session context changes
+     (member/clan/branch/access mode), even if the Firebase UID is unchanged
 3. Fallback path writes token directly to `users/{uid}/deviceTokens`.
 4. Backend triggers call `notifyMembers(...)`.
 5. `notifyMembers` writes `notifications` docs and sends FCM multicast.

--- a/mobile/befam/lib/app/home/app_shell_page.dart
+++ b/mobile/befam/lib/app/home/app_shell_page.dart
@@ -89,7 +89,7 @@ class _AppShellPageState extends State<AppShellPage> {
   @override
   void didUpdateWidget(covariant AppShellPage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.session.uid != widget.session.uid) {
+    if (oldWidget.session != widget.session) {
       unawaited(
         _pushNotificationService.start(
           session: widget.session,

--- a/mobile/befam/lib/features/notifications/services/push_notification_service.dart
+++ b/mobile/befam/lib/features/notifications/services/push_notification_service.dart
@@ -89,11 +89,66 @@ class NoopPushNotificationService implements PushNotificationService {
   Future<void> stop() async {}
 }
 
+class _TokenRegistrationContext {
+  const _TokenRegistrationContext({
+    required this.uid,
+    required this.memberId,
+    required this.clanId,
+    required this.branchId,
+    required this.primaryRole,
+    required this.accessMode,
+  });
+
+  factory _TokenRegistrationContext.fromSession(AuthSession session) {
+    return _TokenRegistrationContext(
+      uid: session.uid,
+      memberId: session.memberId?.trim() ?? '',
+      clanId: session.clanId?.trim() ?? '',
+      branchId: session.branchId?.trim() ?? '',
+      primaryRole: session.primaryRole?.trim() ?? '',
+      accessMode: session.accessMode.name,
+    );
+  }
+
+  final String uid;
+  final String memberId;
+  final String clanId;
+  final String branchId;
+  final String primaryRole;
+  final String accessMode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is _TokenRegistrationContext &&
+        other.uid == uid &&
+        other.memberId == memberId &&
+        other.clanId == clanId &&
+        other.branchId == branchId &&
+        other.primaryRole == primaryRole &&
+        other.accessMode == accessMode;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      uid,
+      memberId,
+      clanId,
+      branchId,
+      primaryRole,
+      accessMode,
+    );
+  }
+}
+
 class FirebasePushNotificationService implements PushNotificationService {
   StreamSubscription<String>? _tokenSubscription;
   StreamSubscription<RemoteMessage>? _foregroundSubscription;
   StreamSubscription<RemoteMessage>? _openedSubscription;
-  String? _activeUid;
+  _TokenRegistrationContext? _activeRegistrationContext;
   bool _tokenCallableMissing = false;
 
   @override
@@ -101,12 +156,13 @@ class FirebasePushNotificationService implements PushNotificationService {
     required AuthSession session,
     void Function(NotificationDeepLink deepLink)? onDeepLink,
   }) async {
-    if (_activeUid == session.uid) {
+    final registrationContext = _TokenRegistrationContext.fromSession(session);
+    if (_activeRegistrationContext == registrationContext) {
       return;
     }
 
     await stop();
-    _activeUid = session.uid;
+    _activeRegistrationContext = registrationContext;
 
     try {
       final messaging = FirebaseServices.messaging;
@@ -157,8 +213,7 @@ class FirebasePushNotificationService implements PushNotificationService {
         onDeepLink?.call(deepLink);
       });
 
-      final initialMessage = await FirebaseServices.messaging
-          .getInitialMessage();
+      final initialMessage = await messaging.getInitialMessage();
       if (initialMessage != null) {
         final deepLink = NotificationDeepLink.fromRemoteMessage(
           initialMessage,
@@ -183,7 +238,7 @@ class FirebasePushNotificationService implements PushNotificationService {
     _tokenSubscription = null;
     _foregroundSubscription = null;
     _openedSubscription = null;
-    _activeUid = null;
+    _activeRegistrationContext = null;
   }
 
   Future<void> _registerToken(AuthSession session, String token) async {


### PR DESCRIPTION
## Summary
- re-run mobile FCM token registration when auth session context changes (member/clan/branch/role/access mode), not only when UID changes
- restart push notification service in app shell when any AuthSession field changes so token metadata stays current
- document the updated token registration behavior in backend notifications docs

## Testing
- cd mobile/befam && dart analyze lib/features/notifications/services/push_notification_service.dart lib/app/home/app_shell_page.dart
- cd mobile/befam && flutter test test/widget_test.dart

Closes #106
Refs #10
