### PR TITLE
test(security): SEC-006 unit tests and SEC-007 rules docs validation

### DIFF
--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install docs dependencies
         run: pip install -r requirements-docs.txt
 
+      - name: Validate rules documentation
+        run: python3 scripts/validate_rules_documentation.py
+
       - name: Build docs
         run: mkdocs build --strict
 

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -4,8 +4,11 @@ on:
   pull_request:
     paths:
       - "docs/**"
+      - "firebase/firestore.rules"
+      - "firebase/storage.rules"
       - "mkdocs.yml"
       - "requirements-docs.txt"
+      - "scripts/validate_rules_documentation.py"
       - ".github/workflows/docs-ci.yml"
       - ".github/workflows/deploy-docs.yml"
   push:
@@ -13,8 +16,11 @@ on:
       - main
     paths:
       - "docs/**"
+      - "firebase/firestore.rules"
+      - "firebase/storage.rules"
       - "mkdocs.yml"
       - "requirements-docs.txt"
+      - "scripts/validate_rules_documentation.py"
       - ".github/workflows/docs-ci.yml"
       - ".github/workflows/deploy-docs.yml"
 
@@ -37,6 +43,9 @@ jobs:
 
       - name: Install docs dependencies
         run: pip install -r requirements-docs.txt
+
+      - name: Validate rules documentation
+        run: python3 scripts/validate_rules_documentation.py
 
       - name: Build docs
         run: mkdocs build --strict

--- a/docs/06-security/firebase-rules.md
+++ b/docs/06-security/firebase-rules.md
@@ -1,6 +1,6 @@
 # Firebase Rules
 
-_Last reviewed: March 14, 2026_
+_Last reviewed: March 15, 2026_
 
 ## Firestore rules highlights
 
@@ -47,4 +47,6 @@ Rules are defined in `firebase/storage.rules` and enforce:
 - keep rules and indexes versioned with feature changes
 - deploy rules/indexes through CI from protected branches
 - validate new role fields in both claims and `users/{uid}` fallback docs
+- keep `docs/06-security/firebase-rules.md` aligned using
+  `scripts/validate_rules_documentation.py` in CI
 - include billing collections in emulator/rules test matrix before rollout

--- a/mobile/befam/test/features/security/security_permissions_test.dart
+++ b/mobile/befam/test/features/security/security_permissions_test.dart
@@ -1,0 +1,231 @@
+import 'package:befam/features/auth/models/auth_entry_method.dart';
+import 'package:befam/features/auth/models/auth_member_access_mode.dart';
+import 'package:befam/features/auth/models/auth_session.dart';
+import 'package:befam/features/clan/services/clan_permissions.dart';
+import 'package:befam/features/events/services/event_permissions.dart';
+import 'package:befam/features/member/models/member_profile.dart';
+import 'package:befam/features/member/models/member_social_links.dart';
+import 'package:befam/features/member/services/member_permissions.dart';
+import 'package:befam/features/relationship/services/relationship_permissions.dart';
+import 'package:befam/features/scholarship/services/scholarship_permissions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ClanPermissions', () {
+    test('clan admin can edit clan settings and manage branches', () {
+      final permissions = ClanPermissions.forSession(
+        _session(primaryRole: 'CLAN_ADMIN'),
+      );
+
+      expect(permissions.canViewWorkspace, isTrue);
+      expect(permissions.canEditClanSettings, isTrue);
+      expect(permissions.canManageBranches, isTrue);
+      expect(permissions.canAssignLeadership, isTrue);
+      expect(permissions.isReadOnly, isFalse);
+    });
+
+    test('branch admin can manage branches but cannot edit clan settings', () {
+      final permissions = ClanPermissions.forSession(
+        _session(primaryRole: 'BRANCH_ADMIN'),
+      );
+
+      expect(permissions.canViewWorkspace, isTrue);
+      expect(permissions.canEditClanSettings, isFalse);
+      expect(permissions.canManageBranches, isTrue);
+      expect(permissions.canAssignLeadership, isTrue);
+    });
+
+    test('unlinked session is read-only even with admin role label', () {
+      final permissions = ClanPermissions.forSession(
+        _session(
+          primaryRole: 'CLAN_ADMIN',
+          accessMode: AuthMemberAccessMode.unlinked,
+          linkedAuthUid: false,
+        ),
+      );
+
+      expect(permissions.canViewWorkspace, isTrue);
+      expect(permissions.canEditClanSettings, isFalse);
+      expect(permissions.canManageBranches, isFalse);
+      expect(permissions.isReadOnly, isTrue);
+    });
+  });
+
+  group('MemberPermissions', () {
+    test('branch admin is restricted to own branch for member management', () {
+      final permissions = MemberPermissions.forSession(
+        _session(primaryRole: 'BRANCH_ADMIN', branchId: 'branch-1'),
+      );
+
+      expect(permissions.canCreateMembers, isTrue);
+      expect(permissions.canEditAnyMember, isTrue);
+      expect(permissions.canManageBranch('branch-1'), isTrue);
+      expect(permissions.canManageBranch('branch-2'), isFalse);
+      expect(permissions.canCreateInBranch('branch-2'), isFalse);
+    });
+
+    test('regular claimed member can edit and view only own profile', () {
+      final session = _session(
+        primaryRole: 'MEMBER',
+        memberId: 'member-self',
+        branchId: 'branch-2',
+      );
+      final permissions = MemberPermissions.forSession(session);
+      final self = _member(id: 'member-self', branchId: 'branch-2');
+      final other = _member(id: 'member-other', branchId: 'branch-2');
+
+      expect(permissions.canEditAnyMember, isFalse);
+      expect(permissions.canEditOwnProfile, isTrue);
+      expect(permissions.canEditMember(self, session), isTrue);
+      expect(permissions.canEditMember(other, session), isFalse);
+      expect(permissions.canViewMember(self, session), isTrue);
+      expect(permissions.canViewMember(other, session), isFalse);
+    });
+
+    test('super admin can view all members but requires non-empty branch id to manage branch write actions', () {
+      final permissions = MemberPermissions.forSession(
+        _session(primaryRole: 'SUPER_ADMIN'),
+      );
+
+      expect(permissions.canViewAllMembers, isTrue);
+      expect(permissions.canManageBranch('branch-9'), isTrue);
+      expect(permissions.canManageBranch(''), isFalse);
+      expect(permissions.canManageBranch(null), isFalse);
+    });
+  });
+
+  group('RelationshipPermissions', () {
+    test('branch admin can mutate only members within own branch', () {
+      final permissions = RelationshipPermissions.forSession(
+        _session(primaryRole: 'BRANCH_ADMIN', branchId: 'branch-1'),
+      );
+      final first = _member(id: 'm1', branchId: 'branch-1');
+      final second = _member(id: 'm2', branchId: 'branch-1');
+      final third = _member(id: 'm3', branchId: 'branch-2');
+
+      expect(permissions.canEditSensitiveRelationships, isTrue);
+      expect(permissions.canMutateBetween(first, second), isTrue);
+      expect(permissions.canMutateBetween(first, third), isFalse);
+    });
+
+    test('unlinked session cannot mutate relationships even with admin role', () {
+      final permissions = RelationshipPermissions.forSession(
+        _session(
+          primaryRole: 'CLAN_ADMIN',
+          accessMode: AuthMemberAccessMode.unlinked,
+          linkedAuthUid: false,
+        ),
+      );
+
+      expect(permissions.canEditSensitiveRelationships, isFalse);
+      expect(
+        permissions.canMutateBetween(
+          _member(id: 'm1', branchId: 'branch-1'),
+          _member(id: 'm2', branchId: 'branch-1'),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('EventPermissions', () {
+    test('claimed admins can manage events', () {
+      final permissions = EventPermissions.forSession(
+        _session(primaryRole: 'CLAN_ADMIN'),
+      );
+
+      expect(permissions.canViewWorkspace, isTrue);
+      expect(permissions.canManageEvents, isTrue);
+      expect(permissions.isReadOnly, isFalse);
+    });
+
+    test('members are read-only in event workspace', () {
+      final permissions = EventPermissions.forSession(
+        _session(primaryRole: 'MEMBER'),
+      );
+
+      expect(permissions.canViewWorkspace, isTrue);
+      expect(permissions.canManageEvents, isFalse);
+      expect(permissions.isReadOnly, isTrue);
+    });
+  });
+
+  group('ScholarshipPermissions', () {
+    test('claimed member can submit but cannot manage programs', () {
+      final permissions = ScholarshipPermissions.forSession(
+        _session(primaryRole: 'MEMBER'),
+      );
+
+      expect(permissions.canViewWorkspace, isTrue);
+      expect(permissions.canSubmitSubmissions, isTrue);
+      expect(permissions.canManagePrograms, isFalse);
+      expect(permissions.canReviewQueue, isFalse);
+    });
+
+    test('branch admin can manage scholarship programs and review queue', () {
+      final permissions = ScholarshipPermissions.forSession(
+        _session(primaryRole: 'BRANCH_ADMIN'),
+      );
+
+      expect(permissions.canManagePrograms, isTrue);
+      expect(permissions.canReviewQueue, isTrue);
+    });
+  });
+}
+
+AuthSession _session({
+  String primaryRole = 'MEMBER',
+  String? clanId = 'clan-1',
+  String? branchId = 'branch-1',
+  String? memberId = 'member-1',
+  AuthMemberAccessMode accessMode = AuthMemberAccessMode.claimed,
+  bool linkedAuthUid = true,
+}) {
+  return AuthSession(
+    uid: 'debug:user',
+    loginMethod: AuthEntryMethod.phone,
+    phoneE164: '+84900000000',
+    displayName: 'Debug User',
+    clanId: clanId,
+    branchId: branchId,
+    memberId: memberId,
+    primaryRole: primaryRole,
+    accessMode: accessMode,
+    linkedAuthUid: linkedAuthUid,
+    isSandbox: true,
+    signedInAtIso: DateTime(2026, 3, 15).toIso8601String(),
+  );
+}
+
+MemberProfile _member({
+  required String id,
+  String clanId = 'clan-1',
+  String branchId = 'branch-1',
+}) {
+  return MemberProfile(
+    id: id,
+    clanId: clanId,
+    branchId: branchId,
+    fullName: 'Member $id',
+    normalizedFullName: 'member $id',
+    nickName: '',
+    gender: null,
+    birthDate: null,
+    deathDate: null,
+    phoneE164: null,
+    email: null,
+    addressText: null,
+    jobTitle: null,
+    avatarUrl: null,
+    bio: null,
+    socialLinks: const MemberSocialLinks(),
+    parentIds: const [],
+    childrenIds: const [],
+    spouseIds: const [],
+    generation: 1,
+    primaryRole: 'MEMBER',
+    status: 'active',
+    isMinor: false,
+    authUid: null,
+  );
+}

--- a/scripts/validate_rules_documentation.py
+++ b/scripts/validate_rules_documentation.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Validate Firebase Rules documentation stays aligned with rules files."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOC_PATH = REPO_ROOT / "docs/06-security/firebase-rules.md"
+FIRESTORE_RULES_PATH = REPO_ROOT / "firebase/firestore.rules"
+STORAGE_RULES_PATH = REPO_ROOT / "firebase/storage.rules"
+
+DOC_REQUIRED_SNIPPETS = [
+    "`firebase/firestore.rules`",
+    "`firebase/storage.rules`",
+    "## Firestore rules highlights",
+    "## Storage rules highlights",
+    "`hasClanAccess(clanId)`",
+    "`primaryRole()`",
+    "`branchIdClaim()`",
+    "`isClanSettingsAdmin()`",
+    "`isBranchScopedMemberManager(...)`",
+    "`safeProfileUpdate()`",
+    "`clans/{clanId}/members/{memberId}/avatar/{fileName}`",
+    "`submissions/{clanId}/{memberId}/{fileName}`",
+]
+
+DOCUMENTED_SERVER_ONLY_COLLECTIONS = {
+    "transactions",
+    "auditLogs",
+    "memberSearchIndex",
+}
+
+REQUIRED_HELPER_FUNCTIONS = {
+    "hasClanAccess",
+    "primaryRole",
+    "branchIdClaim",
+    "isClanSettingsAdmin",
+    "isBranchScopedMemberManager",
+    "safeProfileUpdate",
+}
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing required file: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _extract_function_names(rules_text: str) -> set[str]:
+    return set(re.findall(r"\bfunction\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", rules_text))
+
+
+def _extract_server_only_collections(firestore_rules: str) -> set[str]:
+    # Collect top-level match blocks whose writes are server-only (allow write: if false;).
+    collections: set[str] = set()
+    for match in re.finditer(
+        r"match\s+/([A-Za-z0-9_]+)/\{[A-Za-z0-9_]+\}\s*\{(?P<body>.*?)\n\s*\}",
+        firestore_rules,
+        flags=re.DOTALL,
+    ):
+        body = match.group("body")
+        if re.search(r"allow\s+write\s*:\s*if\s+false\s*;", body):
+            collections.add(match.group(1))
+    return collections
+
+
+def _extract_storage_limits_mb(storage_rules: str) -> tuple[int, int]:
+    avatar_match = re.search(
+        r"match\s+/clans/\{clanId\}/members/\{memberId\}/avatar/\{fileName\}\s*\{.*?"
+        r"request\.resource\.size\s*<\s*(\d+)\s*\*\s*1024\s*\*\s*1024",
+        storage_rules,
+        flags=re.DOTALL,
+    )
+    submission_match = re.search(
+        r"match\s+/submissions/\{clanId\}/\{memberId\}/\{fileName\}\s*\{.*?"
+        r"request\.resource\.size\s*<\s*(\d+)\s*\*\s*1024\s*\*\s*1024",
+        storage_rules,
+        flags=re.DOTALL,
+    )
+    if not avatar_match or not submission_match:
+        raise ValueError("Unable to parse storage upload limits from firebase/storage.rules.")
+
+    return int(avatar_match.group(1)), int(submission_match.group(1))
+
+
+def main() -> int:
+    try:
+        docs_text = _read_text(DOC_PATH)
+        firestore_rules = _read_text(FIRESTORE_RULES_PATH)
+        storage_rules = _read_text(STORAGE_RULES_PATH)
+    except (FileNotFoundError, OSError) as exc:
+        print(f"[rules-doc-validation] {exc}", file=sys.stderr)
+        return 1
+
+    failures: list[str] = []
+
+    for snippet in DOC_REQUIRED_SNIPPETS:
+        if snippet not in docs_text:
+            failures.append(f"Documentation missing required snippet: {snippet}")
+
+    helper_names = _extract_function_names(firestore_rules)
+    missing_helpers = sorted(REQUIRED_HELPER_FUNCTIONS - helper_names)
+    if missing_helpers:
+        failures.append(
+            "firebase/firestore.rules is missing required helper function(s): "
+            + ", ".join(missing_helpers)
+        )
+
+    server_only_in_rules = _extract_server_only_collections(firestore_rules)
+    for collection in sorted(DOCUMENTED_SERVER_ONLY_COLLECTIONS):
+        if collection not in server_only_in_rules:
+            failures.append(
+                "firebase/firestore.rules no longer marks "
+                f"`{collection}` as server-only (`allow write: if false;`)."
+            )
+        if f"`{collection}`" not in docs_text:
+            failures.append(
+                f"Documentation should mention server-only collection `{collection}`."
+            )
+
+    try:
+        avatar_limit_mb, submission_limit_mb = _extract_storage_limits_mb(storage_rules)
+    except ValueError as exc:
+        failures.append(str(exc))
+    else:
+        if f"{avatar_limit_mb} MB max size" not in docs_text:
+            failures.append(
+                "Documentation missing avatar upload size limit text "
+                f"({avatar_limit_mb} MB max size)."
+            )
+        if f"{submission_limit_mb} MB max size" not in docs_text:
+            failures.append(
+                "Documentation missing submission upload size limit text "
+                f"({submission_limit_mb} MB max size)."
+            )
+
+    if failures:
+        print("[rules-doc-validation] FAILED", file=sys.stderr)
+        for failure in failures:
+            print(f" - {failure}", file=sys.stderr)
+        return 1
+
+    print("[rules-doc-validation] PASS: rules documentation is aligned with rules files.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add security-focused Flutter unit tests for permissions across clan/member/relationship/event/scholarship access paths (SEC-006)
- add `scripts/validate_rules_documentation.py` to validate `docs/06-security/firebase-rules.md` stays aligned with Firestore/Storage rules (SEC-007)
- run rules-doc validation in both branch CI and docs CI workflows
- update security rules documentation operational guidance

## Validation
- `python3 scripts/validate_rules_documentation.py`
- `flutter test test/features/security/security_permissions_test.dart`

Closes #155
Closes #156
