### PR TITLE
[NOTIF-002] Notification inbox screen

### DIFF
--- a/docs/01-product/feature-spec.md
+++ b/docs/01-product/feature-spec.md
@@ -18,7 +18,7 @@ _Last reviewed: March 14, 2026_
 | Push token registration | Live | Callable-first with Firestore fallback |
 | Push delivery backend | Live | Notification docs + FCM multicast delivery |
 | Event management UI | Partial | Home shell has Events tab placeholder |
-| Notification inbox UI | Planned | Deep-link hooks already present in shell service |
+| Notification inbox UI | Partial | Inbox list screen is live; mark-read, deep-link destination routing, and pagination are pending |
 | Funds module | Planned | Backlog defined, not shipped in mobile UI yet |
 | Scholarship UI module | Planned | Backend trigger path exists for review updates |
 

--- a/docs/03-mobile/navigation.md
+++ b/docs/03-mobile/navigation.md
@@ -25,8 +25,8 @@ Current bottom navigation destinations:
 - Events
 - Profile
 
-The Events and Profile tabs are currently placeholder workspaces while the tree
-and member/clan workflows are production-focused.
+The Events tab now hosts the notification inbox while Profile remains a
+placeholder workspace.
 
 ## Notification-driven navigation
 

--- a/docs/04-backend/notifications.md
+++ b/docs/04-backend/notifications.md
@@ -39,7 +39,15 @@ Mobile deep-link parser maps payload `target` values to:
 - members can mark their own notifications as read (`isRead` only)
 - creation/deletion is server-controlled
 
+## Mobile inbox status
+
+- notification inbox screen is available in the shell Events destination
+- inbox currently reads most recent notification documents for the active member
+- unread/read state is rendered in UI but write-back actions are tracked as a
+  follow-up story
+
 ## Next delivery step
 
-- complete notification inbox screen and pagination flow in mobile UI
-- keep deep-link behavior aligned with final event/scholarship destinations
+- add mark-as-read interaction
+- complete deep-link destination navigation for event and scholarship targets
+- add inbox pagination support

--- a/mobile/befam/lib/app/home/app_shell_page.dart
+++ b/mobile/befam/lib/app/home/app_shell_page.dart
@@ -8,6 +8,8 @@ import '../../features/genealogy/presentation/genealogy_workspace_page.dart';
 import '../../features/genealogy/services/genealogy_read_repository.dart';
 import '../../features/member/presentation/member_workspace_page.dart';
 import '../../features/member/services/member_repository.dart';
+import '../../features/notifications/presentation/notification_inbox_page.dart';
+import '../../features/notifications/services/notification_inbox_repository.dart';
 import '../../features/notifications/services/push_notification_service.dart';
 import '../../l10n/l10n.dart';
 import '../../features/auth/models/auth_entry_method.dart';
@@ -26,6 +28,7 @@ class AppShellPage extends StatefulWidget {
     required this.clanRepository,
     required this.memberRepository,
     this.genealogyRepository,
+    this.notificationInboxRepository,
     this.pushNotificationService,
     this.onLogoutRequested,
   });
@@ -35,6 +38,7 @@ class AppShellPage extends StatefulWidget {
   final ClanRepository clanRepository;
   final MemberRepository memberRepository;
   final GenealogyReadRepository? genealogyRepository;
+  final NotificationInboxRepository? notificationInboxRepository;
   final PushNotificationService? pushNotificationService;
   final Future<void> Function()? onLogoutRequested;
 
@@ -45,6 +49,7 @@ class AppShellPage extends StatefulWidget {
 class _AppShellPageState extends State<AppShellPage> {
   int _selectedIndex = 0;
   late final GenealogyReadRepository _genealogyRepository;
+  late final NotificationInboxRepository _notificationInboxRepository;
   late final PushNotificationService _pushNotificationService;
 
   static const List<_ShellDestination> _destinations = [
@@ -75,6 +80,9 @@ class _AppShellPageState extends State<AppShellPage> {
     super.initState();
     _genealogyRepository =
         widget.genealogyRepository ?? createDefaultGenealogyReadRepository();
+    _notificationInboxRepository =
+        widget.notificationInboxRepository ??
+        createDefaultNotificationInboxRepository();
     _pushNotificationService =
         widget.pushNotificationService ??
         createDefaultPushNotificationService();
@@ -187,10 +195,9 @@ class _AppShellPageState extends State<AppShellPage> {
         session: widget.session,
         repository: _genealogyRepository,
       ),
-      _ComingSoonPane(
-        title: l10n.shellEventsWorkspaceTitle,
-        description: l10n.shellEventsWorkspaceDescription,
-        icon: Icons.event,
+      NotificationInboxPage(
+        session: widget.session,
+        repository: _notificationInboxRepository,
       ),
       _ComingSoonPane(
         title: l10n.shellProfileWorkspaceTitle,

--- a/mobile/befam/lib/features/notifications/models/notification_inbox_item.dart
+++ b/mobile/befam/lib/features/notifications/models/notification_inbox_item.dart
@@ -1,0 +1,133 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+enum NotificationInboxTarget { event, scholarship, generic, unknown }
+
+class NotificationInboxItem {
+  const NotificationInboxItem({
+    required this.id,
+    required this.memberId,
+    required this.clanId,
+    required this.type,
+    required this.title,
+    required this.body,
+    required this.isRead,
+    required this.createdAt,
+    required this.target,
+    required this.data,
+    this.targetId,
+  });
+
+  final String id;
+  final String memberId;
+  final String clanId;
+  final String type;
+  final String title;
+  final String body;
+  final bool isRead;
+  final DateTime createdAt;
+  final NotificationInboxTarget target;
+  final String? targetId;
+  final Map<String, String> data;
+
+  bool get isUnread => !isRead;
+
+  factory NotificationInboxItem.fromFirestore({
+    required String documentId,
+    required Map<String, dynamic> json,
+  }) {
+    final dataPayload = _readStringMap(json['data']);
+    final type = _readString(json['type']);
+    final target = _resolveTarget(type: type, data: dataPayload);
+
+    return NotificationInboxItem(
+      id: _readString(json['id'], fallback: documentId),
+      memberId: _readString(json['memberId']),
+      clanId: _readString(json['clanId']),
+      type: type,
+      title: _readString(json['title']),
+      body: _readString(json['body']),
+      isRead: json['isRead'] == true,
+      createdAt: _readDateTime(json['createdAt']) ?? DateTime.now(),
+      target: target,
+      targetId: _firstNonEmpty([
+        dataPayload['id'],
+        dataPayload['eventId'],
+        dataPayload['submissionId'],
+        dataPayload['scholarshipSubmissionId'],
+      ]),
+      data: dataPayload,
+    );
+  }
+
+  static NotificationInboxTarget _resolveTarget({
+    required String type,
+    required Map<String, String> data,
+  }) {
+    final targetRaw = data['target']?.trim().toLowerCase() ?? '';
+    switch (targetRaw) {
+      case 'event':
+        return NotificationInboxTarget.event;
+      case 'scholarship':
+        return NotificationInboxTarget.scholarship;
+      case 'generic':
+        return NotificationInboxTarget.generic;
+    }
+
+    final normalizedType = type.trim().toLowerCase();
+    if (normalizedType.contains('event')) {
+      return NotificationInboxTarget.event;
+    }
+    if (normalizedType.contains('scholarship')) {
+      return NotificationInboxTarget.scholarship;
+    }
+    if (normalizedType.isNotEmpty) {
+      return NotificationInboxTarget.generic;
+    }
+    return NotificationInboxTarget.unknown;
+  }
+}
+
+String _readString(Object? value, {String fallback = ''}) {
+  return switch (value) {
+    String v when v.trim().isNotEmpty => v.trim(),
+    String _ => fallback,
+    _ => fallback,
+  };
+}
+
+Map<String, String> _readStringMap(Object? value) {
+  if (value is! Map) {
+    return const {};
+  }
+
+  final mapped = <String, String>{};
+  value.forEach((key, rawValue) {
+    final normalizedKey = _readString(key);
+    final normalizedValue = _readString(rawValue);
+    if (normalizedKey.isEmpty || normalizedValue.isEmpty) {
+      return;
+    }
+    mapped[normalizedKey] = normalizedValue;
+  });
+  return mapped;
+}
+
+DateTime? _readDateTime(Object? value) {
+  return switch (value) {
+    Timestamp timestamp => timestamp.toDate(),
+    DateTime dateTime => dateTime,
+    int milliseconds => DateTime.fromMillisecondsSinceEpoch(milliseconds),
+    String raw => DateTime.tryParse(raw),
+    _ => null,
+  };
+}
+
+String? _firstNonEmpty(List<String?> values) {
+  for (final candidate in values) {
+    final normalized = candidate?.trim() ?? '';
+    if (normalized.isNotEmpty) {
+      return normalized;
+    }
+  }
+  return null;
+}

--- a/mobile/befam/lib/features/notifications/presentation/notification_inbox_page.dart
+++ b/mobile/befam/lib/features/notifications/presentation/notification_inbox_page.dart
@@ -1,0 +1,501 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../../l10n/l10n.dart';
+import '../../auth/models/auth_session.dart';
+import '../models/notification_inbox_item.dart';
+import '../services/notification_inbox_repository.dart';
+
+class NotificationInboxPage extends StatefulWidget {
+  const NotificationInboxPage({
+    super.key,
+    required this.session,
+    required this.repository,
+  });
+
+  final AuthSession session;
+  final NotificationInboxRepository repository;
+
+  @override
+  State<NotificationInboxPage> createState() => _NotificationInboxPageState();
+}
+
+class _NotificationInboxPageState extends State<NotificationInboxPage> {
+  bool _isLoading = true;
+  bool _isRefreshing = false;
+  String? _errorMessage;
+  List<NotificationInboxItem> _items = const [];
+
+  bool get _hasMemberContext {
+    final memberId = widget.session.memberId?.trim() ?? '';
+    final clanId = widget.session.clanId?.trim() ?? '';
+    return memberId.isNotEmpty && clanId.isNotEmpty;
+  }
+
+  int get _unreadCount => _items.where((item) => item.isUnread).length;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadInbox());
+  }
+
+  Future<void> _loadInbox({bool refresh = false}) async {
+    setState(() {
+      _errorMessage = null;
+      if (refresh) {
+        _isRefreshing = true;
+      } else {
+        _isLoading = true;
+      }
+    });
+
+    try {
+      final items = await widget.repository.loadInbox(session: widget.session);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _items = items;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _errorMessage = error.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+          _isRefreshing = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (!_hasMemberContext) {
+      return _InboxStateCard(
+        icon: Icons.lock_outline,
+        title: l10n.notificationInboxNoContextTitle,
+        description: l10n.notificationInboxNoContextDescription,
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () => _loadInbox(refresh: true),
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+        children: [
+          _InboxHeroCard(
+            unreadCount: _unreadCount,
+            isSandbox: widget.repository.isSandbox,
+          ),
+          const SizedBox(height: 20),
+          if (_errorMessage != null) ...[
+            _MessageCard(
+              icon: Icons.error_outline,
+              title: l10n.notificationInboxLoadErrorTitle,
+              description: l10n.notificationInboxLoadErrorDescription,
+              tone: colorScheme.errorContainer,
+              actionLabel: l10n.notificationInboxRetryAction,
+              onAction: _isRefreshing ? null : _loadInbox,
+            ),
+            const SizedBox(height: 20),
+          ],
+          if (_items.isEmpty)
+            _InboxStateCard(
+              icon: Icons.notifications_none_outlined,
+              title: l10n.notificationInboxEmptyTitle,
+              description: l10n.notificationInboxEmptyDescription,
+            )
+          else
+            Column(
+              children: [
+                for (final item in _items)
+                  Padding(
+                    padding: EdgeInsets.only(
+                      bottom: item == _items.last ? 0 : 12,
+                    ),
+                    child: _NotificationCard(item: item),
+                  ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InboxHeroCard extends StatelessWidget {
+  const _InboxHeroCard({required this.unreadCount, required this.isSandbox});
+
+  final int unreadCount;
+  final bool isSandbox;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final l10n = context.l10n;
+
+    final unreadLabel = unreadCount > 0
+        ? l10n.notificationInboxUnreadCount(unreadCount)
+        : l10n.notificationInboxAllRead;
+    final sourceLabel = isSandbox
+        ? l10n.notificationInboxSourceSandbox
+        : l10n.notificationInboxSourceLive;
+
+    return Container(
+      padding: const EdgeInsets.all(22),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [colorScheme.primary, colorScheme.primaryContainer],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l10n.notificationInboxHeroTitle,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              color: colorScheme.onPrimary,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            l10n.notificationInboxHeroDescription,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: colorScheme.onPrimary.withValues(alpha: 0.92),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            children: [
+              _HeroChip(
+                label: unreadLabel,
+                tone: colorScheme.secondaryContainer,
+              ),
+              _HeroChip(
+                label: sourceLabel,
+                tone: colorScheme.surfaceContainerHighest,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroChip extends StatelessWidget {
+  const _HeroChip({required this.label, required this.tone});
+
+  final String label;
+  final Color tone;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: tone,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+        child: Text(
+          label,
+          style: Theme.of(
+            context,
+          ).textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w700),
+        ),
+      ),
+    );
+  }
+}
+
+class _NotificationCard extends StatelessWidget {
+  const _NotificationCard({required this.item});
+
+  final NotificationInboxItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final targetIcon = switch (item.target) {
+      NotificationInboxTarget.event => Icons.event_outlined,
+      NotificationInboxTarget.scholarship => Icons.school_outlined,
+      NotificationInboxTarget.generic => Icons.notifications_active_outlined,
+      NotificationInboxTarget.unknown => Icons.notifications_none_outlined,
+    };
+
+    final targetLabel = switch (item.target) {
+      NotificationInboxTarget.event => l10n.notificationInboxTargetEvent,
+      NotificationInboxTarget.scholarship =>
+        l10n.notificationInboxTargetScholarship,
+      NotificationInboxTarget.generic => l10n.notificationInboxTargetGeneric,
+      NotificationInboxTarget.unknown => l10n.notificationInboxTargetUnknown,
+    };
+
+    return Card(
+      key: Key('notification-row-${item.id}'),
+      color: item.isUnread
+          ? colorScheme.primaryContainer.withValues(alpha: 0.25)
+          : null,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CircleAvatar(
+              radius: 18,
+              backgroundColor: colorScheme.secondaryContainer,
+              child: Icon(targetIcon, size: 18),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          item.title.isEmpty
+                              ? l10n.notificationInboxFallbackTitle
+                              : item.title,
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w800,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      if (item.isUnread)
+                        Container(
+                          width: 8,
+                          height: 8,
+                          margin: const EdgeInsets.only(top: 6),
+                          decoration: BoxDecoration(
+                            color: colorScheme.primary,
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    item.body.isEmpty
+                        ? l10n.notificationInboxFallbackBody
+                        : item.body,
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 10),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      _MetaChip(label: targetLabel),
+                      _MetaChip(
+                        label: item.isUnread
+                            ? l10n.notificationInboxUnreadChip
+                            : l10n.notificationInboxReadChip,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 10),
+                  Text(
+                    _formatTimestamp(context, item.createdAt),
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: colorScheme.onSurface.withValues(alpha: 0.72),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MetaChip extends StatelessWidget {
+  const _MetaChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        child: Text(
+          label,
+          style: Theme.of(
+            context,
+          ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w700),
+        ),
+      ),
+    );
+  }
+}
+
+class _MessageCard extends StatelessWidget {
+  const _MessageCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.tone,
+    this.actionLabel,
+    this.onAction,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final Color tone;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: tone,
+      child: Padding(
+        padding: const EdgeInsets.all(18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(icon),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(description),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            if (actionLabel != null && onAction != null) ...[
+              const SizedBox(height: 12),
+              TextButton.icon(
+                onPressed: onAction,
+                icon: const Icon(Icons.refresh),
+                label: Text(actionLabel!),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InboxStateCard extends StatelessWidget {
+  const _InboxStateCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 460),
+          child: Card(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  CircleAvatar(
+                    radius: 30,
+                    backgroundColor: colorScheme.primaryContainer,
+                    child: Icon(icon, size: 28),
+                  ),
+                  const SizedBox(height: 18),
+                  Text(
+                    title,
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Text(
+                    description,
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _formatTimestamp(BuildContext context, DateTime value) {
+  final localizations = MaterialLocalizations.of(context);
+  final use24HourFormat = MediaQuery.alwaysUse24HourFormatOf(context);
+  final timeLabel = localizations.formatTimeOfDay(
+    TimeOfDay.fromDateTime(value),
+    alwaysUse24HourFormat: use24HourFormat,
+  );
+
+  if (DateUtils.isSameDay(value, DateTime.now())) {
+    return timeLabel;
+  }
+
+  final dateLabel = localizations.formatMediumDate(value);
+  return '$dateLabel $timeLabel';
+}

--- a/mobile/befam/lib/features/notifications/services/debug_notification_inbox_repository.dart
+++ b/mobile/befam/lib/features/notifications/services/debug_notification_inbox_repository.dart
@@ -1,0 +1,68 @@
+import '../../auth/models/auth_session.dart';
+import '../models/notification_inbox_item.dart';
+import 'notification_inbox_repository.dart';
+
+class DebugNotificationInboxRepository implements NotificationInboxRepository {
+  @override
+  bool get isSandbox => true;
+
+  @override
+  Future<List<NotificationInboxItem>> loadInbox({
+    required AuthSession session,
+    int limit = 25,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 140));
+
+    final memberId = session.memberId?.trim() ?? '';
+    final clanId = session.clanId?.trim() ?? '';
+    if (memberId.isEmpty || clanId.isEmpty) {
+      return const [];
+    }
+
+    final now = DateTime.now();
+    final samples = [
+      NotificationInboxItem(
+        id: 'notif_demo_event_001',
+        memberId: memberId,
+        clanId: clanId,
+        type: 'event_created',
+        title: 'Ancestor remembrance ceremony added',
+        body: 'The branch memorial event is scheduled for next Sunday.',
+        isRead: false,
+        createdAt: now.subtract(const Duration(minutes: 18)),
+        target: NotificationInboxTarget.event,
+        targetId: 'event_demo_001',
+        data: const {'target': 'event', 'id': 'event_demo_001'},
+      ),
+      NotificationInboxItem(
+        id: 'notif_demo_scholarship_001',
+        memberId: memberId,
+        clanId: clanId,
+        type: 'scholarship_reviewed',
+        title: 'Scholarship application reviewed',
+        body: 'A scholarship submission now has a decision update.',
+        isRead: false,
+        createdAt: now.subtract(const Duration(hours: 3, minutes: 12)),
+        target: NotificationInboxTarget.scholarship,
+        targetId: 'submission_demo_001',
+        data: const {'target': 'scholarship', 'id': 'submission_demo_001'},
+      ),
+      NotificationInboxItem(
+        id: 'notif_demo_generic_001',
+        memberId: memberId,
+        clanId: clanId,
+        type: 'generic',
+        title: 'Family profile sync completed',
+        body: 'Your latest profile changes are now visible to your clan.',
+        isRead: true,
+        createdAt: now.subtract(const Duration(days: 1, hours: 2)),
+        target: NotificationInboxTarget.generic,
+        targetId: null,
+        data: const {'target': 'generic'},
+      ),
+    ];
+
+    final effectiveLimit = limit.clamp(1, 100);
+    return samples.take(effectiveLimit).toList(growable: false);
+  }
+}

--- a/mobile/befam/lib/features/notifications/services/firebase_notification_inbox_repository.dart
+++ b/mobile/befam/lib/features/notifications/services/firebase_notification_inbox_repository.dart
@@ -1,0 +1,53 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../../core/services/firebase_session_access_sync.dart';
+import '../../../core/services/firebase_services.dart';
+import '../../auth/models/auth_session.dart';
+import '../models/notification_inbox_item.dart';
+import 'notification_inbox_repository.dart';
+
+class FirebaseNotificationInboxRepository
+    implements NotificationInboxRepository {
+  FirebaseNotificationInboxRepository({FirebaseFirestore? firestore})
+    : _firestore = firestore ?? FirebaseServices.firestore;
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> get _notifications =>
+      _firestore.collection('notifications');
+
+  @override
+  bool get isSandbox => false;
+
+  @override
+  Future<List<NotificationInboxItem>> loadInbox({
+    required AuthSession session,
+    int limit = 25,
+  }) async {
+    await FirebaseSessionAccessSync.ensureUserSessionDocument(
+      firestore: _firestore,
+      session: session,
+    );
+
+    final memberId = session.memberId?.trim() ?? '';
+    if (memberId.isEmpty) {
+      return const [];
+    }
+
+    final effectiveLimit = limit.clamp(1, 100);
+    final snapshot = await _notifications
+        .where('memberId', isEqualTo: memberId)
+        .orderBy('createdAt', descending: true)
+        .limit(effectiveLimit)
+        .get();
+
+    return snapshot.docs
+        .map(
+          (doc) => NotificationInboxItem.fromFirestore(
+            documentId: doc.id,
+            json: doc.data(),
+          ),
+        )
+        .toList(growable: false);
+  }
+}

--- a/mobile/befam/lib/features/notifications/services/notification_inbox_repository.dart
+++ b/mobile/befam/lib/features/notifications/services/notification_inbox_repository.dart
@@ -1,0 +1,22 @@
+import '../../../core/services/runtime_mode.dart';
+import '../../auth/models/auth_session.dart';
+import '../models/notification_inbox_item.dart';
+import 'debug_notification_inbox_repository.dart';
+import 'firebase_notification_inbox_repository.dart';
+
+abstract interface class NotificationInboxRepository {
+  bool get isSandbox;
+
+  Future<List<NotificationInboxItem>> loadInbox({
+    required AuthSession session,
+    int limit = 25,
+  });
+}
+
+NotificationInboxRepository createDefaultNotificationInboxRepository() {
+  if (RuntimeMode.shouldUseMockBackend) {
+    return DebugNotificationInboxRepository();
+  }
+
+  return FirebaseNotificationInboxRepository();
+}

--- a/mobile/befam/lib/l10n/app_en.arb
+++ b/mobile/befam/lib/l10n/app_en.arb
@@ -387,6 +387,34 @@
   "notificationOpenedEvent": "Opened the event notification.",
   "notificationOpenedScholarship": "Opened the scholarship notification.",
   "notificationOpenedGeneral": "Opened a notification.",
+  "notificationInboxHeroTitle": "Notification inbox",
+  "notificationInboxHeroDescription": "Review the latest event and scholarship updates delivered to your member profile.",
+  "notificationInboxUnreadCount": "{count} unread",
+  "@notificationInboxUnreadCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "notificationInboxAllRead": "All caught up",
+  "notificationInboxSourceSandbox": "Local sandbox data",
+  "notificationInboxSourceLive": "Live Firestore data",
+  "notificationInboxNoContextTitle": "Notification inbox unavailable",
+  "notificationInboxNoContextDescription": "This session is not linked to a member profile yet, so there is no inbox to show.",
+  "notificationInboxLoadErrorTitle": "Could not load notifications",
+  "notificationInboxLoadErrorDescription": "Pull to refresh or retry now. If this keeps happening, check Firebase connectivity and permissions.",
+  "notificationInboxRetryAction": "Retry",
+  "notificationInboxEmptyTitle": "No notifications yet",
+  "notificationInboxEmptyDescription": "When events and scholarship updates are sent, they will appear here.",
+  "notificationInboxUnreadChip": "Unread",
+  "notificationInboxReadChip": "Read",
+  "notificationInboxTargetEvent": "Event",
+  "notificationInboxTargetScholarship": "Scholarship",
+  "notificationInboxTargetGeneric": "General",
+  "notificationInboxTargetUnknown": "Update",
+  "notificationInboxFallbackTitle": "Notification update",
+  "notificationInboxFallbackBody": "Open this notification for more details.",
   "authIssueRestoreSessionFailed": "We could not restore the last sign-in session.",
   "authIssueRequestOtpBeforeVerify": "Request an OTP before trying to verify it.",
   "authIssueOtpMustBeSixDigits": "Enter the 6-digit OTP to continue.",

--- a/mobile/befam/lib/l10n/app_vi.arb
+++ b/mobile/befam/lib/l10n/app_vi.arb
@@ -387,6 +387,34 @@
   "notificationOpenedEvent": "Đã mở thông báo sự kiện.",
   "notificationOpenedScholarship": "Đã mở thông báo khuyến học.",
   "notificationOpenedGeneral": "Đã mở một thông báo.",
+  "notificationInboxHeroTitle": "Hộp thư thông báo",
+  "notificationInboxHeroDescription": "Xem các cập nhật mới nhất về sự kiện và khuyến học gửi đến hồ sơ thành viên của bạn.",
+  "notificationInboxUnreadCount": "{count} chưa đọc",
+  "@notificationInboxUnreadCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "notificationInboxAllRead": "Bạn đã xem hết thông báo",
+  "notificationInboxSourceSandbox": "Dữ liệu sandbox cục bộ",
+  "notificationInboxSourceLive": "Dữ liệu Firestore trực tiếp",
+  "notificationInboxNoContextTitle": "Chưa thể mở hộp thư thông báo",
+  "notificationInboxNoContextDescription": "Phiên hiện tại chưa liên kết với hồ sơ thành viên nên chưa có hộp thư để hiển thị.",
+  "notificationInboxLoadErrorTitle": "Không thể tải thông báo",
+  "notificationInboxLoadErrorDescription": "Hãy kéo để tải lại hoặc thử lại ngay. Nếu lỗi tiếp tục, hãy kiểm tra kết nối Firebase và quyền truy cập.",
+  "notificationInboxRetryAction": "Thử lại",
+  "notificationInboxEmptyTitle": "Chưa có thông báo nào",
+  "notificationInboxEmptyDescription": "Khi có cập nhật sự kiện hoặc khuyến học, thông báo sẽ xuất hiện tại đây.",
+  "notificationInboxUnreadChip": "Chưa đọc",
+  "notificationInboxReadChip": "Đã đọc",
+  "notificationInboxTargetEvent": "Sự kiện",
+  "notificationInboxTargetScholarship": "Khuyến học",
+  "notificationInboxTargetGeneric": "Chung",
+  "notificationInboxTargetUnknown": "Cập nhật",
+  "notificationInboxFallbackTitle": "Cập nhật thông báo",
+  "notificationInboxFallbackBody": "Mở thông báo này để xem thêm chi tiết.",
   "authIssueRestoreSessionFailed": "BeFam chưa thể khôi phục phiên đăng nhập trước đó.",
   "authIssueRequestOtpBeforeVerify": "Hãy yêu cầu OTP trước khi thử xác minh.",
   "authIssueOtpMustBeSixDigits": "Hãy nhập OTP gồm 6 chữ số để tiếp tục.",

--- a/mobile/befam/lib/l10n/generated/app_localizations.dart
+++ b/mobile/befam/lib/l10n/generated/app_localizations.dart
@@ -2228,6 +2228,132 @@ abstract class AppLocalizations {
   /// **'Đã mở một thông báo.'**
   String get notificationOpenedGeneral;
 
+  /// No description provided for @notificationInboxHeroTitle.
+  ///
+  /// In vi, this message translates to:
+  /// **'Hộp thư thông báo'**
+  String get notificationInboxHeroTitle;
+
+  /// No description provided for @notificationInboxHeroDescription.
+  ///
+  /// In vi, this message translates to:
+  /// **'Xem các cập nhật mới nhất về sự kiện và khuyến học gửi đến hồ sơ thành viên của bạn.'**
+  String get notificationInboxHeroDescription;
+
+  /// No description provided for @notificationInboxUnreadCount.
+  ///
+  /// In vi, this message translates to:
+  /// **'{count} chưa đọc'**
+  String notificationInboxUnreadCount(int count);
+
+  /// No description provided for @notificationInboxAllRead.
+  ///
+  /// In vi, this message translates to:
+  /// **'Bạn đã xem hết thông báo'**
+  String get notificationInboxAllRead;
+
+  /// No description provided for @notificationInboxSourceSandbox.
+  ///
+  /// In vi, this message translates to:
+  /// **'Dữ liệu sandbox cục bộ'**
+  String get notificationInboxSourceSandbox;
+
+  /// No description provided for @notificationInboxSourceLive.
+  ///
+  /// In vi, this message translates to:
+  /// **'Dữ liệu Firestore trực tiếp'**
+  String get notificationInboxSourceLive;
+
+  /// No description provided for @notificationInboxNoContextTitle.
+  ///
+  /// In vi, this message translates to:
+  /// **'Chưa thể mở hộp thư thông báo'**
+  String get notificationInboxNoContextTitle;
+
+  /// No description provided for @notificationInboxNoContextDescription.
+  ///
+  /// In vi, this message translates to:
+  /// **'Phiên hiện tại chưa liên kết với hồ sơ thành viên nên chưa có hộp thư để hiển thị.'**
+  String get notificationInboxNoContextDescription;
+
+  /// No description provided for @notificationInboxLoadErrorTitle.
+  ///
+  /// In vi, this message translates to:
+  /// **'Không thể tải thông báo'**
+  String get notificationInboxLoadErrorTitle;
+
+  /// No description provided for @notificationInboxLoadErrorDescription.
+  ///
+  /// In vi, this message translates to:
+  /// **'Hãy kéo để tải lại hoặc thử lại ngay. Nếu lỗi tiếp tục, hãy kiểm tra kết nối Firebase và quyền truy cập.'**
+  String get notificationInboxLoadErrorDescription;
+
+  /// No description provided for @notificationInboxRetryAction.
+  ///
+  /// In vi, this message translates to:
+  /// **'Thử lại'**
+  String get notificationInboxRetryAction;
+
+  /// No description provided for @notificationInboxEmptyTitle.
+  ///
+  /// In vi, this message translates to:
+  /// **'Chưa có thông báo nào'**
+  String get notificationInboxEmptyTitle;
+
+  /// No description provided for @notificationInboxEmptyDescription.
+  ///
+  /// In vi, this message translates to:
+  /// **'Khi có cập nhật sự kiện hoặc khuyến học, thông báo sẽ xuất hiện tại đây.'**
+  String get notificationInboxEmptyDescription;
+
+  /// No description provided for @notificationInboxUnreadChip.
+  ///
+  /// In vi, this message translates to:
+  /// **'Chưa đọc'**
+  String get notificationInboxUnreadChip;
+
+  /// No description provided for @notificationInboxReadChip.
+  ///
+  /// In vi, this message translates to:
+  /// **'Đã đọc'**
+  String get notificationInboxReadChip;
+
+  /// No description provided for @notificationInboxTargetEvent.
+  ///
+  /// In vi, this message translates to:
+  /// **'Sự kiện'**
+  String get notificationInboxTargetEvent;
+
+  /// No description provided for @notificationInboxTargetScholarship.
+  ///
+  /// In vi, this message translates to:
+  /// **'Khuyến học'**
+  String get notificationInboxTargetScholarship;
+
+  /// No description provided for @notificationInboxTargetGeneric.
+  ///
+  /// In vi, this message translates to:
+  /// **'Chung'**
+  String get notificationInboxTargetGeneric;
+
+  /// No description provided for @notificationInboxTargetUnknown.
+  ///
+  /// In vi, this message translates to:
+  /// **'Cập nhật'**
+  String get notificationInboxTargetUnknown;
+
+  /// No description provided for @notificationInboxFallbackTitle.
+  ///
+  /// In vi, this message translates to:
+  /// **'Cập nhật thông báo'**
+  String get notificationInboxFallbackTitle;
+
+  /// No description provided for @notificationInboxFallbackBody.
+  ///
+  /// In vi, this message translates to:
+  /// **'Mở thông báo này để xem thêm chi tiết.'**
+  String get notificationInboxFallbackBody;
+
   /// No description provided for @authIssueRestoreSessionFailed.
   ///
   /// In vi, this message translates to:

--- a/mobile/befam/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/befam/lib/l10n/generated/app_localizations_en.dart
@@ -1171,6 +1171,77 @@ class AppLocalizationsEn extends AppLocalizations {
   String get notificationOpenedGeneral => 'Opened a notification.';
 
   @override
+  String get notificationInboxHeroTitle => 'Notification inbox';
+
+  @override
+  String get notificationInboxHeroDescription =>
+      'Review the latest event and scholarship updates delivered to your member profile.';
+
+  @override
+  String notificationInboxUnreadCount(int count) {
+    return '$count unread';
+  }
+
+  @override
+  String get notificationInboxAllRead => 'All caught up';
+
+  @override
+  String get notificationInboxSourceSandbox => 'Local sandbox data';
+
+  @override
+  String get notificationInboxSourceLive => 'Live Firestore data';
+
+  @override
+  String get notificationInboxNoContextTitle =>
+      'Notification inbox unavailable';
+
+  @override
+  String get notificationInboxNoContextDescription =>
+      'This session is not linked to a member profile yet, so there is no inbox to show.';
+
+  @override
+  String get notificationInboxLoadErrorTitle => 'Could not load notifications';
+
+  @override
+  String get notificationInboxLoadErrorDescription =>
+      'Pull to refresh or retry now. If this keeps happening, check Firebase connectivity and permissions.';
+
+  @override
+  String get notificationInboxRetryAction => 'Retry';
+
+  @override
+  String get notificationInboxEmptyTitle => 'No notifications yet';
+
+  @override
+  String get notificationInboxEmptyDescription =>
+      'When events and scholarship updates are sent, they will appear here.';
+
+  @override
+  String get notificationInboxUnreadChip => 'Unread';
+
+  @override
+  String get notificationInboxReadChip => 'Read';
+
+  @override
+  String get notificationInboxTargetEvent => 'Event';
+
+  @override
+  String get notificationInboxTargetScholarship => 'Scholarship';
+
+  @override
+  String get notificationInboxTargetGeneric => 'General';
+
+  @override
+  String get notificationInboxTargetUnknown => 'Update';
+
+  @override
+  String get notificationInboxFallbackTitle => 'Notification update';
+
+  @override
+  String get notificationInboxFallbackBody =>
+      'Open this notification for more details.';
+
+  @override
   String get authIssueRestoreSessionFailed =>
       'We could not restore the last sign-in session.';
 

--- a/mobile/befam/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/befam/lib/l10n/generated/app_localizations_vi.dart
@@ -1164,6 +1164,76 @@ class AppLocalizationsVi extends AppLocalizations {
   String get notificationOpenedGeneral => 'Đã mở một thông báo.';
 
   @override
+  String get notificationInboxHeroTitle => 'Hộp thư thông báo';
+
+  @override
+  String get notificationInboxHeroDescription =>
+      'Xem các cập nhật mới nhất về sự kiện và khuyến học gửi đến hồ sơ thành viên của bạn.';
+
+  @override
+  String notificationInboxUnreadCount(int count) {
+    return '$count chưa đọc';
+  }
+
+  @override
+  String get notificationInboxAllRead => 'Bạn đã xem hết thông báo';
+
+  @override
+  String get notificationInboxSourceSandbox => 'Dữ liệu sandbox cục bộ';
+
+  @override
+  String get notificationInboxSourceLive => 'Dữ liệu Firestore trực tiếp';
+
+  @override
+  String get notificationInboxNoContextTitle => 'Chưa thể mở hộp thư thông báo';
+
+  @override
+  String get notificationInboxNoContextDescription =>
+      'Phiên hiện tại chưa liên kết với hồ sơ thành viên nên chưa có hộp thư để hiển thị.';
+
+  @override
+  String get notificationInboxLoadErrorTitle => 'Không thể tải thông báo';
+
+  @override
+  String get notificationInboxLoadErrorDescription =>
+      'Hãy kéo để tải lại hoặc thử lại ngay. Nếu lỗi tiếp tục, hãy kiểm tra kết nối Firebase và quyền truy cập.';
+
+  @override
+  String get notificationInboxRetryAction => 'Thử lại';
+
+  @override
+  String get notificationInboxEmptyTitle => 'Chưa có thông báo nào';
+
+  @override
+  String get notificationInboxEmptyDescription =>
+      'Khi có cập nhật sự kiện hoặc khuyến học, thông báo sẽ xuất hiện tại đây.';
+
+  @override
+  String get notificationInboxUnreadChip => 'Chưa đọc';
+
+  @override
+  String get notificationInboxReadChip => 'Đã đọc';
+
+  @override
+  String get notificationInboxTargetEvent => 'Sự kiện';
+
+  @override
+  String get notificationInboxTargetScholarship => 'Khuyến học';
+
+  @override
+  String get notificationInboxTargetGeneric => 'Chung';
+
+  @override
+  String get notificationInboxTargetUnknown => 'Cập nhật';
+
+  @override
+  String get notificationInboxFallbackTitle => 'Cập nhật thông báo';
+
+  @override
+  String get notificationInboxFallbackBody =>
+      'Mở thông báo này để xem thêm chi tiết.';
+
+  @override
   String get authIssueRestoreSessionFailed =>
       'BeFam chưa thể khôi phục phiên đăng nhập trước đó.';
 

--- a/mobile/befam/test/features/notifications/notification_inbox_page_test.dart
+++ b/mobile/befam/test/features/notifications/notification_inbox_page_test.dart
@@ -1,0 +1,139 @@
+import 'package:befam/features/auth/models/auth_entry_method.dart';
+import 'package:befam/features/auth/models/auth_member_access_mode.dart';
+import 'package:befam/features/auth/models/auth_session.dart';
+import 'package:befam/features/notifications/models/notification_inbox_item.dart';
+import 'package:befam/features/notifications/presentation/notification_inbox_page.dart';
+import 'package:befam/features/notifications/services/notification_inbox_repository.dart';
+import 'package:befam/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  AuthSession buildSession({
+    String? memberId = 'member_demo_parent_001',
+    String? clanId = 'clan_demo_001',
+  }) {
+    return AuthSession(
+      uid: 'debug:+84901234567',
+      loginMethod: AuthEntryMethod.phone,
+      phoneE164: '+84901234567',
+      displayName: 'Nguyen Minh',
+      memberId: memberId,
+      clanId: clanId,
+      branchId: 'branch_demo_001',
+      primaryRole: 'CLAN_ADMIN',
+      accessMode: AuthMemberAccessMode.claimed,
+      linkedAuthUid: true,
+      isSandbox: true,
+      signedInAtIso: DateTime(2026, 3, 14).toIso8601String(),
+    );
+  }
+
+  testWidgets('renders notification rows from repository data', (tester) async {
+    final repository = _FakeNotificationInboxRepository(
+      items: [
+        NotificationInboxItem(
+          id: 'notif_001',
+          memberId: 'member_demo_parent_001',
+          clanId: 'clan_demo_001',
+          type: 'event_created',
+          title: 'Ancestor remembrance ceremony added',
+          body: 'The branch memorial event is scheduled for next Sunday.',
+          isRead: false,
+          createdAt: DateTime(2026, 3, 14, 10, 30),
+          target: NotificationInboxTarget.event,
+          targetId: 'event_demo_001',
+          data: const {'target': 'event', 'id': 'event_demo_001'},
+        ),
+        NotificationInboxItem(
+          id: 'notif_002',
+          memberId: 'member_demo_parent_001',
+          clanId: 'clan_demo_001',
+          type: 'generic',
+          title: 'Family profile sync completed',
+          body: 'Your latest profile changes are now visible to your clan.',
+          isRead: true,
+          createdAt: DateTime(2026, 3, 13, 19, 15),
+          target: NotificationInboxTarget.generic,
+          targetId: null,
+          data: const {'target': 'generic'},
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      _TestApp(
+        child: NotificationInboxPage(
+          session: buildSession(),
+          repository: repository,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('notification-row-notif_001')), findsOneWidget);
+    expect(find.byKey(const Key('notification-row-notif_002')), findsOneWidget);
+    expect(find.text('2 unread'), findsNothing);
+    expect(find.text('1 unread'), findsOneWidget);
+    expect(find.text('Unread'), findsOneWidget);
+    expect(find.text('Read'), findsOneWidget);
+  });
+
+  testWidgets('shows no-context state when member context is missing', (
+    tester,
+  ) async {
+    final repository = _FakeNotificationInboxRepository(items: const []);
+
+    await tester.pumpWidget(
+      _TestApp(
+        child: NotificationInboxPage(
+          session: buildSession(memberId: null, clanId: null),
+          repository: repository,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Notification inbox unavailable'), findsOneWidget);
+    expect(find.text('No notifications yet'), findsNothing);
+  });
+}
+
+class _FakeNotificationInboxRepository implements NotificationInboxRepository {
+  _FakeNotificationInboxRepository({required this.items});
+
+  final List<NotificationInboxItem> items;
+
+  @override
+  bool get isSandbox => true;
+
+  @override
+  Future<List<NotificationInboxItem>> loadInbox({
+    required AuthSession session,
+    int limit = 25,
+  }) async {
+    return items.take(limit).toList(growable: false);
+  }
+}
+
+class _TestApp extends StatelessWidget {
+  const _TestApp({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      locale: const Locale('en'),
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      home: Scaffold(body: child),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a new mobile notification inbox screen with loading, empty, and error states
- wire the inbox into the shell Events destination using a notification inbox repository abstraction
- implement Firebase + debug notification inbox repositories and a Firestore notification model mapper
- add localized inbox copy (vi/en) and update product/navigation/notification docs to reflect current status
- add widget coverage for inbox rendering and missing-member-context behavior

## Testing
- cd mobile/befam && flutter analyze lib/app/home/app_shell_page.dart lib/features/notifications/models/notification_inbox_item.dart lib/features/notifications/services/notification_inbox_repository.dart lib/features/notifications/services/firebase_notification_inbox_repository.dart lib/features/notifications/services/debug_notification_inbox_repository.dart lib/features/notifications/presentation/notification_inbox_page.dart test/features/notifications/notification_inbox_page_test.dart
- cd mobile/befam && flutter test test/features/notifications/notification_inbox_page_test.dart test/widget_test.dart

Closes #107
Refs #10
