### PR TITLE
feat(funds): implement epic 11 funds workspace and ledger flows

### DIFF
--- a/mobile/befam/lib/app/home/app_shell_page.dart
+++ b/mobile/befam/lib/app/home/app_shell_page.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 
 import '../../features/clan/presentation/clan_detail_page.dart';
 import '../../features/clan/services/clan_repository.dart';
+import '../../features/funds/presentation/fund_workspace_page.dart';
+import '../../features/funds/services/fund_repository.dart';
 import '../../features/genealogy/presentation/genealogy_workspace_page.dart';
 import '../../features/genealogy/services/genealogy_read_repository.dart';
 import '../../features/member/presentation/member_workspace_page.dart';
@@ -25,6 +27,7 @@ class AppShellPage extends StatefulWidget {
     required this.session,
     required this.clanRepository,
     required this.memberRepository,
+    this.fundRepository,
     this.genealogyRepository,
     this.pushNotificationService,
     this.onLogoutRequested,
@@ -34,6 +37,7 @@ class AppShellPage extends StatefulWidget {
   final AuthSession session;
   final ClanRepository clanRepository;
   final MemberRepository memberRepository;
+  final FundRepository? fundRepository;
   final GenealogyReadRepository? genealogyRepository;
   final PushNotificationService? pushNotificationService;
   final Future<void> Function()? onLogoutRequested;
@@ -45,6 +49,7 @@ class AppShellPage extends StatefulWidget {
 class _AppShellPageState extends State<AppShellPage> {
   int _selectedIndex = 0;
   late final GenealogyReadRepository _genealogyRepository;
+  late final FundRepository _fundRepository;
   late final PushNotificationService _pushNotificationService;
 
   static const List<_ShellDestination> _destinations = [
@@ -75,6 +80,7 @@ class _AppShellPageState extends State<AppShellPage> {
     super.initState();
     _genealogyRepository =
         widget.genealogyRepository ?? createDefaultGenealogyReadRepository();
+    _fundRepository = widget.fundRepository ?? createDefaultFundRepository();
     _pushNotificationService =
         widget.pushNotificationService ??
         createDefaultPushNotificationService();
@@ -177,6 +183,7 @@ class _AppShellPageState extends State<AppShellPage> {
         session: widget.session,
         clanRepository: widget.clanRepository,
         memberRepository: widget.memberRepository,
+        fundRepository: _fundRepository,
         onOpenTreeRequested: () {
           setState(() {
             _selectedIndex = 1;
@@ -270,6 +277,7 @@ class _HomeDashboard extends StatelessWidget {
     required this.session,
     required this.clanRepository,
     required this.memberRepository,
+    required this.fundRepository,
     required this.onOpenTreeRequested,
   });
 
@@ -277,6 +285,7 @@ class _HomeDashboard extends StatelessWidget {
   final AuthSession session;
   final ClanRepository clanRepository;
   final MemberRepository memberRepository;
+  final FundRepository fundRepository;
   final VoidCallback onOpenTreeRequested;
 
   @override
@@ -473,6 +482,18 @@ class _HomeDashboard extends StatelessWidget {
         );
       },
       'tree' => onOpenTreeRequested,
+      'funds' => () {
+        Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (context) {
+              return FundWorkspacePage(
+                session: session,
+                repository: fundRepository,
+              );
+            },
+          ),
+        );
+      },
       _ => null,
     };
   }

--- a/mobile/befam/lib/app/home/app_shortcuts.dart
+++ b/mobile/befam/lib/app/home/app_shortcuts.dart
@@ -52,7 +52,7 @@ const List<Map<String, dynamic>> _bootstrapShortcutSeed = [
         'Track contribution funds, transaction history, and transparent balances.',
     'route': '/funds',
     'iconKey': 'funds',
-    'status': 'planned',
+    'status': 'live',
   },
   {
     'id': 'scholarship',

--- a/mobile/befam/lib/core/services/debug_genealogy_store.dart
+++ b/mobile/befam/lib/core/services/debug_genealogy_store.dart
@@ -1,4 +1,6 @@
 import '../../features/clan/models/branch_profile.dart';
+import '../../features/funds/models/fund_profile.dart';
+import '../../features/funds/models/fund_transaction.dart';
 import '../../features/member/models/member_profile.dart';
 import '../../features/member/models/member_social_links.dart';
 import '../../features/relationship/models/relationship_record.dart';
@@ -7,8 +9,12 @@ class DebugGenealogyStore {
   DebugGenealogyStore({
     required this.members,
     required this.branches,
+    required this.funds,
+    required this.transactions,
     required this.relationships,
     this.memberSequence = 1000,
+    this.fundSequence = 1000,
+    this.transactionSequence = 1000,
   });
 
   factory DebugGenealogyStore.seeded() {
@@ -176,6 +182,96 @@ class DebugGenealogyStore {
           memberCount: 2,
         ),
       },
+      funds: {
+        'fund_demo_scholarship': const FundProfile(
+          id: 'fund_demo_scholarship',
+          clanId: 'clan_demo_001',
+          branchId: null,
+          name: 'Scholarship Fund',
+          description: 'Supports descendants with annual scholarships.',
+          fundType: 'scholarship',
+          currency: 'VND',
+          balanceMinor: 2500000,
+          status: 'active',
+        ),
+        'fund_demo_operations': const FundProfile(
+          id: 'fund_demo_operations',
+          clanId: 'clan_demo_001',
+          branchId: null,
+          name: 'Clan Operations Fund',
+          description: 'Covers ceremonies and shared operations.',
+          fundType: 'operations',
+          currency: 'VND',
+          balanceMinor: 850000,
+          status: 'active',
+        ),
+      },
+      transactions: {
+        'txn_demo_001': FundTransaction(
+          id: 'txn_demo_001',
+          fundId: 'fund_demo_scholarship',
+          clanId: 'clan_demo_001',
+          branchId: null,
+          transactionType: FundTransactionType.donation,
+          amountMinor: 3000000,
+          currency: 'VND',
+          memberId: 'member_demo_parent_001',
+          externalReference: null,
+          occurredAt: DateTime.utc(2026, 1, 12, 2, 0),
+          note: 'Tet contribution campaign',
+          receiptUrl: null,
+          createdAt: DateTime.utc(2026, 1, 12, 2, 5),
+          createdBy: 'member_demo_parent_001',
+        ),
+        'txn_demo_002': FundTransaction(
+          id: 'txn_demo_002',
+          fundId: 'fund_demo_scholarship',
+          clanId: 'clan_demo_001',
+          branchId: null,
+          transactionType: FundTransactionType.expense,
+          amountMinor: 500000,
+          currency: 'VND',
+          memberId: 'member_demo_parent_001',
+          externalReference: null,
+          occurredAt: DateTime.utc(2026, 2, 10, 7, 0),
+          note: 'Scholarship disbursement batch 1',
+          receiptUrl: null,
+          createdAt: DateTime.utc(2026, 2, 10, 7, 2),
+          createdBy: 'member_demo_parent_001',
+        ),
+        'txn_demo_003': FundTransaction(
+          id: 'txn_demo_003',
+          fundId: 'fund_demo_operations',
+          clanId: 'clan_demo_001',
+          branchId: null,
+          transactionType: FundTransactionType.donation,
+          amountMinor: 1000000,
+          currency: 'VND',
+          memberId: 'member_demo_parent_002',
+          externalReference: 'OPS-2026-01',
+          occurredAt: DateTime.utc(2026, 1, 20, 3, 0),
+          note: 'Operations contribution',
+          receiptUrl: null,
+          createdAt: DateTime.utc(2026, 1, 20, 3, 1),
+          createdBy: 'member_demo_parent_002',
+        ),
+        'txn_demo_004': FundTransaction(
+          id: 'txn_demo_004',
+          fundId: 'fund_demo_operations',
+          clanId: 'clan_demo_001',
+          branchId: null,
+          transactionType: FundTransactionType.expense,
+          amountMinor: 150000,
+          currency: 'VND',
+          memberId: 'member_demo_parent_002',
+          externalReference: null,
+          occurredAt: DateTime.utc(2026, 2, 1, 8, 0),
+          note: 'Memorial logistics supplies',
+          receiptUrl: null,
+          createdAt: DateTime.utc(2026, 2, 1, 8, 1),
+          createdBy: 'member_demo_parent_002',
+        ),
+      },
       relationships: {
         'rel_parent_child_member_demo_parent_001_member_demo_child_001':
             const RelationshipRecord(
@@ -205,6 +301,7 @@ class DebugGenealogyStore {
     );
     store.reconcileRelationshipFields('clan_demo_001');
     store.recountBranchMembers('clan_demo_001');
+    store.recountFundBalances('clan_demo_001');
     return store;
   }
 
@@ -214,8 +311,12 @@ class DebugGenealogyStore {
 
   final Map<String, MemberProfile> members;
   final Map<String, BranchProfile> branches;
+  final Map<String, FundProfile> funds;
+  final Map<String, FundTransaction> transactions;
   final Map<String, RelationshipRecord> relationships;
   int memberSequence;
+  int fundSequence;
+  int transactionSequence;
 
   void recountBranchMembers(String clanId) {
     for (final entry in branches.entries) {
@@ -300,6 +401,25 @@ class DebugGenealogyStore {
         childrenIds: childIds,
         spouseIds: spouseIds,
       );
+    }
+  }
+
+  void recountFundBalances(String clanId) {
+    for (final entry in funds.entries) {
+      final fund = entry.value;
+      if (fund.clanId != clanId) {
+        continue;
+      }
+
+      var balance = 0;
+      for (final transaction in transactions.values.where(
+        (candidate) =>
+            candidate.clanId == clanId && candidate.fundId == fund.id,
+      )) {
+        balance += transaction.signedAmountMinor;
+      }
+
+      funds[entry.key] = fund.copyWith(balanceMinor: balance);
     }
   }
 }

--- a/mobile/befam/lib/features/funds/models/fund_draft.dart
+++ b/mobile/befam/lib/features/funds/models/fund_draft.dart
@@ -1,0 +1,53 @@
+import 'fund_profile.dart';
+
+class FundDraft {
+  const FundDraft({
+    required this.name,
+    required this.description,
+    required this.fundType,
+    required this.currency,
+    this.branchId,
+  });
+
+  final String name;
+  final String description;
+  final String fundType;
+  final String currency;
+  final String? branchId;
+
+  factory FundDraft.empty() {
+    return const FundDraft(
+      name: '',
+      description: '',
+      fundType: 'scholarship',
+      currency: 'VND',
+    );
+  }
+
+  factory FundDraft.fromProfile(FundProfile profile) {
+    return FundDraft(
+      name: profile.name,
+      description: profile.description,
+      fundType: profile.fundType,
+      currency: profile.currency,
+      branchId: profile.branchId,
+    );
+  }
+
+  FundDraft copyWith({
+    String? name,
+    String? description,
+    String? fundType,
+    String? currency,
+    String? branchId,
+    bool clearBranchId = false,
+  }) {
+    return FundDraft(
+      name: name ?? this.name,
+      description: description ?? this.description,
+      fundType: fundType ?? this.fundType,
+      currency: currency ?? this.currency,
+      branchId: clearBranchId ? null : (branchId ?? this.branchId),
+    );
+  }
+}

--- a/mobile/befam/lib/features/funds/models/fund_profile.dart
+++ b/mobile/befam/lib/features/funds/models/fund_profile.dart
@@ -1,0 +1,96 @@
+class FundProfile {
+  const FundProfile({
+    required this.id,
+    required this.clanId,
+    this.branchId,
+    required this.name,
+    required this.description,
+    required this.fundType,
+    required this.currency,
+    required this.balanceMinor,
+    required this.status,
+  });
+
+  final String id;
+  final String clanId;
+  final String? branchId;
+  final String name;
+  final String description;
+  final String fundType;
+  final String currency;
+  final int balanceMinor;
+  final String status;
+
+  bool get isActive => status.trim().toLowerCase() == 'active';
+
+  FundProfile copyWith({
+    String? id,
+    String? clanId,
+    String? branchId,
+    bool clearBranchId = false,
+    String? name,
+    String? description,
+    String? fundType,
+    String? currency,
+    int? balanceMinor,
+    String? status,
+  }) {
+    return FundProfile(
+      id: id ?? this.id,
+      clanId: clanId ?? this.clanId,
+      branchId: clearBranchId ? null : (branchId ?? this.branchId),
+      name: name ?? this.name,
+      description: description ?? this.description,
+      fundType: fundType ?? this.fundType,
+      currency: currency ?? this.currency,
+      balanceMinor: balanceMinor ?? this.balanceMinor,
+      status: status ?? this.status,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'clanId': clanId,
+      'branchId': branchId,
+      'name': name,
+      'description': description,
+      'fundType': fundType,
+      'currency': currency,
+      'balanceMinor': balanceMinor,
+      'status': status,
+    };
+  }
+
+  factory FundProfile.fromJson(Map<String, dynamic> json) {
+    return FundProfile(
+      id: json['id'] as String? ?? '',
+      clanId: json['clanId'] as String? ?? '',
+      branchId: _nullableString(json['branchId']),
+      name: json['name'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+      fundType: json['fundType'] as String? ?? 'custom',
+      currency: (json['currency'] as String? ?? 'VND').trim().toUpperCase(),
+      balanceMinor: _asInt(json['balanceMinor']),
+      status: json['status'] as String? ?? 'active',
+    );
+  }
+}
+
+String? _nullableString(Object? value) {
+  final text = value is String ? value.trim() : '';
+  return text.isEmpty ? null : text;
+}
+
+int _asInt(Object? value) {
+  if (value is int) {
+    return value;
+  }
+  if (value is double) {
+    return value.round();
+  }
+  if (value is String) {
+    return int.tryParse(value) ?? 0;
+  }
+  return 0;
+}

--- a/mobile/befam/lib/features/funds/models/fund_transaction.dart
+++ b/mobile/befam/lib/features/funds/models/fund_transaction.dart
@@ -1,0 +1,182 @@
+enum FundTransactionType {
+  donation,
+  expense;
+
+  String get jsonValue => name;
+
+  String get label {
+    return switch (this) {
+      FundTransactionType.donation => 'Donation',
+      FundTransactionType.expense => 'Expense',
+    };
+  }
+
+  static FundTransactionType fromJsonValue(String? value) {
+    return switch (value?.trim().toLowerCase()) {
+      'expense' => FundTransactionType.expense,
+      _ => FundTransactionType.donation,
+    };
+  }
+}
+
+class FundTransaction {
+  const FundTransaction({
+    required this.id,
+    required this.fundId,
+    required this.clanId,
+    this.branchId,
+    required this.transactionType,
+    required this.amountMinor,
+    required this.currency,
+    this.memberId,
+    this.externalReference,
+    required this.occurredAt,
+    required this.note,
+    this.receiptUrl,
+    this.createdAt,
+    this.createdBy,
+  });
+
+  final String id;
+  final String fundId;
+  final String clanId;
+  final String? branchId;
+  final FundTransactionType transactionType;
+  final int amountMinor;
+  final String currency;
+  final String? memberId;
+  final String? externalReference;
+  final DateTime occurredAt;
+  final String note;
+  final String? receiptUrl;
+  final DateTime? createdAt;
+  final String? createdBy;
+
+  bool get isDonation => transactionType == FundTransactionType.donation;
+  bool get isExpense => transactionType == FundTransactionType.expense;
+
+  int get signedAmountMinor => isDonation ? amountMinor : -amountMinor;
+
+  FundTransaction copyWith({
+    String? id,
+    String? fundId,
+    String? clanId,
+    String? branchId,
+    bool clearBranchId = false,
+    FundTransactionType? transactionType,
+    int? amountMinor,
+    String? currency,
+    String? memberId,
+    bool clearMemberId = false,
+    String? externalReference,
+    bool clearExternalReference = false,
+    DateTime? occurredAt,
+    String? note,
+    String? receiptUrl,
+    bool clearReceiptUrl = false,
+    DateTime? createdAt,
+    bool clearCreatedAt = false,
+    String? createdBy,
+    bool clearCreatedBy = false,
+  }) {
+    return FundTransaction(
+      id: id ?? this.id,
+      fundId: fundId ?? this.fundId,
+      clanId: clanId ?? this.clanId,
+      branchId: clearBranchId ? null : (branchId ?? this.branchId),
+      transactionType: transactionType ?? this.transactionType,
+      amountMinor: amountMinor ?? this.amountMinor,
+      currency: currency ?? this.currency,
+      memberId: clearMemberId ? null : (memberId ?? this.memberId),
+      externalReference: clearExternalReference
+          ? null
+          : (externalReference ?? this.externalReference),
+      occurredAt: occurredAt ?? this.occurredAt,
+      note: note ?? this.note,
+      receiptUrl: clearReceiptUrl ? null : (receiptUrl ?? this.receiptUrl),
+      createdAt: clearCreatedAt ? null : (createdAt ?? this.createdAt),
+      createdBy: clearCreatedBy ? null : (createdBy ?? this.createdBy),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'fundId': fundId,
+      'clanId': clanId,
+      'branchId': branchId,
+      'transactionType': transactionType.jsonValue,
+      'amountMinor': amountMinor,
+      'currency': currency,
+      'memberId': memberId,
+      'externalReference': externalReference,
+      'occurredAt': occurredAt.toUtc().toIso8601String(),
+      'note': note,
+      'receiptUrl': receiptUrl,
+      'createdAt': createdAt?.toUtc().toIso8601String(),
+      'createdBy': createdBy,
+    };
+  }
+
+  factory FundTransaction.fromJson(Map<String, dynamic> json) {
+    return FundTransaction(
+      id: json['id'] as String? ?? '',
+      fundId: json['fundId'] as String? ?? '',
+      clanId: json['clanId'] as String? ?? '',
+      branchId: _nullableString(json['branchId']),
+      transactionType: FundTransactionType.fromJsonValue(
+        json['transactionType'] as String?,
+      ),
+      amountMinor: _asInt(json['amountMinor']),
+      currency: (json['currency'] as String? ?? 'VND').trim().toUpperCase(),
+      memberId: _nullableString(json['memberId']),
+      externalReference: _nullableString(json['externalReference']),
+      occurredAt: _parseDateTime(
+        json['occurredAt'],
+        fallback: DateTime.now().toUtc(),
+      ),
+      note: json['note'] as String? ?? '',
+      receiptUrl: _nullableString(json['receiptUrl']),
+      createdAt: _parseNullableDateTime(json['createdAt']),
+      createdBy: _nullableString(json['createdBy']),
+    );
+  }
+}
+
+String? _nullableString(Object? value) {
+  final text = value is String ? value.trim() : '';
+  return text.isEmpty ? null : text;
+}
+
+int _asInt(Object? value) {
+  if (value is int) {
+    return value;
+  }
+  if (value is double) {
+    return value.round();
+  }
+  if (value is String) {
+    return int.tryParse(value) ?? 0;
+  }
+  return 0;
+}
+
+DateTime? _parseNullableDateTime(Object? value) {
+  if (value == null) {
+    return null;
+  }
+  return _parseDateTime(value, fallback: DateTime.now().toUtc());
+}
+
+DateTime _parseDateTime(Object? value, {required DateTime fallback}) {
+  if (value is DateTime) {
+    return value.toUtc();
+  }
+  if (value is String) {
+    final parsed = DateTime.tryParse(value);
+    if (parsed != null) {
+      return parsed.toUtc();
+    }
+  }
+  return fallback;
+}

--- a/mobile/befam/lib/features/funds/models/fund_transaction_draft.dart
+++ b/mobile/befam/lib/features/funds/models/fund_transaction_draft.dart
@@ -1,0 +1,69 @@
+import 'fund_transaction.dart';
+
+class FundTransactionDraft {
+  const FundTransactionDraft({
+    required this.fundId,
+    required this.transactionType,
+    required this.amountInput,
+    required this.currency,
+    required this.occurredAt,
+    required this.note,
+    this.memberId,
+    this.externalReference,
+    this.receiptUrl,
+  });
+
+  final String fundId;
+  final FundTransactionType transactionType;
+  final String amountInput;
+  final String currency;
+  final DateTime occurredAt;
+  final String note;
+  final String? memberId;
+  final String? externalReference;
+  final String? receiptUrl;
+
+  factory FundTransactionDraft.empty({
+    required String fundId,
+    required FundTransactionType transactionType,
+    required String currency,
+  }) {
+    return FundTransactionDraft(
+      fundId: fundId,
+      transactionType: transactionType,
+      amountInput: '',
+      currency: currency,
+      occurredAt: DateTime.now(),
+      note: '',
+    );
+  }
+
+  FundTransactionDraft copyWith({
+    String? fundId,
+    FundTransactionType? transactionType,
+    String? amountInput,
+    String? currency,
+    DateTime? occurredAt,
+    String? note,
+    String? memberId,
+    bool clearMemberId = false,
+    String? externalReference,
+    bool clearExternalReference = false,
+    String? receiptUrl,
+    bool clearReceiptUrl = false,
+  }) {
+    return FundTransactionDraft(
+      fundId: fundId ?? this.fundId,
+      transactionType: transactionType ?? this.transactionType,
+      amountInput: amountInput ?? this.amountInput,
+      currency: currency ?? this.currency,
+      occurredAt: occurredAt ?? this.occurredAt,
+      note: note ?? this.note,
+      memberId: clearMemberId ? null : (memberId ?? this.memberId),
+      externalReference: clearExternalReference
+          ? null
+          : (externalReference ?? this.externalReference),
+      receiptUrl: clearReceiptUrl ? null : (receiptUrl ?? this.receiptUrl),
+    );
+  }
+}

--- a/mobile/befam/lib/features/funds/models/fund_transaction_filters.dart
+++ b/mobile/befam/lib/features/funds/models/fund_transaction_filters.dart
@@ -1,0 +1,34 @@
+import 'fund_transaction.dart';
+
+class FundTransactionFilters {
+  const FundTransactionFilters({
+    this.query = '',
+    this.transactionType,
+    this.from,
+    this.to,
+  });
+
+  final String query;
+  final FundTransactionType? transactionType;
+  final DateTime? from;
+  final DateTime? to;
+
+  FundTransactionFilters copyWith({
+    String? query,
+    FundTransactionType? transactionType,
+    bool clearTransactionType = false,
+    DateTime? from,
+    bool clearFrom = false,
+    DateTime? to,
+    bool clearTo = false,
+  }) {
+    return FundTransactionFilters(
+      query: query ?? this.query,
+      transactionType: clearTransactionType
+          ? null
+          : (transactionType ?? this.transactionType),
+      from: clearFrom ? null : (from ?? this.from),
+      to: clearTo ? null : (to ?? this.to),
+    );
+  }
+}

--- a/mobile/befam/lib/features/funds/models/fund_workspace_snapshot.dart
+++ b/mobile/befam/lib/features/funds/models/fund_workspace_snapshot.dart
@@ -1,0 +1,12 @@
+import 'fund_profile.dart';
+import 'fund_transaction.dart';
+
+class FundWorkspaceSnapshot {
+  const FundWorkspaceSnapshot({
+    required this.funds,
+    required this.transactions,
+  });
+
+  final List<FundProfile> funds;
+  final List<FundTransaction> transactions;
+}

--- a/mobile/befam/lib/features/funds/presentation/fund_controller.dart
+++ b/mobile/befam/lib/features/funds/presentation/fund_controller.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/foundation.dart';
+
+import '../../auth/models/auth_session.dart';
+import '../models/fund_draft.dart';
+import '../models/fund_profile.dart';
+import '../models/fund_transaction.dart';
+import '../models/fund_transaction_draft.dart';
+import '../models/fund_transaction_filters.dart';
+import '../services/fund_repository.dart';
+
+class FundController extends ChangeNotifier {
+  FundController({
+    required FundRepository repository,
+    required AuthSession session,
+  }) : _repository = repository,
+       _session = session;
+
+  final FundRepository _repository;
+  final AuthSession _session;
+
+  bool _isLoading = true;
+  bool _isSavingFund = false;
+  bool _isSavingTransaction = false;
+  String? _errorMessage;
+  List<FundProfile> _funds = const [];
+  List<FundTransaction> _transactions = const [];
+  String? _selectedFundId;
+  FundTransactionFilters _filters = const FundTransactionFilters();
+
+  bool get isLoading => _isLoading;
+  bool get isSavingFund => _isSavingFund;
+  bool get isSavingTransaction => _isSavingTransaction;
+  String? get errorMessage => _errorMessage;
+  List<FundProfile> get funds => _funds;
+  List<FundTransaction> get transactions => _transactions;
+  FundTransactionFilters get filters => _filters;
+
+  bool get hasClanContext => (_session.clanId ?? '').trim().isNotEmpty;
+
+  bool get canManageFunds {
+    final role = _session.primaryRole?.trim().toUpperCase();
+    return role == 'SUPER_ADMIN' ||
+        role == 'CLAN_ADMIN' ||
+        role == 'BRANCH_ADMIN';
+  }
+
+  FundProfile? get selectedFund {
+    if (_selectedFundId == null || _selectedFundId!.isEmpty) {
+      return _funds.isEmpty ? null : _funds.first;
+    }
+
+    for (final fund in _funds) {
+      if (fund.id == _selectedFundId) {
+        return fund;
+      }
+    }
+
+    return _funds.isEmpty ? null : _funds.first;
+  }
+
+  int get totalBalanceMinor {
+    return _funds.fold<int>(0, (sum, fund) => sum + fund.balanceMinor);
+  }
+
+  Future<void> initialize() async {
+    await refresh();
+  }
+
+  Future<void> refresh() async {
+    final previousSelectedFundId = _selectedFundId;
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final snapshot = await _repository.loadWorkspace(session: _session);
+      _funds = snapshot.funds;
+      _transactions = snapshot.transactions;
+      _selectedFundId = _resolveSelectedFundId(previousSelectedFundId);
+    } catch (error) {
+      _errorMessage = error.toString();
+      _funds = const [];
+      _transactions = const [];
+      _selectedFundId = null;
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  void selectFund(String fundId) {
+    _selectedFundId = fundId;
+    notifyListeners();
+  }
+
+  void updateQueryFilter(String value) {
+    _filters = _filters.copyWith(query: value);
+    notifyListeners();
+  }
+
+  void updateTypeFilter(FundTransactionType? type) {
+    _filters = _filters.copyWith(
+      transactionType: type,
+      clearTransactionType: type == null,
+    );
+    notifyListeners();
+  }
+
+  void clearFilters() {
+    _filters = const FundTransactionFilters();
+    notifyListeners();
+  }
+
+  List<FundTransaction> filteredTransactionsForFund(String fundId) {
+    final query = _filters.query.trim().toLowerCase();
+
+    return _transactions
+        .where((transaction) {
+          if (transaction.fundId != fundId) {
+            return false;
+          }
+
+          if (_filters.transactionType != null &&
+              transaction.transactionType != _filters.transactionType) {
+            return false;
+          }
+
+          final from = _filters.from;
+          if (from != null && transaction.occurredAt.isBefore(from.toUtc())) {
+            return false;
+          }
+
+          final to = _filters.to;
+          if (to != null && transaction.occurredAt.isAfter(to.toUtc())) {
+            return false;
+          }
+
+          if (query.isEmpty) {
+            return true;
+          }
+
+          final haystack = [
+            transaction.note,
+            transaction.externalReference ?? '',
+            transaction.memberId ?? '',
+          ].join(' ').toLowerCase();
+
+          return haystack.contains(query);
+        })
+        .toList(growable: false)
+      ..sort((left, right) => right.occurredAt.compareTo(left.occurredAt));
+  }
+
+  Future<FundRepositoryErrorCode?> saveFund({
+    String? fundId,
+    required FundDraft draft,
+  }) async {
+    if (!canManageFunds) {
+      return FundRepositoryErrorCode.permissionDenied;
+    }
+
+    _isSavingFund = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final saved = await _repository.saveFund(
+        session: _session,
+        fundId: fundId,
+        draft: draft,
+      );
+      await refresh();
+      _selectedFundId = saved.id;
+      notifyListeners();
+      return null;
+    } on FundRepositoryException catch (error) {
+      _errorMessage = error.toString();
+      return error.code;
+    } finally {
+      _isSavingFund = false;
+      notifyListeners();
+    }
+  }
+
+  Future<FundRepositoryErrorCode?> recordTransaction({
+    required FundTransactionDraft draft,
+  }) async {
+    if (!canManageFunds) {
+      return FundRepositoryErrorCode.permissionDenied;
+    }
+
+    _isSavingTransaction = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      await _repository.recordTransaction(session: _session, draft: draft);
+      await refresh();
+      return null;
+    } on FundRepositoryException catch (error) {
+      _errorMessage = error.toString();
+      return error.code;
+    } finally {
+      _isSavingTransaction = false;
+      notifyListeners();
+    }
+  }
+
+  String? _resolveSelectedFundId(String? previousSelectedFundId) {
+    if (_funds.isEmpty) {
+      return null;
+    }
+
+    if (previousSelectedFundId != null &&
+        _funds.any((fund) => fund.id == previousSelectedFundId)) {
+      return previousSelectedFundId;
+    }
+
+    return _funds.first.id;
+  }
+}

--- a/mobile/befam/lib/features/funds/presentation/fund_workspace_page.dart
+++ b/mobile/befam/lib/features/funds/presentation/fund_workspace_page.dart
@@ -1,0 +1,1582 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../auth/models/auth_session.dart';
+import '../models/fund_draft.dart';
+import '../models/fund_profile.dart';
+import '../models/fund_transaction.dart';
+import '../models/fund_transaction_draft.dart';
+import '../services/currency_minor_units.dart';
+import '../services/fund_repository.dart';
+import 'fund_controller.dart';
+
+class FundWorkspacePage extends StatefulWidget {
+  const FundWorkspacePage({
+    super.key,
+    required this.session,
+    required this.repository,
+  });
+
+  final AuthSession session;
+  final FundRepository repository;
+
+  @override
+  State<FundWorkspacePage> createState() => _FundWorkspacePageState();
+}
+
+class _FundWorkspacePageState extends State<FundWorkspacePage> {
+  late final FundController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = FundController(
+      repository: widget.repository,
+      session: widget.session,
+    );
+    unawaited(_controller.initialize());
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _openFundEditor({FundProfile? fund}) async {
+    final didSave = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) {
+        return _FundEditorSheet(
+          title: fund == null ? 'Create fund' : 'Edit fund',
+          description:
+              'Set up a fund profile for donations, expenses, and transparent balance tracking.',
+          initialDraft: fund == null
+              ? FundDraft.empty()
+              : FundDraft.fromProfile(fund),
+          isSaving: _controller.isSavingFund,
+          onSubmit: (draft) {
+            return _controller.saveFund(fundId: fund?.id, draft: draft);
+          },
+        );
+      },
+    );
+
+    if (didSave == true && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            fund == null
+                ? 'Fund created successfully.'
+                : 'Fund updated successfully.',
+          ),
+        ),
+      );
+    }
+  }
+
+  void _openFundDetail(FundProfile fund) {
+    _controller.selectFund(fund.id);
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (context) {
+          return _FundDetailPage(controller: _controller, fundId: fund.id);
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        final theme = Theme.of(context);
+        final colorScheme = theme.colorScheme;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Funds'),
+            actions: [
+              IconButton(
+                tooltip: 'Refresh',
+                onPressed: _controller.isLoading ? null : _controller.refresh,
+                icon: const Icon(Icons.refresh),
+              ),
+            ],
+          ),
+          floatingActionButton: _controller.canManageFunds
+              ? FloatingActionButton.extended(
+                  onPressed: () => _openFundEditor(),
+                  icon: const Icon(Icons.add),
+                  label: const Text('Add fund'),
+                )
+              : null,
+          body: SafeArea(
+            child: _controller.isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : !_controller.hasClanContext
+                ? const _EmptyWorkspace(
+                    icon: Icons.lock_outline,
+                    title: 'No clan context',
+                    description:
+                        'Link this account to a clan before viewing funds and transactions.',
+                  )
+                : RefreshIndicator(
+                    onRefresh: _controller.refresh,
+                    child: ListView(
+                      padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+                      children: [
+                        _WorkspaceHero(
+                          title: 'Fund ledger workspace',
+                          description:
+                              'Track donations, expenses, running balance, and history across each fund.',
+                          canManageFunds: _controller.canManageFunds,
+                          onPrimaryAction: _controller.canManageFunds
+                              ? () => _openFundEditor()
+                              : null,
+                        ),
+                        const SizedBox(height: 20),
+                        if (_controller.errorMessage case final error?) ...[
+                          _InfoCard(
+                            icon: Icons.error_outline,
+                            title: 'Unable to sync funds',
+                            description: error,
+                            tone: colorScheme.errorContainer,
+                          ),
+                          const SizedBox(height: 20),
+                        ],
+                        if (!_controller.canManageFunds) ...[
+                          _InfoCard(
+                            icon: Icons.visibility_outlined,
+                            title: 'Read-only role',
+                            description:
+                                'Only clan-level administrators can create funds or post transactions.',
+                            tone: colorScheme.secondaryContainer,
+                          ),
+                          const SizedBox(height: 20),
+                        ],
+                        _StatRow(
+                          items: [
+                            _StatTile(
+                              label: 'Funds',
+                              value: '${_controller.funds.length}',
+                              icon: Icons.account_balance_wallet_outlined,
+                            ),
+                            _StatTile(
+                              label: 'Transactions',
+                              value: '${_controller.transactions.length}',
+                              icon: Icons.receipt_long_outlined,
+                            ),
+                            _StatTile(
+                              label: 'Access',
+                              value: _controller.canManageFunds
+                                  ? 'Write'
+                                  : 'Read',
+                              icon: Icons.verified_user_outlined,
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 20),
+                        _SectionCard(
+                          title: 'Fund list',
+                          actionLabel: _controller.canManageFunds
+                              ? 'Create fund'
+                              : null,
+                          onAction: _controller.canManageFunds
+                              ? () => _openFundEditor()
+                              : null,
+                          child: _controller.funds.isEmpty
+                              ? const _EmptyWorkspace(
+                                  icon: Icons.savings_outlined,
+                                  title: 'No funds yet',
+                                  description:
+                                      'Create the first fund to start recording donations and expenses.',
+                                )
+                              : Column(
+                                  children: [
+                                    for (
+                                      var i = 0;
+                                      i < _controller.funds.length;
+                                      i++
+                                    )
+                                      Padding(
+                                        padding: EdgeInsets.only(
+                                          bottom:
+                                              i == _controller.funds.length - 1
+                                              ? 0
+                                              : 14,
+                                        ),
+                                        child: _FundSummaryCard(
+                                          fund: _controller.funds[i],
+                                          onTap: () => _openFundDetail(
+                                            _controller.funds[i],
+                                          ),
+                                          onEdit: _controller.canManageFunds
+                                              ? () => _openFundEditor(
+                                                  fund: _controller.funds[i],
+                                                )
+                                              : null,
+                                        ),
+                                      ),
+                                  ],
+                                ),
+                        ),
+                      ],
+                    ),
+                  ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _FundDetailPage extends StatefulWidget {
+  const _FundDetailPage({required this.controller, required this.fundId});
+
+  final FundController controller;
+  final String fundId;
+
+  @override
+  State<_FundDetailPage> createState() => _FundDetailPageState();
+}
+
+class _FundDetailPageState extends State<_FundDetailPage> {
+  late final TextEditingController _queryController;
+
+  @override
+  void initState() {
+    super.initState();
+    _queryController = TextEditingController(
+      text: widget.controller.filters.query,
+    );
+  }
+
+  @override
+  void dispose() {
+    _queryController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _openTransactionEditor(
+    FundProfile fund,
+    FundTransactionType type,
+  ) async {
+    final didSave = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) {
+        return _TransactionEditorSheet(
+          title: type == FundTransactionType.donation
+              ? 'Record donation'
+              : 'Record expense',
+          description: type == FundTransactionType.donation
+              ? 'Add incoming contributions to this fund.'
+              : 'Log outgoing expenses from this fund.',
+          initialDraft: FundTransactionDraft.empty(
+            fundId: fund.id,
+            transactionType: type,
+            currency: fund.currency,
+          ),
+          isSaving: widget.controller.isSavingTransaction,
+          onSubmit: (draft) {
+            return widget.controller.recordTransaction(draft: draft);
+          },
+        );
+      },
+    );
+
+    if (didSave == true && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            type == FundTransactionType.donation
+                ? 'Donation saved.'
+                : 'Expense saved.',
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: widget.controller,
+      builder: (context, _) {
+        final fund = widget.controller.funds
+            .where((item) => item.id == widget.fundId)
+            .firstOrNull;
+        final theme = Theme.of(context);
+        final colorScheme = theme.colorScheme;
+
+        if (fund == null) {
+          return const Scaffold(
+            body: SafeArea(
+              child: _EmptyWorkspace(
+                icon: Icons.search_off,
+                title: 'Fund not found',
+                description: 'This fund may have been removed or changed.',
+              ),
+            ),
+          );
+        }
+
+        final transactions = widget.controller.filteredTransactionsForFund(
+          fund.id,
+        );
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(fund.name),
+            actions: [
+              IconButton(
+                tooltip: 'Refresh',
+                onPressed: widget.controller.isLoading
+                    ? null
+                    : widget.controller.refresh,
+                icon: const Icon(Icons.refresh),
+              ),
+            ],
+          ),
+          body: SafeArea(
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(22),
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        colorScheme.primary,
+                        colorScheme.primaryContainer,
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                    borderRadius: BorderRadius.circular(24),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        _titleCase(fund.fundType),
+                        style: theme.textTheme.labelLarge?.copyWith(
+                          color: colorScheme.onPrimary,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        'Running balance',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: colorScheme.onPrimary.withValues(alpha: 0.9),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        CurrencyMinorUnits.formatMinorUnits(
+                          amountMinor: fund.balanceMinor,
+                          currency: fund.currency,
+                        ),
+                        style: theme.textTheme.headlineSmall?.copyWith(
+                          color: colorScheme.onPrimary,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      if (fund.description.trim().isNotEmpty) ...[
+                        const SizedBox(height: 12),
+                        Text(
+                          fund.description,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: colorScheme.onPrimary.withValues(
+                              alpha: 0.88,
+                            ),
+                          ),
+                        ),
+                      ],
+                      if (widget.controller.canManageFunds) ...[
+                        const SizedBox(height: 18),
+                        Wrap(
+                          spacing: 10,
+                          runSpacing: 10,
+                          children: [
+                            FilledButton.icon(
+                              onPressed: () => _openTransactionEditor(
+                                fund,
+                                FundTransactionType.donation,
+                              ),
+                              icon: const Icon(Icons.add_circle_outline),
+                              label: const Text('Add donation'),
+                            ),
+                            OutlinedButton.icon(
+                              style: OutlinedButton.styleFrom(
+                                foregroundColor: colorScheme.onPrimary,
+                                side: BorderSide(
+                                  color: colorScheme.onPrimary.withValues(
+                                    alpha: 0.4,
+                                  ),
+                                ),
+                              ),
+                              onPressed: () => _openTransactionEditor(
+                                fund,
+                                FundTransactionType.expense,
+                              ),
+                              icon: const Icon(Icons.remove_circle_outline),
+                              label: const Text('Add expense'),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 20),
+                _SectionCard(
+                  title: 'Transaction filters',
+                  actionLabel:
+                      widget.controller.filters.query.trim().isNotEmpty ||
+                          widget.controller.filters.transactionType != null
+                      ? 'Clear'
+                      : null,
+                  onAction:
+                      widget.controller.filters.query.trim().isNotEmpty ||
+                          widget.controller.filters.transactionType != null
+                      ? () {
+                          _queryController.clear();
+                          widget.controller.clearFilters();
+                        }
+                      : null,
+                  child: Column(
+                    children: [
+                      TextField(
+                        controller: _queryController,
+                        decoration: const InputDecoration(
+                          labelText: 'Search note/reference/member',
+                          prefixIcon: Icon(Icons.search),
+                        ),
+                        textInputAction: TextInputAction.search,
+                        onChanged: widget.controller.updateQueryFilter,
+                      ),
+                      const SizedBox(height: 14),
+                      DropdownButtonFormField<FundTransactionType?>(
+                        initialValue: widget.controller.filters.transactionType,
+                        decoration: const InputDecoration(
+                          labelText: 'Transaction type',
+                        ),
+                        items: const [
+                          DropdownMenuItem<FundTransactionType?>(
+                            value: null,
+                            child: Text('All types'),
+                          ),
+                          DropdownMenuItem<FundTransactionType?>(
+                            value: FundTransactionType.donation,
+                            child: Text('Donations'),
+                          ),
+                          DropdownMenuItem<FundTransactionType?>(
+                            value: FundTransactionType.expense,
+                            child: Text('Expenses'),
+                          ),
+                        ],
+                        onChanged: widget.controller.updateTypeFilter,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 20),
+                _SectionCard(
+                  title: 'Transaction history',
+                  actionLabel: widget.controller.canManageFunds
+                      ? 'Donation'
+                      : null,
+                  onAction: widget.controller.canManageFunds
+                      ? () => _openTransactionEditor(
+                          fund,
+                          FundTransactionType.donation,
+                        )
+                      : null,
+                  child: transactions.isEmpty
+                      ? const _EmptyWorkspace(
+                          icon: Icons.receipt_long_outlined,
+                          title: 'No transactions',
+                          description:
+                              'Create a donation or expense to populate this ledger.',
+                        )
+                      : Column(
+                          children: [
+                            for (var i = 0; i < transactions.length; i++)
+                              Padding(
+                                padding: EdgeInsets.only(
+                                  bottom: i == transactions.length - 1 ? 0 : 12,
+                                ),
+                                child: _TransactionRow(
+                                  transaction: transactions[i],
+                                ),
+                              ),
+                          ],
+                        ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _FundEditorSheet extends StatefulWidget {
+  const _FundEditorSheet({
+    required this.title,
+    required this.description,
+    required this.initialDraft,
+    required this.isSaving,
+    required this.onSubmit,
+  });
+
+  final String title;
+  final String description;
+  final FundDraft initialDraft;
+  final bool isSaving;
+  final Future<FundRepositoryErrorCode?> Function(FundDraft draft) onSubmit;
+
+  @override
+  State<_FundEditorSheet> createState() => _FundEditorSheetState();
+}
+
+class _FundEditorSheetState extends State<_FundEditorSheet> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  late final TextEditingController _descriptionController;
+  late final TextEditingController _branchIdController;
+
+  late String _fundType;
+  late String _currency;
+  FundRepositoryErrorCode? _submitError;
+  bool _isSubmitting = false;
+
+  static const _fundTypes = [
+    'scholarship',
+    'operations',
+    'maintenance',
+    'custom',
+  ];
+
+  static const _currencies = ['VND', 'USD', 'EUR'];
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.initialDraft.name);
+    _descriptionController = TextEditingController(
+      text: widget.initialDraft.description,
+    );
+    _branchIdController = TextEditingController(
+      text: widget.initialDraft.branchId ?? '',
+    );
+    _fundType = _fundTypes.contains(widget.initialDraft.fundType)
+        ? widget.initialDraft.fundType
+        : 'custom';
+    _currency = _currencies.contains(widget.initialDraft.currency.toUpperCase())
+        ? widget.initialDraft.currency.toUpperCase()
+        : 'VND';
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    _branchIdController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+
+    final error = await widget.onSubmit(
+      FundDraft(
+        name: _nameController.text.trim(),
+        description: _descriptionController.text.trim(),
+        fundType: _fundType,
+        currency: _currency,
+        branchId: _nullIfBlank(_branchIdController.text),
+      ),
+    );
+
+    if (!mounted) {
+      return;
+    }
+
+    if (error == null) {
+      Navigator.of(context).pop(true);
+      return;
+    }
+
+    setState(() {
+      _isSubmitting = false;
+      _submitError = error;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final insets = MediaQuery.viewInsetsOf(context);
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: insets.bottom),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+        ),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 28),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: Container(
+                    width: 44,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.outlineVariant,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  widget.title,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Text(widget.description, style: theme.textTheme.bodyMedium),
+                if (_submitError != null) ...[
+                  const SizedBox(height: 16),
+                  _InfoCard(
+                    icon: Icons.error_outline,
+                    title: 'Unable to save fund',
+                    description: _errorMessageForCode(_submitError!),
+                    tone: theme.colorScheme.errorContainer,
+                  ),
+                ],
+                const SizedBox(height: 18),
+                TextFormField(
+                  key: const Key('fund-name-input'),
+                  controller: _nameController,
+                  decoration: const InputDecoration(
+                    labelText: 'Fund name',
+                    hintText: 'Scholarship Fund',
+                  ),
+                  validator: (value) {
+                    return value == null || value.trim().isEmpty
+                        ? 'Fund name is required.'
+                        : null;
+                  },
+                ),
+                const SizedBox(height: 14),
+                DropdownButtonFormField<String>(
+                  initialValue: _fundType,
+                  decoration: const InputDecoration(labelText: 'Fund type'),
+                  items: [
+                    for (final type in _fundTypes)
+                      DropdownMenuItem<String>(
+                        value: type,
+                        child: Text(_titleCase(type)),
+                      ),
+                  ],
+                  onChanged: (value) {
+                    if (value == null) {
+                      return;
+                    }
+                    setState(() {
+                      _fundType = value;
+                    });
+                  },
+                ),
+                const SizedBox(height: 14),
+                DropdownButtonFormField<String>(
+                  initialValue: _currency,
+                  decoration: const InputDecoration(labelText: 'Currency'),
+                  items: [
+                    for (final currency in _currencies)
+                      DropdownMenuItem<String>(
+                        value: currency,
+                        child: Text(currency),
+                      ),
+                  ],
+                  onChanged: (value) {
+                    if (value == null) {
+                      return;
+                    }
+                    setState(() {
+                      _currency = value;
+                    });
+                  },
+                ),
+                const SizedBox(height: 14),
+                TextFormField(
+                  key: const Key('fund-branch-id-input'),
+                  controller: _branchIdController,
+                  decoration: const InputDecoration(
+                    labelText: 'Branch id (optional)',
+                    hintText: 'branch_demo_001',
+                  ),
+                ),
+                const SizedBox(height: 14),
+                TextFormField(
+                  key: const Key('fund-description-input'),
+                  controller: _descriptionController,
+                  maxLines: 4,
+                  decoration: const InputDecoration(
+                    labelText: 'Description',
+                    hintText:
+                        'Describe who this fund supports and how it is used.',
+                  ),
+                ),
+                const SizedBox(height: 22),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: (_isSubmitting || widget.isSaving)
+                        ? null
+                        : _submit,
+                    icon: (_isSubmitting || widget.isSaving)
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.save_outlined),
+                    label: Text(
+                      (_isSubmitting || widget.isSaving)
+                          ? 'Saving...'
+                          : 'Save fund',
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TransactionEditorSheet extends StatefulWidget {
+  const _TransactionEditorSheet({
+    required this.title,
+    required this.description,
+    required this.initialDraft,
+    required this.isSaving,
+    required this.onSubmit,
+  });
+
+  final String title;
+  final String description;
+  final FundTransactionDraft initialDraft;
+  final bool isSaving;
+  final Future<FundRepositoryErrorCode?> Function(FundTransactionDraft draft)
+  onSubmit;
+
+  @override
+  State<_TransactionEditorSheet> createState() =>
+      _TransactionEditorSheetState();
+}
+
+class _TransactionEditorSheetState extends State<_TransactionEditorSheet> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _amountController;
+  late final TextEditingController _noteController;
+  late final TextEditingController _memberIdController;
+  late final TextEditingController _referenceController;
+  late DateTime _occurredAt;
+
+  FundRepositoryErrorCode? _submitError;
+  bool _isSubmitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _amountController = TextEditingController(
+      text: widget.initialDraft.amountInput,
+    );
+    _noteController = TextEditingController(text: widget.initialDraft.note);
+    _memberIdController = TextEditingController(
+      text: widget.initialDraft.memberId ?? '',
+    );
+    _referenceController = TextEditingController(
+      text: widget.initialDraft.externalReference ?? '',
+    );
+    _occurredAt = widget.initialDraft.occurredAt;
+  }
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    _noteController.dispose();
+    _memberIdController.dispose();
+    _referenceController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickOccurredDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      firstDate: DateTime(1900),
+      lastDate: DateTime(2100),
+      initialDate: _occurredAt,
+    );
+
+    if (picked == null || !mounted) {
+      return;
+    }
+
+    setState(() {
+      _occurredAt = DateTime(
+        picked.year,
+        picked.month,
+        picked.day,
+        _occurredAt.hour,
+        _occurredAt.minute,
+      );
+    });
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+
+    final error = await widget.onSubmit(
+      FundTransactionDraft(
+        fundId: widget.initialDraft.fundId,
+        transactionType: widget.initialDraft.transactionType,
+        amountInput: _amountController.text.trim(),
+        currency: widget.initialDraft.currency,
+        occurredAt: _occurredAt,
+        note: _noteController.text.trim(),
+        memberId: _nullIfBlank(_memberIdController.text),
+        externalReference: _nullIfBlank(_referenceController.text),
+      ),
+    );
+
+    if (!mounted) {
+      return;
+    }
+
+    if (error == null) {
+      Navigator.of(context).pop(true);
+      return;
+    }
+
+    setState(() {
+      _isSubmitting = false;
+      _submitError = error;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final insets = MediaQuery.viewInsetsOf(context);
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: insets.bottom),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+        ),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 28),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: Container(
+                    width: 44,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.outlineVariant,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  widget.title,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Text(widget.description, style: theme.textTheme.bodyMedium),
+                if (_submitError != null) ...[
+                  const SizedBox(height: 16),
+                  _InfoCard(
+                    icon: Icons.error_outline,
+                    title: 'Unable to save transaction',
+                    description: _errorMessageForCode(_submitError!),
+                    tone: theme.colorScheme.errorContainer,
+                  ),
+                ],
+                const SizedBox(height: 18),
+                TextFormField(
+                  key: const Key('fund-transaction-amount-input'),
+                  controller: _amountController,
+                  keyboardType: const TextInputType.numberWithOptions(
+                    decimal: true,
+                  ),
+                  decoration: InputDecoration(
+                    labelText: 'Amount',
+                    hintText: widget.initialDraft.currency == 'VND'
+                        ? '500000'
+                        : '50.00',
+                    suffixText: widget.initialDraft.currency,
+                  ),
+                  validator: (value) {
+                    return value == null || value.trim().isEmpty
+                        ? 'Amount is required.'
+                        : null;
+                  },
+                ),
+                const SizedBox(height: 14),
+                TextFormField(
+                  key: const Key('fund-transaction-note-input'),
+                  controller: _noteController,
+                  maxLines: 3,
+                  decoration: const InputDecoration(
+                    labelText: 'Note',
+                    hintText: 'Tet contribution',
+                  ),
+                ),
+                const SizedBox(height: 14),
+                TextFormField(
+                  key: const Key('fund-transaction-member-input'),
+                  controller: _memberIdController,
+                  decoration: const InputDecoration(
+                    labelText: 'Member id (optional)',
+                    hintText: 'member_demo_parent_001',
+                  ),
+                ),
+                const SizedBox(height: 14),
+                TextFormField(
+                  key: const Key('fund-transaction-reference-input'),
+                  controller: _referenceController,
+                  decoration: const InputDecoration(
+                    labelText: 'Reference (optional)',
+                    hintText: 'RECEIPT-2026-001',
+                  ),
+                ),
+                const SizedBox(height: 14),
+                InkWell(
+                  borderRadius: BorderRadius.circular(12),
+                  onTap: _pickOccurredDate,
+                  child: InputDecorator(
+                    decoration: const InputDecoration(
+                      labelText: 'Occurred date',
+                      suffixIcon: Icon(Icons.calendar_today_outlined),
+                    ),
+                    child: Text(_formatDate(_occurredAt)),
+                  ),
+                ),
+                const SizedBox(height: 22),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: (_isSubmitting || widget.isSaving)
+                        ? null
+                        : _submit,
+                    icon: (_isSubmitting || widget.isSaving)
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : Icon(
+                            widget.initialDraft.transactionType ==
+                                    FundTransactionType.donation
+                                ? Icons.add_circle_outline
+                                : Icons.remove_circle_outline,
+                          ),
+                    label: Text(
+                      (_isSubmitting || widget.isSaving)
+                          ? 'Saving...'
+                          : widget.initialDraft.transactionType ==
+                                FundTransactionType.donation
+                          ? 'Save donation'
+                          : 'Save expense',
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FundSummaryCard extends StatelessWidget {
+  const _FundSummaryCard({
+    required this.fund,
+    required this.onTap,
+    this.onEdit,
+  });
+
+  final FundProfile fund;
+  final VoidCallback onTap;
+  final VoidCallback? onEdit;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(18),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          fund.name,
+                          style: Theme.of(context).textTheme.titleMedium
+                              ?.copyWith(fontWeight: FontWeight.w800),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          _titleCase(fund.fundType),
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (onEdit != null)
+                    IconButton(
+                      tooltip: 'Edit fund',
+                      onPressed: onEdit,
+                      icon: const Icon(Icons.edit_outlined),
+                    ),
+                ],
+              ),
+              if (fund.description.trim().isNotEmpty) ...[
+                const SizedBox(height: 10),
+                Text(
+                  fund.description,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+              const SizedBox(height: 14),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
+                decoration: BoxDecoration(
+                  color: colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Row(
+                  children: [
+                    const Icon(Icons.trending_up_outlined, size: 20),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        CurrencyMinorUnits.formatMinorUnits(
+                          amountMinor: fund.balanceMinor,
+                          currency: fund.currency,
+                        ),
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(fontWeight: FontWeight.w700),
+                      ),
+                    ),
+                    const Icon(Icons.chevron_right),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TransactionRow extends StatelessWidget {
+  const _TransactionRow({required this.transaction});
+
+  final FundTransaction transaction;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isDonation =
+        transaction.transactionType == FundTransactionType.donation;
+    final tileColor = isDonation
+        ? colorScheme.primaryContainer
+        : colorScheme.tertiaryContainer;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CircleAvatar(
+              backgroundColor: tileColor,
+              child: Icon(
+                isDonation ? Icons.add : Icons.remove,
+                color: colorScheme.onSurface,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          transaction.note.trim().isEmpty
+                              ? transaction.transactionType.label
+                              : transaction.note,
+                          style: Theme.of(context).textTheme.titleSmall
+                              ?.copyWith(fontWeight: FontWeight.w700),
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Text(
+                        '${isDonation ? '+' : '-'}${CurrencyMinorUnits.formatMinorUnits(amountMinor: transaction.amountMinor, currency: transaction.currency)}',
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          color: isDonation
+                              ? colorScheme.primary
+                              : colorScheme.tertiary,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    '${transaction.transactionType.label} • ${_formatDate(transaction.occurredAt)}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  if ((transaction.externalReference ?? '')
+                      .trim()
+                      .isNotEmpty) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      'Ref: ${transaction.externalReference}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  const _SectionCard({
+    required this.title,
+    required this.child,
+    this.actionLabel,
+    this.onAction,
+  });
+
+  final String title;
+  final Widget child;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ),
+                if (actionLabel != null && onAction != null)
+                  TextButton(onPressed: onAction, child: Text(actionLabel!)),
+              ],
+            ),
+            const SizedBox(height: 12),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoCard extends StatelessWidget {
+  const _InfoCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.tone,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final Color tone;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: tone,
+      child: Padding(
+        padding: const EdgeInsets.all(18),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(description),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyWorkspace extends StatelessWidget {
+  const _EmptyWorkspace({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            Icon(icon, size: 30),
+            const SizedBox(height: 10),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+            ),
+            const SizedBox(height: 8),
+            Text(description, textAlign: TextAlign.center),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WorkspaceHero extends StatelessWidget {
+  const _WorkspaceHero({
+    required this.title,
+    required this.description,
+    required this.canManageFunds,
+    this.onPrimaryAction,
+  });
+
+  final String title;
+  final String description;
+  final bool canManageFunds;
+  final VoidCallback? onPrimaryAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [colorScheme.primary, colorScheme.primaryContainer],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(28),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              color: colorScheme.onPrimary,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            description,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: colorScheme.onPrimary.withValues(alpha: 0.9),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            children: [
+              _HeroTag(
+                label: canManageFunds ? 'Write enabled' : 'Read-only access',
+                tone: colorScheme.secondaryContainer,
+              ),
+              _HeroTag(
+                label: 'Balance + history',
+                tone: colorScheme.surfaceContainerHighest,
+              ),
+            ],
+          ),
+          if (canManageFunds && onPrimaryAction != null) ...[
+            const SizedBox(height: 18),
+            FilledButton.icon(
+              onPressed: onPrimaryAction,
+              icon: const Icon(Icons.add),
+              label: const Text('Create first fund'),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroTag extends StatelessWidget {
+  const _HeroTag({required this.label, required this.tone});
+
+  final String label;
+  final Color tone;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: tone,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        child: Text(
+          label,
+          style: Theme.of(
+            context,
+          ).textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w700),
+        ),
+      ),
+    );
+  }
+}
+
+class _StatRow extends StatelessWidget {
+  const _StatRow({required this.items});
+
+  final List<_StatTile> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    final crossAxisCount = screenWidth > 840 ? 3 : 1;
+
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: items.length,
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: crossAxisCount,
+        crossAxisSpacing: 12,
+        mainAxisSpacing: 12,
+        childAspectRatio: crossAxisCount == 1 ? 3.4 : 1.8,
+      ),
+      itemBuilder: (context, index) {
+        return items[index];
+      },
+    );
+  }
+}
+
+class _StatTile extends StatelessWidget {
+  const _StatTile({
+    required this.label,
+    required this.value,
+    required this.icon,
+  });
+
+  final String label;
+  final String value;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            CircleAvatar(
+              backgroundColor: colorScheme.primaryContainer,
+              child: Icon(icon),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(label, style: Theme.of(context).textTheme.labelLarge),
+                  const SizedBox(height: 4),
+                  Text(
+                    value,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _titleCase(String value) {
+  final clean = value.trim().replaceAll('_', ' ');
+  if (clean.isEmpty) {
+    return '';
+  }
+
+  final words = clean.split(RegExp(r'\s+'));
+  return words
+      .map((word) {
+        if (word.isEmpty) {
+          return word;
+        }
+        return '${word[0].toUpperCase()}${word.substring(1).toLowerCase()}';
+      })
+      .join(' ');
+}
+
+String _formatDate(DateTime value) {
+  final local = value.toLocal();
+  final month = local.month.toString().padLeft(2, '0');
+  final day = local.day.toString().padLeft(2, '0');
+  return '${local.year}-$month-$day';
+}
+
+String? _nullIfBlank(String? value) {
+  final trimmed = value?.trim() ?? '';
+  return trimmed.isEmpty ? null : trimmed;
+}
+
+String _errorMessageForCode(FundRepositoryErrorCode code) {
+  return switch (code) {
+    FundRepositoryErrorCode.permissionDenied =>
+      'You do not have permission for this action.',
+    FundRepositoryErrorCode.fundNotFound => 'The selected fund was not found.',
+    FundRepositoryErrorCode.invalidCurrency =>
+      'Currency is invalid. Use a 3-letter ISO code like VND or USD.',
+    FundRepositoryErrorCode.invalidAmount =>
+      'Amount is invalid. Check decimal format and value.',
+    FundRepositoryErrorCode.insufficientBalance =>
+      'Expense exceeds available balance.',
+    FundRepositoryErrorCode.validationFailed =>
+      'Submitted data did not pass validation.',
+    FundRepositoryErrorCode.writeFailed =>
+      'Unable to save changes right now. Try again.',
+  };
+}
+
+extension<T> on Iterable<T> {
+  T? get firstOrNull {
+    final iterator = this.iterator;
+    if (!iterator.moveNext()) {
+      return null;
+    }
+    return iterator.current;
+  }
+}

--- a/mobile/befam/lib/features/funds/services/currency_minor_units.dart
+++ b/mobile/befam/lib/features/funds/services/currency_minor_units.dart
@@ -1,0 +1,135 @@
+class CurrencyMinorUnits {
+  CurrencyMinorUnits._();
+
+  static const Map<String, int> _minorUnitsByCurrency = {
+    'VND': 0,
+    'JPY': 0,
+    'KRW': 0,
+    'USD': 2,
+    'EUR': 2,
+    'GBP': 2,
+    'AUD': 2,
+    'CAD': 2,
+    'SGD': 2,
+  };
+
+  static String normalizeCurrencyCode(String currency) {
+    return currency.trim().toUpperCase();
+  }
+
+  static bool isValidCurrencyCode(String currency) {
+    final normalized = normalizeCurrencyCode(currency);
+    return RegExp(r'^[A-Z]{3}$').hasMatch(normalized);
+  }
+
+  static int minorUnitsFor(String currency) {
+    final normalized = normalizeCurrencyCode(currency);
+    return _minorUnitsByCurrency[normalized] ?? 2;
+  }
+
+  static int toMinorUnits({
+    required String currency,
+    required String amountInput,
+  }) {
+    final normalizedCurrency = normalizeCurrencyCode(currency);
+    if (!isValidCurrencyCode(normalizedCurrency)) {
+      throw const FormatException('invalid_currency');
+    }
+
+    final compact = amountInput.replaceAll(',', '').replaceAll(' ', '').trim();
+    if (compact.isEmpty) {
+      throw const FormatException('amount_required');
+    }
+
+    if (!RegExp(r'^[+-]?\d+(?:\.\d+)?$').hasMatch(compact)) {
+      throw const FormatException('invalid_amount');
+    }
+
+    final sign = compact.startsWith('-') ? -1 : 1;
+    final digits = (compact.startsWith('-') || compact.startsWith('+'))
+        ? compact.substring(1)
+        : compact;
+
+    final parts = digits.split('.');
+    final wholePart = parts[0];
+    final fractionPart = parts.length > 1 ? parts[1] : '';
+    final fractionDigits = minorUnitsFor(normalizedCurrency);
+
+    if (fractionDigits == 0) {
+      if (fractionPart.isNotEmpty && int.tryParse(fractionPart) != 0) {
+        throw const FormatException('fraction_not_supported');
+      }
+
+      return sign * int.parse(wholePart);
+    }
+
+    if (fractionPart.length > fractionDigits) {
+      throw const FormatException('too_many_fraction_digits');
+    }
+
+    final paddedFraction = fractionPart.padRight(fractionDigits, '0');
+    final wholeMinor = int.parse(wholePart) * _pow10(fractionDigits);
+    final fractionMinor = int.parse(paddedFraction);
+    return sign * (wholeMinor + fractionMinor);
+  }
+
+  static String formatMinorUnits({
+    required int amountMinor,
+    required String currency,
+  }) {
+    final normalizedCurrency = normalizeCurrencyCode(currency);
+    final fractionDigits = minorUnitsFor(normalizedCurrency);
+    final negative = amountMinor < 0;
+    final absoluteMinor = amountMinor.abs();
+
+    if (fractionDigits == 0) {
+      final whole = _groupThousands(absoluteMinor.toString());
+      return '${negative ? '-' : ''}$whole $normalizedCurrency';
+    }
+
+    final divisor = _pow10(fractionDigits);
+    final wholePart = absoluteMinor ~/ divisor;
+    final fractionPart = absoluteMinor % divisor;
+
+    final wholeText = _groupThousands(wholePart.toString());
+    final fractionText = fractionPart.toString().padLeft(fractionDigits, '0');
+
+    return '${negative ? '-' : ''}$wholeText.$fractionText $normalizedCurrency';
+  }
+
+  static int _pow10(int exponent) {
+    var value = 1;
+    for (var i = 0; i < exponent; i++) {
+      value *= 10;
+    }
+    return value;
+  }
+
+  static String _groupThousands(String digits) {
+    if (digits.length <= 3) {
+      return digits;
+    }
+
+    final buffer = StringBuffer();
+    final firstGroup = digits.length % 3;
+    var offset = 0;
+
+    if (firstGroup != 0) {
+      buffer.write(digits.substring(0, firstGroup));
+      offset = firstGroup;
+      if (offset < digits.length) {
+        buffer.write(',');
+      }
+    }
+
+    while (offset < digits.length) {
+      buffer.write(digits.substring(offset, offset + 3));
+      offset += 3;
+      if (offset < digits.length) {
+        buffer.write(',');
+      }
+    }
+
+    return buffer.toString();
+  }
+}

--- a/mobile/befam/lib/features/funds/services/debug_fund_repository.dart
+++ b/mobile/befam/lib/features/funds/services/debug_fund_repository.dart
@@ -1,0 +1,218 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+
+import '../../../core/services/debug_genealogy_store.dart';
+import '../../auth/models/auth_session.dart';
+import '../models/fund_draft.dart';
+import '../models/fund_profile.dart';
+import '../models/fund_transaction.dart';
+import '../models/fund_transaction_draft.dart';
+import '../models/fund_workspace_snapshot.dart';
+import 'currency_minor_units.dart';
+import 'fund_repository.dart';
+import 'fund_transaction_validation.dart';
+
+class DebugFundRepository implements FundRepository {
+  DebugFundRepository({required DebugGenealogyStore store}) : _store = store;
+
+  factory DebugFundRepository.seeded() {
+    return DebugFundRepository(store: DebugGenealogyStore.seeded());
+  }
+
+  factory DebugFundRepository.shared() {
+    return DebugFundRepository(store: DebugGenealogyStore.sharedSeeded());
+  }
+
+  final DebugGenealogyStore _store;
+
+  @override
+  bool get isSandbox => true;
+
+  @override
+  Future<FundWorkspaceSnapshot> loadWorkspace({
+    required AuthSession session,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+
+    final clanId = session.clanId;
+    if (clanId == null || clanId.isEmpty) {
+      return const FundWorkspaceSnapshot(funds: [], transactions: []);
+    }
+
+    final funds = _store.funds.values
+        .where((fund) => fund.clanId == clanId)
+        .sortedBy((fund) => fund.name.toLowerCase())
+        .toList(growable: false);
+
+    final transactions = _store.transactions.values
+        .where((transaction) => transaction.clanId == clanId)
+        .sorted((left, right) => right.occurredAt.compareTo(left.occurredAt))
+        .toList(growable: false);
+
+    return FundWorkspaceSnapshot(funds: funds, transactions: transactions);
+  }
+
+  @override
+  Future<FundProfile> saveFund({
+    required AuthSession session,
+    String? fundId,
+    required FundDraft draft,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 140));
+
+    final clanId = session.clanId;
+    if (clanId == null || clanId.isEmpty) {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.permissionDenied,
+      );
+    }
+
+    final normalizedCurrency = CurrencyMinorUnits.normalizeCurrencyCode(
+      draft.currency,
+    );
+    if (!CurrencyMinorUnits.isValidCurrencyCode(normalizedCurrency)) {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.invalidCurrency,
+      );
+    }
+
+    final trimmedName = draft.name.trim();
+    if (trimmedName.isEmpty) {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.validationFailed,
+      );
+    }
+
+    final resolvedFundId = fundId ?? 'fund_demo_${_store.fundSequence++}';
+    final existing = _store.funds[resolvedFundId];
+    final payload = FundProfile(
+      id: resolvedFundId,
+      clanId: clanId,
+      branchId: _nullableTrim(draft.branchId),
+      name: trimmedName,
+      description: draft.description.trim(),
+      fundType: draft.fundType.trim().isEmpty
+          ? 'custom'
+          : draft.fundType.trim().toLowerCase(),
+      currency: normalizedCurrency,
+      balanceMinor: existing?.balanceMinor ?? 0,
+      status: existing?.status ?? 'active',
+    );
+
+    _store.funds[resolvedFundId] = payload;
+    return payload;
+  }
+
+  @override
+  Future<FundTransaction> recordTransaction({
+    required AuthSession session,
+    required FundTransactionDraft draft,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 160));
+
+    final clanId = session.clanId;
+    if (clanId == null || clanId.isEmpty) {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.permissionDenied,
+      );
+    }
+
+    final fund = _store.funds[draft.fundId];
+    if (fund == null || fund.clanId != clanId) {
+      throw const FundRepositoryException(FundRepositoryErrorCode.fundNotFound);
+    }
+
+    final normalizedCurrency = CurrencyMinorUnits.normalizeCurrencyCode(
+      draft.currency,
+    );
+    if (!CurrencyMinorUnits.isValidCurrencyCode(normalizedCurrency)) {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.invalidCurrency,
+      );
+    }
+
+    final amountMinor = _parseAmountMinor(
+      currency: normalizedCurrency,
+      amountInput: draft.amountInput,
+    );
+
+    try {
+      validateFundTransactionInput(
+        fundId: draft.fundId,
+        transactionType: draft.transactionType,
+        amountMinor: amountMinor,
+        currentBalanceMinor: fund.balanceMinor,
+        currency: normalizedCurrency,
+        occurredAt: draft.occurredAt,
+        note: draft.note,
+      );
+    } on FundTransactionValidationException catch (error) {
+      throw _mapValidationError(error);
+    }
+
+    final transactionId = 'txn_demo_${_store.transactionSequence++}';
+    final created = FundTransaction(
+      id: transactionId,
+      fundId: fund.id,
+      clanId: clanId,
+      branchId: fund.branchId,
+      transactionType: draft.transactionType,
+      amountMinor: amountMinor,
+      currency: normalizedCurrency,
+      memberId: _nullableTrim(draft.memberId) ?? session.memberId,
+      externalReference: _nullableTrim(draft.externalReference),
+      occurredAt: draft.occurredAt.toUtc(),
+      note: draft.note.trim(),
+      receiptUrl: _nullableTrim(draft.receiptUrl),
+      createdAt: DateTime.now().toUtc(),
+      createdBy: session.memberId ?? session.uid,
+    );
+
+    _store.transactions[transactionId] = created;
+    _store.funds[fund.id] = fund.copyWith(
+      balanceMinor: fund.balanceMinor + created.signedAmountMinor,
+    );
+
+    return created;
+  }
+
+  int _parseAmountMinor({
+    required String currency,
+    required String amountInput,
+  }) {
+    try {
+      return CurrencyMinorUnits.toMinorUnits(
+        currency: currency,
+        amountInput: amountInput,
+      );
+    } on FormatException {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.invalidAmount,
+      );
+    }
+  }
+
+  FundRepositoryException _mapValidationError(
+    FundTransactionValidationException error,
+  ) {
+    return switch (error.code) {
+      FundTransactionValidationErrorCode.insufficientBalance =>
+        const FundRepositoryException(
+          FundRepositoryErrorCode.insufficientBalance,
+        ),
+      FundTransactionValidationErrorCode.unsupportedCurrency =>
+        const FundRepositoryException(FundRepositoryErrorCode.invalidCurrency),
+      FundTransactionValidationErrorCode.amountNotPositive =>
+        const FundRepositoryException(FundRepositoryErrorCode.invalidAmount),
+      _ => const FundRepositoryException(
+        FundRepositoryErrorCode.validationFailed,
+      ),
+    };
+  }
+}
+
+String? _nullableTrim(String? value) {
+  final trimmed = value?.trim() ?? '';
+  return trimmed.isEmpty ? null : trimmed;
+}

--- a/mobile/befam/lib/features/funds/services/firebase_fund_repository.dart
+++ b/mobile/befam/lib/features/funds/services/firebase_fund_repository.dart
@@ -1,0 +1,331 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:collection/collection.dart';
+
+import '../../../core/services/firebase_services.dart';
+import '../../../core/services/firebase_session_access_sync.dart';
+import '../../auth/models/auth_session.dart';
+import '../models/fund_draft.dart';
+import '../models/fund_profile.dart';
+import '../models/fund_transaction.dart';
+import '../models/fund_transaction_draft.dart';
+import '../models/fund_workspace_snapshot.dart';
+import 'currency_minor_units.dart';
+import 'fund_repository.dart';
+import 'fund_transaction_validation.dart';
+
+class FirebaseFundRepository implements FundRepository {
+  FirebaseFundRepository({FirebaseFirestore? firestore})
+    : _firestore = firestore ?? FirebaseServices.firestore;
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> get _funds =>
+      _firestore.collection('funds');
+
+  CollectionReference<Map<String, dynamic>> get _transactions =>
+      _firestore.collection('transactions');
+
+  @override
+  bool get isSandbox => false;
+
+  @override
+  Future<FundWorkspaceSnapshot> loadWorkspace({
+    required AuthSession session,
+  }) async {
+    await FirebaseSessionAccessSync.ensureUserSessionDocument(
+      firestore: _firestore,
+      session: session,
+    );
+
+    final clanId = session.clanId;
+    if (clanId == null || clanId.isEmpty) {
+      return const FundWorkspaceSnapshot(funds: [], transactions: []);
+    }
+
+    final results = await Future.wait<QuerySnapshot<Map<String, dynamic>>>([
+      _funds.where('clanId', isEqualTo: clanId).get(),
+      _transactions
+          .where('clanId', isEqualTo: clanId)
+          .orderBy('occurredAt', descending: true)
+          .limit(400)
+          .get(),
+    ]);
+
+    final funds = results[0].docs
+        .map(
+          (doc) => FundProfile.fromJson(
+            _normalizeFirestoreMap(doc.data(), fallbackId: doc.id),
+          ),
+        )
+        .sortedBy((fund) => fund.name.toLowerCase())
+        .toList(growable: false);
+
+    final transactions = results[1].docs
+        .map(
+          (doc) => FundTransaction.fromJson(
+            _normalizeFirestoreMap(doc.data(), fallbackId: doc.id),
+          ),
+        )
+        .sorted((left, right) => right.occurredAt.compareTo(left.occurredAt))
+        .toList(growable: false);
+
+    return FundWorkspaceSnapshot(funds: funds, transactions: transactions);
+  }
+
+  @override
+  Future<FundProfile> saveFund({
+    required AuthSession session,
+    String? fundId,
+    required FundDraft draft,
+  }) async {
+    await FirebaseSessionAccessSync.ensureUserSessionDocument(
+      firestore: _firestore,
+      session: session,
+    );
+
+    final clanId = session.clanId;
+    if (clanId == null || clanId.isEmpty) {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.permissionDenied,
+      );
+    }
+
+    final normalizedCurrency = CurrencyMinorUnits.normalizeCurrencyCode(
+      draft.currency,
+    );
+    if (!CurrencyMinorUnits.isValidCurrencyCode(normalizedCurrency)) {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.invalidCurrency,
+      );
+    }
+
+    final trimmedName = draft.name.trim();
+    if (trimmedName.isEmpty) {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.validationFailed,
+      );
+    }
+
+    try {
+      final docRef = fundId == null ? _funds.doc() : _funds.doc(fundId);
+      final existing = await docRef.get();
+
+      await docRef.set({
+        'id': docRef.id,
+        'clanId': clanId,
+        'branchId': _nullableTrim(draft.branchId),
+        'name': trimmedName,
+        'description': draft.description.trim(),
+        'fundType': draft.fundType.trim().isEmpty
+            ? 'custom'
+            : draft.fundType.trim().toLowerCase(),
+        'currency': normalizedCurrency,
+        'balanceMinor': _coerceInt(existing.data()?['balanceMinor']),
+        'status': existing.data()?['status'] as String? ?? 'active',
+        'updatedAt': FieldValue.serverTimestamp(),
+        'updatedBy': session.memberId ?? session.uid,
+        if (!existing.exists) 'createdAt': FieldValue.serverTimestamp(),
+        if (!existing.exists) 'createdBy': session.memberId ?? session.uid,
+      }, SetOptions(merge: true));
+
+      final refreshed = await docRef.get();
+      final payload = _normalizeFirestoreMap(
+        refreshed.data() ?? {},
+        fallbackId: docRef.id,
+      );
+      return FundProfile.fromJson(payload);
+    } on FirebaseException catch (error) {
+      throw _mapFirebaseError(error);
+    }
+  }
+
+  @override
+  Future<FundTransaction> recordTransaction({
+    required AuthSession session,
+    required FundTransactionDraft draft,
+  }) async {
+    await FirebaseSessionAccessSync.ensureUserSessionDocument(
+      firestore: _firestore,
+      session: session,
+    );
+
+    final clanId = session.clanId;
+    if (clanId == null || clanId.isEmpty) {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.permissionDenied,
+      );
+    }
+
+    final normalizedCurrency = CurrencyMinorUnits.normalizeCurrencyCode(
+      draft.currency,
+    );
+    if (!CurrencyMinorUnits.isValidCurrencyCode(normalizedCurrency)) {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.invalidCurrency,
+      );
+    }
+
+    final amountMinor = _parseAmountMinor(
+      currency: normalizedCurrency,
+      amountInput: draft.amountInput,
+    );
+
+    try {
+      return await _firestore.runTransaction((tx) async {
+        final fundRef = _funds.doc(draft.fundId);
+        final fundSnapshot = await tx.get(fundRef);
+
+        if (!fundSnapshot.exists || fundSnapshot.data() == null) {
+          throw const FundRepositoryException(
+            FundRepositoryErrorCode.fundNotFound,
+          );
+        }
+
+        final fund = FundProfile.fromJson(
+          _normalizeFirestoreMap(fundSnapshot.data()!, fallbackId: fundRef.id),
+        );
+        if (fund.clanId != clanId) {
+          throw const FundRepositoryException(
+            FundRepositoryErrorCode.permissionDenied,
+          );
+        }
+
+        try {
+          validateFundTransactionInput(
+            fundId: draft.fundId,
+            transactionType: draft.transactionType,
+            amountMinor: amountMinor,
+            currentBalanceMinor: fund.balanceMinor,
+            currency: normalizedCurrency,
+            occurredAt: draft.occurredAt,
+            note: draft.note,
+          );
+        } on FundTransactionValidationException catch (error) {
+          throw _mapValidationError(error);
+        }
+
+        final transactionRef = _transactions.doc();
+        final createdAt = DateTime.now().toUtc();
+        final created = FundTransaction(
+          id: transactionRef.id,
+          fundId: fund.id,
+          clanId: clanId,
+          branchId: fund.branchId,
+          transactionType: draft.transactionType,
+          amountMinor: amountMinor,
+          currency: normalizedCurrency,
+          memberId: _nullableTrim(draft.memberId) ?? session.memberId,
+          externalReference: _nullableTrim(draft.externalReference),
+          occurredAt: draft.occurredAt.toUtc(),
+          note: draft.note.trim(),
+          receiptUrl: _nullableTrim(draft.receiptUrl),
+          createdAt: createdAt,
+          createdBy: session.memberId ?? session.uid,
+        );
+
+        tx.set(transactionRef, {
+          ...created.toJson(),
+          'occurredAt': Timestamp.fromDate(created.occurredAt),
+          'createdAt': FieldValue.serverTimestamp(),
+        });
+        tx.set(fundRef, {
+          'balanceMinor': fund.balanceMinor + created.signedAmountMinor,
+          'updatedAt': FieldValue.serverTimestamp(),
+          'updatedBy': session.memberId ?? session.uid,
+        }, SetOptions(merge: true));
+
+        return created;
+      });
+    } on FirebaseException catch (error) {
+      throw _mapFirebaseError(error);
+    }
+  }
+
+  int _parseAmountMinor({
+    required String currency,
+    required String amountInput,
+  }) {
+    try {
+      return CurrencyMinorUnits.toMinorUnits(
+        currency: currency,
+        amountInput: amountInput,
+      );
+    } on FormatException {
+      throw const FundRepositoryException(
+        FundRepositoryErrorCode.invalidAmount,
+      );
+    }
+  }
+
+  FundRepositoryException _mapValidationError(
+    FundTransactionValidationException error,
+  ) {
+    return switch (error.code) {
+      FundTransactionValidationErrorCode.insufficientBalance =>
+        const FundRepositoryException(
+          FundRepositoryErrorCode.insufficientBalance,
+        ),
+      FundTransactionValidationErrorCode.unsupportedCurrency =>
+        const FundRepositoryException(FundRepositoryErrorCode.invalidCurrency),
+      FundTransactionValidationErrorCode.amountNotPositive =>
+        const FundRepositoryException(FundRepositoryErrorCode.invalidAmount),
+      _ => const FundRepositoryException(
+        FundRepositoryErrorCode.validationFailed,
+      ),
+    };
+  }
+
+  FundRepositoryException _mapFirebaseError(FirebaseException error) {
+    if (error.code == 'permission-denied') {
+      return FundRepositoryException(
+        FundRepositoryErrorCode.permissionDenied,
+        error.message,
+      );
+    }
+
+    return FundRepositoryException(
+      FundRepositoryErrorCode.writeFailed,
+      error.message,
+    );
+  }
+}
+
+Map<String, dynamic> _normalizeFirestoreMap(
+  Map<String, dynamic> source, {
+  required String fallbackId,
+}) {
+  final data = <String, dynamic>{'id': fallbackId};
+
+  for (final entry in source.entries) {
+    final value = entry.value;
+    if (value is Timestamp) {
+      data[entry.key] = value.toDate().toUtc().toIso8601String();
+    } else {
+      data[entry.key] = value;
+    }
+  }
+
+  data['id'] = (data['id'] as String?)?.trim().isNotEmpty == true
+      ? data['id']
+      : fallbackId;
+
+  return data;
+}
+
+String? _nullableTrim(String? value) {
+  final trimmed = value?.trim() ?? '';
+  return trimmed.isEmpty ? null : trimmed;
+}
+
+int _coerceInt(Object? value) {
+  if (value is int) {
+    return value;
+  }
+  if (value is double) {
+    return value.round();
+  }
+  if (value is String) {
+    return int.tryParse(value) ?? 0;
+  }
+  return 0;
+}

--- a/mobile/befam/lib/features/funds/services/fund_repository.dart
+++ b/mobile/befam/lib/features/funds/services/fund_repository.dart
@@ -1,0 +1,54 @@
+import '../../../core/services/runtime_mode.dart';
+import '../../auth/models/auth_session.dart';
+import '../models/fund_draft.dart';
+import '../models/fund_profile.dart';
+import '../models/fund_transaction.dart';
+import '../models/fund_transaction_draft.dart';
+import '../models/fund_workspace_snapshot.dart';
+import 'debug_fund_repository.dart';
+import 'firebase_fund_repository.dart';
+
+enum FundRepositoryErrorCode {
+  permissionDenied,
+  fundNotFound,
+  invalidCurrency,
+  invalidAmount,
+  insufficientBalance,
+  validationFailed,
+  writeFailed,
+}
+
+class FundRepositoryException implements Exception {
+  const FundRepositoryException(this.code, [this.message]);
+
+  final FundRepositoryErrorCode code;
+  final String? message;
+
+  @override
+  String toString() => message ?? code.name;
+}
+
+abstract interface class FundRepository {
+  bool get isSandbox;
+
+  Future<FundWorkspaceSnapshot> loadWorkspace({required AuthSession session});
+
+  Future<FundProfile> saveFund({
+    required AuthSession session,
+    String? fundId,
+    required FundDraft draft,
+  });
+
+  Future<FundTransaction> recordTransaction({
+    required AuthSession session,
+    required FundTransactionDraft draft,
+  });
+}
+
+FundRepository createDefaultFundRepository() {
+  if (RuntimeMode.shouldUseMockBackend) {
+    return DebugFundRepository.shared();
+  }
+
+  return FirebaseFundRepository();
+}

--- a/mobile/befam/lib/features/funds/services/fund_transaction_validation.dart
+++ b/mobile/befam/lib/features/funds/services/fund_transaction_validation.dart
@@ -1,0 +1,71 @@
+import '../models/fund_transaction.dart';
+import 'currency_minor_units.dart';
+
+enum FundTransactionValidationErrorCode {
+  fundRequired,
+  unsupportedCurrency,
+  amountNotPositive,
+  insufficientBalance,
+  occurredAtInFuture,
+  noteTooLong,
+}
+
+class FundTransactionValidationException implements Exception {
+  const FundTransactionValidationException(this.code, [this.message]);
+
+  final FundTransactionValidationErrorCode code;
+  final String? message;
+
+  @override
+  String toString() => message ?? code.name;
+}
+
+void validateFundTransactionInput({
+  required String fundId,
+  required FundTransactionType transactionType,
+  required int amountMinor,
+  required int currentBalanceMinor,
+  required String currency,
+  required DateTime occurredAt,
+  String? note,
+  DateTime? now,
+}) {
+  if (fundId.trim().isEmpty) {
+    throw const FundTransactionValidationException(
+      FundTransactionValidationErrorCode.fundRequired,
+    );
+  }
+
+  final normalizedCurrency = CurrencyMinorUnits.normalizeCurrencyCode(currency);
+  if (!CurrencyMinorUnits.isValidCurrencyCode(normalizedCurrency)) {
+    throw const FundTransactionValidationException(
+      FundTransactionValidationErrorCode.unsupportedCurrency,
+    );
+  }
+
+  if (amountMinor <= 0) {
+    throw const FundTransactionValidationException(
+      FundTransactionValidationErrorCode.amountNotPositive,
+    );
+  }
+
+  if (transactionType == FundTransactionType.expense &&
+      amountMinor > currentBalanceMinor) {
+    throw const FundTransactionValidationException(
+      FundTransactionValidationErrorCode.insufficientBalance,
+    );
+  }
+
+  final currentTime = now?.toUtc() ?? DateTime.now().toUtc();
+  if (occurredAt.toUtc().isAfter(currentTime.add(const Duration(minutes: 5)))) {
+    throw const FundTransactionValidationException(
+      FundTransactionValidationErrorCode.occurredAtInFuture,
+    );
+  }
+
+  if ((note ?? '').trim().length > 280) {
+    throw const FundTransactionValidationException(
+      FundTransactionValidationErrorCode.noteTooLong,
+    );
+  }
+}

--- a/mobile/befam/test/features/funds/currency_minor_units_test.dart
+++ b/mobile/befam/test/features/funds/currency_minor_units_test.dart
@@ -1,0 +1,34 @@
+import 'package:befam/features/funds/services/currency_minor_units.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('returns expected minor units for VND and USD', () {
+    expect(CurrencyMinorUnits.minorUnitsFor('VND'), 0);
+    expect(CurrencyMinorUnits.minorUnitsFor('USD'), 2);
+  });
+
+  test('converts amount input to minor units', () {
+    expect(
+      CurrencyMinorUnits.toMinorUnits(currency: 'VND', amountInput: '500000'),
+      500000,
+    );
+    expect(
+      CurrencyMinorUnits.toMinorUnits(currency: 'USD', amountInput: '12.34'),
+      1234,
+    );
+  });
+
+  test('formats minor units to currency text', () {
+    expect(
+      CurrencyMinorUnits.formatMinorUnits(
+        amountMinor: 2500000,
+        currency: 'VND',
+      ),
+      '2,500,000 VND',
+    );
+    expect(
+      CurrencyMinorUnits.formatMinorUnits(amountMinor: -1535, currency: 'USD'),
+      '-15.35 USD',
+    );
+  });
+}

--- a/mobile/befam/test/features/funds/fund_repository_test.dart
+++ b/mobile/befam/test/features/funds/fund_repository_test.dart
@@ -1,0 +1,120 @@
+import 'package:befam/features/auth/models/auth_entry_method.dart';
+import 'package:befam/features/auth/models/auth_member_access_mode.dart';
+import 'package:befam/features/auth/models/auth_session.dart';
+import 'package:befam/features/funds/models/fund_draft.dart';
+import 'package:befam/features/funds/models/fund_transaction.dart';
+import 'package:befam/features/funds/models/fund_transaction_draft.dart';
+import 'package:befam/features/funds/services/debug_fund_repository.dart';
+import 'package:befam/features/funds/services/fund_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  AuthSession buildClanAdminSession() {
+    return AuthSession(
+      uid: 'debug:+84901234567',
+      loginMethod: AuthEntryMethod.phone,
+      phoneE164: '+84901234567',
+      displayName: 'Nguyen Minh',
+      memberId: 'member_demo_parent_001',
+      clanId: 'clan_demo_001',
+      branchId: 'branch_demo_001',
+      primaryRole: 'CLAN_ADMIN',
+      accessMode: AuthMemberAccessMode.claimed,
+      linkedAuthUid: true,
+      isSandbox: true,
+      signedInAtIso: DateTime(2026, 3, 14).toIso8601String(),
+    );
+  }
+
+  test('loads seeded funds and transactions', () async {
+    final repository = DebugFundRepository.seeded();
+    final session = buildClanAdminSession();
+
+    final snapshot = await repository.loadWorkspace(session: session);
+
+    expect(snapshot.funds, hasLength(2));
+    expect(snapshot.transactions, hasLength(4));
+
+    final scholarship = snapshot.funds.firstWhere(
+      (fund) => fund.id == 'fund_demo_scholarship',
+    );
+    expect(scholarship.balanceMinor, 2500000);
+  });
+
+  test('creates a new fund with zero starting balance', () async {
+    final repository = DebugFundRepository.seeded();
+    final session = buildClanAdminSession();
+
+    final created = await repository.saveFund(
+      session: session,
+      draft: const FundDraft(
+        name: 'Temple Maintenance',
+        description: 'Keeps yearly maintenance transparent.',
+        fundType: 'maintenance',
+        currency: 'VND',
+      ),
+    );
+
+    expect(created.name, 'Temple Maintenance');
+    expect(created.balanceMinor, 0);
+
+    final snapshot = await repository.loadWorkspace(session: session);
+    expect(snapshot.funds.any((fund) => fund.id == created.id), isTrue);
+  });
+
+  test('records donation and updates running balance', () async {
+    final repository = DebugFundRepository.seeded();
+    final session = buildClanAdminSession();
+
+    final before = await repository.loadWorkspace(session: session);
+    final fund = before.funds.firstWhere(
+      (candidate) => candidate.id == 'fund_demo_operations',
+    );
+
+    final donation = await repository.recordTransaction(
+      session: session,
+      draft: FundTransactionDraft(
+        fundId: fund.id,
+        transactionType: FundTransactionType.donation,
+        amountInput: '500000',
+        currency: fund.currency,
+        occurredAt: DateTime.utc(2026, 3, 13, 2, 0),
+        note: 'Quarterly contribution',
+      ),
+    );
+
+    expect(donation.amountMinor, 500000);
+
+    final after = await repository.loadWorkspace(session: session);
+    final updatedFund = after.funds.firstWhere(
+      (candidate) => candidate.id == fund.id,
+    );
+    expect(updatedFund.balanceMinor, fund.balanceMinor + 500000);
+  });
+
+  test('rejects expense that exceeds balance', () async {
+    final repository = DebugFundRepository.seeded();
+    final session = buildClanAdminSession();
+
+    expect(
+      () => repository.recordTransaction(
+        session: session,
+        draft: FundTransactionDraft(
+          fundId: 'fund_demo_operations',
+          transactionType: FundTransactionType.expense,
+          amountInput: '999999999',
+          currency: 'VND',
+          occurredAt: DateTime.utc(2026, 3, 13, 4, 0),
+          note: 'Invalid overdraw',
+        ),
+      ),
+      throwsA(
+        isA<FundRepositoryException>().having(
+          (error) => error.code,
+          'code',
+          FundRepositoryErrorCode.insufficientBalance,
+        ),
+      ),
+    );
+  });
+}

--- a/mobile/befam/test/features/funds/fund_transaction_validation_test.dart
+++ b/mobile/befam/test/features/funds/fund_transaction_validation_test.dart
@@ -1,0 +1,68 @@
+import 'package:befam/features/funds/models/fund_transaction.dart';
+import 'package:befam/features/funds/services/fund_transaction_validation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('rejects non-positive amounts', () {
+    expect(
+      () => validateFundTransactionInput(
+        fundId: 'fund_demo_001',
+        transactionType: FundTransactionType.donation,
+        amountMinor: 0,
+        currentBalanceMinor: 500000,
+        currency: 'VND',
+        occurredAt: DateTime.utc(2026, 3, 14),
+        now: DateTime.utc(2026, 3, 14, 0, 30),
+      ),
+      throwsA(
+        isA<FundTransactionValidationException>().having(
+          (error) => error.code,
+          'code',
+          FundTransactionValidationErrorCode.amountNotPositive,
+        ),
+      ),
+    );
+  });
+
+  test('rejects expense over current balance', () {
+    expect(
+      () => validateFundTransactionInput(
+        fundId: 'fund_demo_001',
+        transactionType: FundTransactionType.expense,
+        amountMinor: 900000,
+        currentBalanceMinor: 100000,
+        currency: 'VND',
+        occurredAt: DateTime.utc(2026, 3, 14),
+        now: DateTime.utc(2026, 3, 14, 0, 30),
+      ),
+      throwsA(
+        isA<FundTransactionValidationException>().having(
+          (error) => error.code,
+          'code',
+          FundTransactionValidationErrorCode.insufficientBalance,
+        ),
+      ),
+    );
+  });
+
+  test('rejects transactions in the future', () {
+    expect(
+      () => validateFundTransactionInput(
+        fundId: 'fund_demo_001',
+        transactionType: FundTransactionType.donation,
+        amountMinor: 100000,
+        currentBalanceMinor: 100000,
+        currency: 'VND',
+        occurredAt: DateTime.utc(2026, 3, 15, 1, 0),
+        now: DateTime.utc(2026, 3, 14, 1, 0),
+      ),
+      throwsA(
+        isA<FundTransactionValidationException>().having(
+          (error) => error.code,
+          'code',
+          FundTransactionValidationErrorCode.occurredAtInFuture,
+        ),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- implement the new Funds feature module under `mobile/befam/lib/features/funds`
- deliver fund list and detail screens, create fund flow, donation/expense forms, transaction filtering, and running balance UI
- add currency/minor-unit utility and transaction validation rules
- add debug + firebase fund repositories and controller wiring
- wire the home shortcut (`/funds`) to open the Funds workspace
- seed debug store with sample funds/transactions and running-balance reconciliation
- add funds test suite for repository behavior, validation, and currency utilities

## Story coverage
- [FUND-001] Fund list screen
- [FUND-002] Fund detail screen
- [FUND-003] Create fund form
- [FUND-004] Donation create form
- [FUND-005] Expense create form
- [FUND-006] Transaction list with filters
- [FUND-007] Running balance display
- [FUND-008] Transaction validation rules
- [FUND-009] Fund repository tests
- [FUND-010] Currency and minor units utility

## Testing
- `flutter test test/features/funds`
- `flutter analyze lib/features/funds lib/app/home/app_shell_page.dart lib/core/services/debug_genealogy_store.dart`

Refs #11
Closes #114
Closes #115
Closes #116
Closes #117
Closes #118
Closes #119
Closes #120
Closes #121
Closes #122
Closes #123
