### PR TITLE
fix(functions): initialize admin app before firestore access

### DIFF
--- a/firebase/functions/src/shared/firestore.ts
+++ b/firebase/functions/src/shared/firestore.ts
@@ -1,3 +1,6 @@
+import { getApps, initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
-export const db = getFirestore();
+const app = getApps()[0] ?? initializeApp();
+
+export const db = getFirestore(app);


### PR DESCRIPTION
Summary:\n- ensure Firebase Admin app is initialized before creating shared Firestore client\n- prevent deploy-time analysis crash in Cloud Functions\n\nRoot cause:\n- shared firestore client was created at module load using getFirestore() before initializeApp() executed in index.ts\n- during deploy analysis this produced app/no-app\n\nValidation:\n- npm --prefix firebase/functions run build\n