### PR TITLE
fix(functions): initialize admin app before firestore access

### DIFF
--- a/firebase/functions/src/shared/firestore.ts
+++ b/firebase/functions/src/shared/firestore.ts
@@ -1,3 +1,6 @@
+import { getApps, initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
-export const db = getFirestore();
+const app = getApps()[0] ?? initializeApp();
+
+export const db = getFirestore(app);


### PR DESCRIPTION
Hotfix to ensure Firebase Admin app initialization happens before shared Firestore client creation during Functions deploy analysis.