### PR TITLE
feat(auth): local bypass for phone and OTP in debug

### DIFF
--- a/mobile/befam/lib/core/services/runtime_mode.dart
+++ b/mobile/befam/lib/core/services/runtime_mode.dart
@@ -11,10 +11,28 @@ class RuntimeMode {
   static const bool forceMockBackend = bool.fromEnvironment(
     'BEFAM_USE_MOCK_AUTH',
   );
+  static const String localAuthBypass = String.fromEnvironment(
+    'BEFAM_LOCAL_AUTH_BYPASS',
+    defaultValue: 'auto',
+  );
   static const bool forceTestMode = bool.fromEnvironment('FLUTTER_TEST');
 
   static bool get shouldUseMockBackend {
-    return forceTestMode || _isWidgetTestBinding() || _isDebugMockOverride;
+    return forceTestMode ||
+        _isWidgetTestBinding() ||
+        shouldBypassPhoneOtp ||
+        _isDebugMockOverride;
+  }
+
+  static bool get shouldBypassPhoneOtp {
+    final mode = localAuthBypass.toLowerCase().trim();
+    if (mode == 'on' || mode == 'true' || mode == '1') {
+      return true;
+    }
+    if (mode == 'off' || mode == 'false' || mode == '0') {
+      return false;
+    }
+    return kDebugMode;
   }
 
   static bool get _isDebugMockOverride {

--- a/mobile/befam/lib/features/auth/presentation/auth_controller.dart
+++ b/mobile/befam/lib/features/auth/presentation/auth_controller.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import '../../../core/services/app_logger.dart';
+import '../../../core/services/runtime_mode.dart';
 import '../models/auth_entry_method.dart';
 import '../models/auth_issue.dart';
 import '../models/auth_otp_request_result.dart';
@@ -20,6 +21,11 @@ enum AuthStep { loginMethodSelection, phoneNumber, childIdentifier, otp }
 typedef AuthOtpAction = Future<AuthOtpRequestResult> Function();
 
 class AuthController extends ChangeNotifier {
+  static const String _localBypassPhoneE164 = String.fromEnvironment(
+    'BEFAM_LOCAL_BYPASS_PHONE',
+    defaultValue: '+84901234567',
+  );
+
   AuthController({
     required AuthGateway authGateway,
     required AuthAnalyticsService analyticsService,
@@ -45,6 +51,7 @@ class AuthController extends ChangeNotifier {
   bool _disposed = false;
 
   bool get isSandbox => _authGateway.isSandbox;
+  bool get canUseLocalBypass => RuntimeMode.shouldBypassPhoneOtp;
 
   Future<void> initialize() async {
     if (_initialized) {
@@ -132,6 +139,39 @@ class AuthController extends ChangeNotifier {
       () => _authGateway.requestPhoneOtp(parsedPhone.e164),
       method: AuthEntryMethod.phone,
     );
+  }
+
+  Future<void> signInWithLocalBypass() async {
+    if (!canUseLocalBypass || isBusy) {
+      return;
+    }
+
+    _clearError();
+    unawaited(
+      _analyticsService.logLoginMethodSelected(
+        AuthEntryMethod.phone,
+        isSandbox: isSandbox,
+      ),
+    );
+
+    await _startOtpRequest(
+      () => _authGateway.requestPhoneOtp(_localBypassPhoneE164),
+      method: AuthEntryMethod.phone,
+    );
+
+    final challenge = pendingChallenge;
+    if (session != null || challenge == null) {
+      return;
+    }
+
+    final otpHint = challenge.debugOtpHint;
+    if (otpHint == null || !RegExp(r'^\d{6}$').hasMatch(otpHint)) {
+      error = const AuthIssue(AuthIssueKey.preparationFailed);
+      _emit();
+      return;
+    }
+
+    await verifyOtp(otpHint);
   }
 
   Future<void> submitChildIdentifier(String rawChildIdentifier) async {

--- a/mobile/befam/lib/features/auth/presentation/auth_experience.dart
+++ b/mobile/befam/lib/features/auth/presentation/auth_experience.dart
@@ -127,12 +127,15 @@ class _AuthScaffold extends StatelessWidget {
               ],
               switch (controller.step) {
                 AuthStep.loginMethodSelection => _LoginMethodSelectionCard(
+                  isBusy: controller.isBusy,
+                  showLocalBypass: controller.canUseLocalBypass,
                   onPhoneSelected: () {
                     controller.selectLoginMethod(AuthEntryMethod.phone);
                   },
                   onChildSelected: () {
                     controller.selectLoginMethod(AuthEntryMethod.child);
                   },
+                  onLocalBypassSelected: controller.signInWithLocalBypass,
                 ),
                 AuthStep.phoneNumber => _PhoneLoginCard(
                   isBusy: controller.isBusy,
@@ -299,12 +302,18 @@ class _AuthMessageCard extends StatelessWidget {
 
 class _LoginMethodSelectionCard extends StatelessWidget {
   const _LoginMethodSelectionCard({
+    required this.isBusy,
+    required this.showLocalBypass,
     required this.onPhoneSelected,
     required this.onChildSelected,
+    required this.onLocalBypassSelected,
   });
 
+  final bool isBusy;
+  final bool showLocalBypass;
   final VoidCallback onPhoneSelected;
   final VoidCallback onChildSelected;
+  final Future<void> Function() onLocalBypassSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -313,6 +322,20 @@ class _LoginMethodSelectionCard extends StatelessWidget {
     return Column(
       children: [
         const _QuickBenefitsCard(),
+        if (showLocalBypass) ...[
+          const SizedBox(height: 16),
+          _MethodCard(
+            title: l10n.authSandboxChip,
+            description: l10n.authPhoneHelperSandbox,
+            icon: Icons.bolt_rounded,
+            buttonLabel: l10n.authContinueNow,
+            onPressed: isBusy
+                ? null
+                : () {
+                    unawaited(onLocalBypassSelected());
+                  },
+          ),
+        ],
         const SizedBox(height: 16),
         _MethodCard(
           title: l10n.authMethodPhoneTitle,
@@ -347,7 +370,7 @@ class _MethodCard extends StatelessWidget {
   final String description;
   final IconData icon;
   final String buttonLabel;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- add `BEFAM_LOCAL_AUTH_BYPASS` runtime flag with `auto|on|off` support
- enable local bypass mode by default in debug builds (`auto`) so phone + OTP can be skipped during local testing
- add one-tap auth entry on the login method screen to sign in via local bypass flow
- keep bypass configurable with `BEFAM_LOCAL_AUTH_BYPASS=off` when we want to return to normal auth

## Validation
- flutter analyze
- flutter test test/widget_test.dart
