### PR TITLE
[REL] Epic #18 Release Hardening (REL-RELEASE-001/002/005/006)

### DIFF
--- a/docs/03-mobile/ui-design.md
+++ b/docs/03-mobile/ui-design.md
@@ -28,6 +28,19 @@ to keep the app approachable for both younger and older users.
 - large text compatibility and overflow hardening
 - generous tap targets and legible heading hierarchy
 - reduced cognitive load in home/auth copy
+- icon-only actions include explicit tooltips on core workspace screens
+- workspace loading states include readable progress messaging and live-region
+  semantics via `core/widgets/app_feedback_states.dart`
+- calendar day tiles provide richer semantic labels for solar/lunar context and
+  event counts
+
+## Empty/loading/error audit baseline
+
+- all major workspaces now render explicit loading states instead of spinner-only
+  placeholders
+- no-context and empty states provide user-facing guidance in each module
+- retry actions are available on recoverable error states
+- runtime widget crashes show a fallback card UI instead of a broken frame
 
 ## Content style
 

--- a/docs/05-devops/ci-cd.md
+++ b/docs/05-devops/ci-cd.md
@@ -189,3 +189,13 @@ Current production automation on `main` now:
 6. uploads the unsigned iOS XCArchive
 7. pushes the BeFam mobile builder image to GHCR
 8. pushes the Firebase tooling image to GHCR
+
+## Release quality gates
+
+Before promoting a release candidate to `main`, complete:
+
+- `05-devops/pre-release-qa-checklist.md`
+- `05-devops/store-assets-checklist.md`
+
+These checklists are part of Epic 17 release-hardening controls and should be
+linked in the release PR description.

--- a/docs/05-devops/pre-release-qa-checklist.md
+++ b/docs/05-devops/pre-release-qa-checklist.md
@@ -1,0 +1,57 @@
+# Pre-Release QA Checklist
+
+_Last reviewed: March 15, 2026_
+
+Use this checklist for every release candidate before merge/promotion to `main`.
+
+## Build and environment
+
+- [ ] latest `staging` branch is pulled and release candidate commit is tagged
+- [ ] Firebase project/environment values are correct for production release flow
+- [ ] `flutter analyze` passes locally
+- [ ] `flutter test` passes locally
+- [ ] CI checks `ci-docs`, `ci-functions`, and `ci-mobile` are green
+
+## Core user journeys
+
+- [ ] authentication via phone flow works end-to-end
+- [ ] home shortcuts navigate correctly
+- [ ] clan, member, relationship, genealogy flows load and update as expected
+- [ ] dual calendar create/edit/delete flows work for solar and lunar events
+- [ ] notifications inbox and deep links open target content correctly
+- [ ] profile edit and avatar upload work for allowed roles
+
+## Accessibility pass (REL-RELEASE-001)
+
+- [ ] all icon-only actions have a tooltip or accessible label
+- [ ] loading states announce meaningful status text
+- [ ] dynamic content areas are readable with large text scaling
+- [ ] focus order is logical for major forms and dialogs
+- [ ] color contrast is acceptable for key actions, chips, and status cards
+
+## Empty/loading/error state audit (REL-RELEASE-002)
+
+- [ ] each workspace has a non-blank loading state with user-facing message
+- [ ] no-context states provide clear guidance instead of raw errors
+- [ ] empty list states explain what to do next
+- [ ] error states include retry path where recovery is possible
+- [ ] fallback error UI renders when a widget tree crash occurs
+
+## Performance and reliability
+
+- [ ] cold start is acceptable on a low-end Android test device
+- [ ] scrolling remains smooth in calendar/month grid and genealogy views
+- [ ] no repeated severe `perf.*` warnings in debug verification runs
+- [ ] Crashlytics and log signals are visible for injected failure scenarios
+
+## Release documentation and assets
+
+- [ ] [Store Assets Checklist](store-assets-checklist.md) is completed
+- [ ] release notes include delivered stories and known limitations
+- [ ] support/privacy links in docs and store listing are valid
+
+## Sign-off
+
+- [ ] QA sign-off recorded in release PR
+- [ ] engineering sign-off recorded in release PR
+- [ ] product sign-off recorded in release PR

--- a/docs/05-devops/store-assets-checklist.md
+++ b/docs/05-devops/store-assets-checklist.md
@@ -1,0 +1,49 @@
+# Store Assets Checklist
+
+_Last reviewed: March 15, 2026_
+
+This checklist is required before each production release candidate.
+
+## Brand identity assets
+
+- [ ] final app name and short description are approved for both Vietnamese and English
+- [ ] app icon source file (vector or high-res PNG) is archived in design storage
+- [ ] adaptive icon layers (foreground/background) are exported for Android
+- [ ] iOS app icon set is exported for required App Store Connect sizes
+
+## Screenshots and previews
+
+- [ ] Android phone screenshots (Vietnamese)
+- [ ] Android phone screenshots (English)
+- [ ] iPhone screenshots (Vietnamese)
+- [ ] iPhone screenshots (English)
+- [ ] at least one screenshot shows dual calendar, events, and profile workflows
+- [ ] screenshots avoid debug/demo labels that are not user-facing in production
+- [ ] optional App Preview video is exported and validated for aspect ratio and duration
+
+## Listing content
+
+- [ ] app subtitle / short description
+- [ ] full description with key features and privacy wording
+- [ ] keywords and category selection reviewed
+- [ ] support URL and contact email are valid
+- [ ] privacy policy URL is reachable and current
+- [ ] terms URL (if used) is reachable and current
+
+## Compliance assets
+
+- [ ] age rating questionnaires updated
+- [ ] ad disclosure fields are accurate (free/base plans include ads)
+- [ ] billing disclosures match current subscription plans
+- [ ] data safety / nutrition labels reviewed against latest implementation
+
+## Localization and quality
+
+- [ ] listing text is proofread in both Vietnamese and English
+- [ ] screenshots match localized text and UI labels
+- [ ] dark/light rendering checks complete for store imagery (if both used)
+
+## Final gate
+
+- [ ] product, engineering, and QA sign-off recorded in release issue
+- [ ] release tag is blocked until this checklist is fully complete

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,8 @@ nav:
       - Notifications: 04-backend/notifications.md
   - DevOps:
       - CI/CD: 05-devops/ci-cd.md
+      - Pre-Release QA Checklist: 05-devops/pre-release-qa-checklist.md
+      - Store Assets Checklist: 05-devops/store-assets-checklist.md
       - GitHub Workflow: 05-devops/github-workflow.md
       - Branching Strategy: 05-devops/branching-strategy.md
       - GitHub Backlog: 05-devops/github-backlog.md

--- a/mobile/befam/lib/core/widgets/app_feedback_states.dart
+++ b/mobile/befam/lib/core/widgets/app_feedback_states.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+class AppLoadingState extends StatelessWidget {
+  const AppLoadingState({
+    super.key,
+    required this.message,
+    this.semanticLabel,
+    this.padding = const EdgeInsets.all(24),
+  });
+
+  final String message;
+  final String? semanticLabel;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Center(
+      child: Padding(
+        padding: padding,
+        child: Semantics(
+          container: true,
+          liveRegion: true,
+          label: semanticLabel ?? message,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                width: 28,
+                height: 28,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2.8,
+                  color: colorScheme.primary,
+                ),
+              ),
+              const SizedBox(height: 14),
+              Text(
+                message,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class AppInlineProgressIndicator extends StatelessWidget {
+  const AppInlineProgressIndicator({
+    super.key,
+    this.size = 18,
+    this.strokeWidth = 2,
+    required this.semanticLabel,
+  });
+
+  final double size;
+  final double strokeWidth;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      label: semanticLabel,
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: CircularProgressIndicator(strokeWidth: strokeWidth),
+      ),
+    );
+  }
+}

--- a/mobile/befam/lib/features/calendar/presentation/dual_calendar_workspace_page.dart
+++ b/mobile/befam/lib/features/calendar/presentation/dual_calendar_workspace_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../../core/widgets/app_feedback_states.dart';
 import '../../../l10n/generated/app_localizations.dart';
 import '../../../l10n/l10n.dart';
 import '../models/calendar_date_mode.dart';
@@ -75,7 +76,12 @@ class _DualCalendarWorkspacePageState extends State<DualCalendarWorkspacePage> {
           ),
           body: SafeArea(
             child: _controller.isLoading
-                ? const Center(child: CircularProgressIndicator())
+                ? AppLoadingState(
+                    message: l10n.pick(
+                      vi: 'Đang tải lịch song song...',
+                      en: 'Loading dual calendar...',
+                    ),
+                  )
                 : RefreshIndicator(
                     onRefresh: _controller.refreshAll,
                     child: ListView(
@@ -92,6 +98,17 @@ class _DualCalendarWorkspacePageState extends State<DualCalendarWorkspacePage> {
                             ),
                             description: message,
                             tone: colorScheme.errorContainer,
+                          ),
+                          const SizedBox(height: 8),
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: TextButton.icon(
+                              onPressed: _controller.refreshAll,
+                              icon: const Icon(Icons.refresh),
+                              label: Text(
+                                l10n.pick(vi: 'Thử lại', en: 'Retry'),
+                              ),
+                            ),
                           ),
                           const SizedBox(height: 16),
                         ],
@@ -371,10 +388,8 @@ class _SettingsCard extends StatelessWidget {
           const SizedBox(height: 8),
           Text(
             l10n.pick(
-              vi:
-                  'Theo dõi ngày dương và âm trong cùng một nơi. Chạm vào ngày để xem chi tiết và lời nhắc.',
-              en:
-                  'Track solar and lunar dates in one place. Tap a day to view details and reminders.',
+              vi: 'Theo dõi ngày dương và âm trong cùng một nơi. Chạm vào ngày để xem chi tiết và lời nhắc.',
+              en: 'Track solar and lunar dates in one place. Tap a day to view details and reminders.',
             ),
             style: textTheme.bodyMedium?.copyWith(height: 1.35),
           ),
@@ -579,6 +594,35 @@ class _MonthGrid extends StatelessWidget {
   final ValueChanged<DateTime> onSelectDay;
   final Future<void> Function(DateTime month) onJumpToMonth;
 
+  String _daySemanticsLabel(
+    BuildContext context, {
+    required DateTime day,
+    required LunarDate? lunarDate,
+    required int eventCount,
+    required bool isToday,
+    required bool isSelected,
+    required bool isHoliday,
+  }) {
+    final l10n = context.l10n;
+    final solarLabel = '${_monthName(l10n, day.month)} ${day.day}, ${day.year}';
+    final lunarLabel = lunarDate == null
+        ? l10n.pick(vi: 'Âm lịch chưa có dữ liệu', en: 'Lunar date unavailable')
+        : l10n.pick(
+            vi: 'Âm lịch ${lunarDate.displayLabel}',
+            en: 'Lunar ${lunarDate.displayLabel}',
+          );
+    final eventsLabel = eventCount == 0
+        ? l10n.pick(vi: 'không có sự kiện', en: 'no events')
+        : l10n.pick(vi: '$eventCount sự kiện', en: '$eventCount events');
+    final tags = <String>[
+      if (isToday) l10n.pick(vi: 'hôm nay', en: 'today'),
+      if (isSelected) l10n.pick(vi: 'đã chọn', en: 'selected'),
+      if (isHoliday) l10n.pick(vi: 'ngày lễ', en: 'holiday'),
+    ];
+    final tagText = tags.isEmpty ? '' : ' (${tags.join(', ')})';
+    return '$solarLabel, $lunarLabel, $eventsLabel$tagText';
+  }
+
   @override
   Widget build(BuildContext context) {
     final focusedMonth = controller.focusedMonth;
@@ -638,24 +682,41 @@ class _MonthGrid extends StatelessWidget {
             final eventCount = controller.eventCountForDay(day);
             final isHoliday = isCurrentMonth && controller.isHolidayDay(day);
 
-            return InkWell(
-              key: Key('calendar-day-${_isoDay(day)}'),
-              borderRadius: BorderRadius.circular(14),
-              onTap: () async {
-                if (!isCurrentMonth) {
-                  await onJumpToMonth(DateTime(day.year, day.month));
-                }
-                onSelectDay(day);
-              },
-              child: _DayTile(
+            return Semantics(
+              button: true,
+              selected: isSelected,
+              label: _daySemanticsLabel(
+                context,
                 day: day,
                 lunarDate: lunarDate,
-                isCurrentMonth: isCurrentMonth,
-                isSelected: isSelected,
-                isToday: isToday,
-                isHoliday: isHoliday,
                 eventCount: eventCount,
-                displayMode: controller.displayMode,
+                isToday: isToday,
+                isSelected: isSelected,
+                isHoliday: isHoliday,
+              ),
+              hint: l10n.pick(
+                vi: 'Nhấn để xem chi tiết ngày',
+                en: 'Tap to view day details',
+              ),
+              child: InkWell(
+                key: Key('calendar-day-${_isoDay(day)}'),
+                borderRadius: BorderRadius.circular(14),
+                onTap: () async {
+                  if (!isCurrentMonth) {
+                    await onJumpToMonth(DateTime(day.year, day.month));
+                  }
+                  onSelectDay(day);
+                },
+                child: _DayTile(
+                  day: day,
+                  lunarDate: lunarDate,
+                  isCurrentMonth: isCurrentMonth,
+                  isSelected: isSelected,
+                  isToday: isToday,
+                  isHoliday: isHoliday,
+                  eventCount: eventCount,
+                  displayMode: controller.displayMode,
+                ),
               ),
             );
           },
@@ -706,10 +767,8 @@ class _SelectedDayPanel extends StatelessWidget {
                       en: 'Lunar date unavailable for this day.',
                     )
                   : l10n.pick(
-                      vi:
-                          'Âm lịch ${lunarDate.displayLabel}${lunarDate.isLeapMonth ? ' (tháng nhuận)' : ''}',
-                      en:
-                          'Lunar ${lunarDate.displayLabel}${lunarDate.isLeapMonth ? ' (Leap month)' : ''}',
+                      vi: 'Âm lịch ${lunarDate.displayLabel}${lunarDate.isLeapMonth ? ' (tháng nhuận)' : ''}',
+                      en: 'Lunar ${lunarDate.displayLabel}${lunarDate.isLeapMonth ? ' (Leap month)' : ''}',
                     ),
             ),
             if (holidays.isNotEmpty) ...[
@@ -729,7 +788,10 @@ class _SelectedDayPanel extends StatelessWidget {
             const SizedBox(height: 14),
             Text(
               occurrences.isEmpty
-                  ? l10n.pick(vi: 'Không có sự kiện cho ngày này.', en: 'No events for this day.')
+                  ? l10n.pick(
+                      vi: 'Không có sự kiện cho ngày này.',
+                      en: 'No events for this day.',
+                    )
                   : l10n.pick(vi: 'Sự kiện', en: 'Events'),
               style: const TextStyle(fontWeight: FontWeight.w700),
             ),
@@ -799,10 +861,8 @@ class _ReminderPanel extends StatelessWidget {
                           Expanded(
                             child: Text(
                               l10n.pick(
-                                vi:
-                                    '${_formatDateTime(reminder.reminderAt)} · trước ${reminder.offsetMinutes} phút',
-                                en:
-                                    '${_formatDateTime(reminder.reminderAt)} · ${reminder.offsetMinutes} min before',
+                                vi: '${_formatDateTime(reminder.reminderAt)} · trước ${reminder.offsetMinutes} phút',
+                                en: '${_formatDateTime(reminder.reminderAt)} · ${reminder.offsetMinutes} min before',
                               ),
                             ),
                           ),
@@ -1462,9 +1522,7 @@ class _EventEditorSheetState extends State<_EventEditorSheet> {
   Future<void> _submit() async {
     final title = _titleController.text.trim();
     if (title.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
             context.l10n.pick(

--- a/mobile/befam/lib/features/clan/presentation/branch_list_page.dart
+++ b/mobile/befam/lib/features/clan/presentation/branch_list_page.dart
@@ -117,6 +117,7 @@ class BranchListPage extends StatelessWidget {
           floatingActionButton: controller.permissions.canManageBranches
               ? FloatingActionButton.extended(
                   onPressed: () => onEditBranch(),
+                  tooltip: l10n.clanAddBranchAction,
                   icon: const Icon(Icons.add),
                   label: Text(l10n.clanAddBranchAction),
                 )

--- a/mobile/befam/lib/features/clan/presentation/clan_detail_page.dart
+++ b/mobile/befam/lib/features/clan/presentation/clan_detail_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../../core/widgets/app_feedback_states.dart';
 import '../../../l10n/l10n.dart';
 import '../../auth/models/auth_session.dart';
 import '../models/branch_draft.dart';
@@ -129,7 +130,12 @@ class _ClanDetailPageState extends State<ClanDetailPage> {
           ),
           body: SafeArea(
             child: _controller.isLoading
-                ? const Center(child: CircularProgressIndicator())
+                ? AppLoadingState(
+                    message: l10n.pick(
+                      vi: 'Đang tải không gian họ tộc...',
+                      en: 'Loading clan workspace...',
+                    ),
+                  )
                 : !_controller.permissions.canViewWorkspace
                 ? _EmptyWorkspace(
                     icon: Icons.lock_outline,
@@ -169,6 +175,15 @@ class _ClanDetailPageState extends State<ClanDetailPage> {
                                 ? l10n.clanPermissionDeniedDescription
                                 : l10n.clanLoadErrorDescription,
                             tone: colorScheme.errorContainer,
+                          ),
+                          const SizedBox(height: 8),
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: TextButton.icon(
+                              onPressed: _controller.refresh,
+                              icon: const Icon(Icons.refresh),
+                              label: Text(l10n.clanRefreshAction),
+                            ),
                           ),
                           const SizedBox(height: 20),
                         ],

--- a/mobile/befam/lib/features/events/presentation/event_workspace_page.dart
+++ b/mobile/befam/lib/features/events/presentation/event_workspace_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../../core/widgets/app_feedback_states.dart';
 import '../../../l10n/l10n.dart';
 import '../../auth/models/auth_session.dart';
 import '../../clan/models/branch_profile.dart';
@@ -118,13 +119,19 @@ class _EventWorkspacePageState extends State<EventWorkspacePage> {
               ? FloatingActionButton.extended(
                   key: const Key('event-create-button'),
                   onPressed: () => _openEventEditor(),
+                  tooltip: l10n.eventCreateAction,
                   icon: const Icon(Icons.add),
                   label: Text(l10n.eventCreateAction),
                 )
               : null,
           body: SafeArea(
             child: _controller.isLoading
-                ? const Center(child: CircularProgressIndicator())
+                ? AppLoadingState(
+                    message: l10n.pick(
+                      vi: 'Đang tải không gian sự kiện...',
+                      en: 'Loading event workspace...',
+                    ),
+                  )
                 : !_controller.hasClanContext
                 ? _WorkspaceEmptyState(
                     icon: Icons.lock_outline,
@@ -163,6 +170,15 @@ class _EventWorkspacePageState extends State<EventWorkspacePage> {
                             title: l10n.eventLoadErrorTitle,
                             description: l10n.eventLoadErrorDescription,
                             tone: colorScheme.errorContainer,
+                          ),
+                          const SizedBox(height: 8),
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: TextButton.icon(
+                              onPressed: _controller.refresh,
+                              icon: const Icon(Icons.refresh),
+                              label: Text(l10n.eventRefreshAction),
+                            ),
                           ),
                           const SizedBox(height: 20),
                         ],

--- a/mobile/befam/lib/features/funds/presentation/fund_workspace_page.dart
+++ b/mobile/befam/lib/features/funds/presentation/fund_workspace_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../../core/widgets/app_feedback_states.dart';
 import '../../../l10n/l10n.dart';
 import '../../auth/models/auth_session.dart';
 import '../models/fund_draft.dart';
@@ -57,12 +58,10 @@ class _FundWorkspacePageState extends State<FundWorkspacePage> {
           title: fund == null
               ? l10n.pick(vi: 'Tạo quỹ', en: 'Create fund')
               : l10n.pick(vi: 'Chỉnh sửa quỹ', en: 'Edit fund'),
-          description:
-              l10n.pick(
-                vi: 'Thiết lập hồ sơ quỹ để ghi nhận đóng góp, chi tiêu và theo dõi số dư minh bạch.',
-                en:
-                    'Set up a fund profile for donations, expenses, and transparent balance tracking.',
-              ),
+          description: l10n.pick(
+            vi: 'Thiết lập hồ sơ quỹ để ghi nhận đóng góp, chi tiêu và theo dõi số dư minh bạch.',
+            en: 'Set up a fund profile for donations, expenses, and transparent balance tracking.',
+          ),
           initialDraft: fund == null
               ? FundDraft.empty()
               : FundDraft.fromProfile(fund),
@@ -127,13 +126,19 @@ class _FundWorkspacePageState extends State<FundWorkspacePage> {
           floatingActionButton: _controller.canManageFunds
               ? FloatingActionButton.extended(
                   onPressed: () => _openFundEditor(),
+                  tooltip: l10n.pick(vi: 'Thêm quỹ', en: 'Add fund'),
                   icon: const Icon(Icons.add),
                   label: Text(l10n.pick(vi: 'Thêm quỹ', en: 'Add fund')),
                 )
               : null,
           body: SafeArea(
             child: _controller.isLoading
-                ? const Center(child: CircularProgressIndicator())
+                ? AppLoadingState(
+                    message: l10n.pick(
+                      vi: 'Đang tải không gian quỹ...',
+                      en: 'Loading fund workspace...',
+                    ),
+                  )
                 : !_controller.hasClanContext
                 ? _EmptyWorkspace(
                     icon: Icons.lock_outline,
@@ -142,10 +147,8 @@ class _FundWorkspacePageState extends State<FundWorkspacePage> {
                       en: 'No clan context',
                     ),
                     description: l10n.pick(
-                      vi:
-                          'Liên kết tài khoản này với một họ tộc trước khi xem quỹ và giao dịch.',
-                      en:
-                          'Link this account to a clan before viewing funds and transactions.',
+                      vi: 'Liên kết tài khoản này với một họ tộc trước khi xem quỹ và giao dịch.',
+                      en: 'Link this account to a clan before viewing funds and transactions.',
                     ),
                   )
                 : RefreshIndicator(
@@ -159,10 +162,8 @@ class _FundWorkspacePageState extends State<FundWorkspacePage> {
                             en: 'Fund ledger workspace',
                           ),
                           description: l10n.pick(
-                            vi:
-                                'Theo dõi đóng góp, chi tiêu, số dư hiện tại và lịch sử theo từng quỹ.',
-                            en:
-                                'Track donations, expenses, running balance, and history across each fund.',
+                            vi: 'Theo dõi đóng góp, chi tiêu, số dư hiện tại và lịch sử theo từng quỹ.',
+                            en: 'Track donations, expenses, running balance, and history across each fund.',
                           ),
                           canManageFunds: _controller.canManageFunds,
                           onPrimaryAction: _controller.canManageFunds
@@ -180,6 +181,17 @@ class _FundWorkspacePageState extends State<FundWorkspacePage> {
                             description: error,
                             tone: colorScheme.errorContainer,
                           ),
+                          const SizedBox(height: 8),
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: TextButton.icon(
+                              onPressed: _controller.refresh,
+                              icon: const Icon(Icons.refresh),
+                              label: Text(
+                                l10n.pick(vi: 'Tải lại', en: 'Retry'),
+                              ),
+                            ),
+                          ),
                           const SizedBox(height: 20),
                         ],
                         if (!_controller.canManageFunds) ...[
@@ -190,10 +202,8 @@ class _FundWorkspacePageState extends State<FundWorkspacePage> {
                               en: 'Read-only role',
                             ),
                             description: l10n.pick(
-                              vi:
-                                  'Chỉ quản trị cấp họ tộc mới có thể tạo quỹ hoặc ghi giao dịch.',
-                              en:
-                                  'Only clan-level administrators can create funds or post transactions.',
+                              vi: 'Chỉ quản trị cấp họ tộc mới có thể tạo quỹ hoặc ghi giao dịch.',
+                              en: 'Only clan-level administrators can create funds or post transactions.',
                             ),
                             tone: colorScheme.secondaryContainer,
                           ),
@@ -246,10 +256,8 @@ class _FundWorkspacePageState extends State<FundWorkspacePage> {
                                     en: 'No funds yet',
                                   ),
                                   description: l10n.pick(
-                                    vi:
-                                        'Tạo quỹ đầu tiên để bắt đầu ghi nhận đóng góp và chi tiêu.',
-                                    en:
-                                        'Create the first fund to start recording donations and expenses.',
+                                    vi: 'Tạo quỹ đầu tiên để bắt đầu ghi nhận đóng góp và chi tiêu.',
+                                    en: 'Create the first fund to start recording donations and expenses.',
                                   ),
                                 )
                               : Column(

--- a/mobile/befam/lib/features/genealogy/presentation/genealogy_workspace_page.dart
+++ b/mobile/befam/lib/features/genealogy/presentation/genealogy_workspace_page.dart
@@ -4,6 +4,7 @@ import 'dart:developer' as developer;
 
 import 'package:flutter/material.dart';
 
+import '../../../core/widgets/app_feedback_states.dart';
 import '../../../l10n/generated/app_localizations.dart';
 import '../../../l10n/l10n.dart';
 import '../../auth/models/auth_member_access_mode.dart';
@@ -84,7 +85,12 @@ class _GenealogyWorkspacePageState extends State<GenealogyWorkspacePage>
   Widget build(BuildContext context) {
     final l10n = context.l10n;
     if (_isLoading && _segment == null) {
-      return const Center(child: CircularProgressIndicator());
+      return AppLoadingState(
+        message: l10n.pick(
+          vi: 'Đang tải cây gia phả...',
+          en: 'Loading family tree...',
+        ),
+      );
     }
 
     if (_error != null && _segment == null) {
@@ -1626,6 +1632,7 @@ class _DepthControl extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return DecoratedBox(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceContainerHighest,
@@ -1641,7 +1648,7 @@ class _DepthControl extends StatelessWidget {
               visualDensity: VisualDensity.compact,
               onPressed: canDecrease ? onDecrease : null,
               icon: const Icon(Icons.remove),
-              tooltip: '-',
+              tooltip: l10n.pick(vi: 'Giảm $label', en: 'Decrease $label'),
             ),
             Text('$label $depth', key: Key('genealogy-depth-$id-value')),
             IconButton(
@@ -1649,7 +1656,7 @@ class _DepthControl extends StatelessWidget {
               visualDensity: VisualDensity.compact,
               onPressed: canIncrease ? onIncrease : null,
               icon: const Icon(Icons.add),
-              tooltip: '+',
+              tooltip: l10n.pick(vi: 'Tăng $label', en: 'Increase $label'),
             ),
           ],
         ),
@@ -1672,6 +1679,7 @@ class _TreeZoomControls extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final l10n = context.l10n;
     return DecoratedBox(
       decoration: BoxDecoration(
         color: colorScheme.surface.withValues(alpha: 0.92),
@@ -1688,21 +1696,24 @@ class _TreeZoomControls extends StatelessWidget {
               visualDensity: VisualDensity.compact,
               onPressed: onZoomOut,
               icon: const Icon(Icons.remove),
-              tooltip: '-',
+              tooltip: l10n.pick(vi: 'Thu nhỏ cây', en: 'Zoom out tree'),
             ),
             IconButton(
               key: const Key('tree-zoom-in'),
               visualDensity: VisualDensity.compact,
               onPressed: onZoomIn,
               icon: const Icon(Icons.add),
-              tooltip: '+',
+              tooltip: l10n.pick(vi: 'Phóng to cây', en: 'Zoom in tree'),
             ),
             IconButton(
               key: const Key('tree-zoom-reset'),
               visualDensity: VisualDensity.compact,
               onPressed: onReset,
               icon: const Icon(Icons.filter_center_focus),
-              tooltip: 'Reset',
+              tooltip: l10n.pick(
+                vi: 'Đặt lại vị trí cây',
+                en: 'Reset tree view',
+              ),
             ),
           ],
         ),

--- a/mobile/befam/lib/features/member/presentation/member_workspace_page.dart
+++ b/mobile/befam/lib/features/member/presentation/member_workspace_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../../core/widgets/app_feedback_states.dart';
 import '../../../l10n/generated/app_localizations.dart';
 import '../../../l10n/l10n.dart';
 import '../../auth/models/auth_session.dart';
@@ -148,7 +149,12 @@ class _MemberWorkspacePageState extends State<MemberWorkspacePage> {
           ),
           body: SafeArea(
             child: _controller.isLoading
-                ? const Center(child: CircularProgressIndicator())
+                ? AppLoadingState(
+                    message: l10n.pick(
+                      vi: 'Đang tải không gian thành viên...',
+                      en: 'Loading member workspace...',
+                    ),
+                  )
                 : !_controller.hasClanContext
                 ? _WorkspaceEmptyState(
                     icon: Icons.lock_outline,
@@ -185,6 +191,15 @@ class _MemberWorkspacePageState extends State<MemberWorkspacePage> {
                             title: l10n.memberLoadErrorTitle,
                             description: l10n.memberLoadErrorDescription,
                             tone: colorScheme.errorContainer,
+                          ),
+                          const SizedBox(height: 8),
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: TextButton.icon(
+                              onPressed: _controller.refresh,
+                              icon: const Icon(Icons.refresh),
+                              label: Text(l10n.memberRefreshAction),
+                            ),
                           ),
                           const SizedBox(height: 20),
                         ],
@@ -976,6 +991,10 @@ class _MemberEditorSheetState extends State<_MemberEditorSheet> {
                           labelText: l10n.memberBirthDateLabel,
                           hintText: 'YYYY-MM-DD',
                           suffixIcon: IconButton(
+                            tooltip: l10n.pick(
+                              vi: 'Chọn ngày sinh',
+                              en: 'Select birth date',
+                            ),
                             onPressed: () => _pickDate(_birthDateController),
                             icon: const Icon(Icons.calendar_today_outlined),
                           ),
@@ -996,6 +1015,10 @@ class _MemberEditorSheetState extends State<_MemberEditorSheet> {
                           labelText: l10n.memberDeathDateLabel,
                           hintText: 'YYYY-MM-DD',
                           suffixIcon: IconButton(
+                            tooltip: l10n.pick(
+                              vi: 'Chọn ngày mất',
+                              en: 'Select death date',
+                            ),
                             onPressed: () => _pickDate(_deathDateController),
                             icon: const Icon(Icons.calendar_today_outlined),
                           ),

--- a/mobile/befam/lib/features/notifications/presentation/notification_inbox_page.dart
+++ b/mobile/befam/lib/features/notifications/presentation/notification_inbox_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../../core/widgets/app_feedback_states.dart';
 import '../../../l10n/l10n.dart';
 import '../../auth/models/auth_session.dart';
 import '../models/notification_inbox_item.dart';
@@ -198,7 +199,12 @@ class _NotificationInboxPageState extends State<NotificationInboxPage> {
     final colorScheme = Theme.of(context).colorScheme;
 
     if (_isLoading) {
-      return const Center(child: CircularProgressIndicator());
+      return AppLoadingState(
+        message: l10n.pick(
+          vi: 'Đang tải hộp thư thông báo...',
+          en: 'Loading notifications...',
+        ),
+      );
     }
 
     if (!_hasMemberContext) {
@@ -256,9 +262,14 @@ class _NotificationInboxPageState extends State<NotificationInboxPage> {
                   ),
                 const SizedBox(height: 16),
                 if (_isLoadingMore)
-                  const Padding(
+                  Padding(
                     padding: EdgeInsets.symmetric(vertical: 12),
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                    child: AppInlineProgressIndicator(
+                      semanticLabel: l10n.pick(
+                        vi: 'Đang tải thêm thông báo',
+                        en: 'Loading more notifications',
+                      ),
+                    ),
                   )
                 else if (_nextCursor != null)
                   OutlinedButton.icon(
@@ -494,11 +505,16 @@ class _NotificationCard extends StatelessWidget {
                             key: Key('notification-mark-read-${item.id}'),
                             onPressed: isMarkingRead ? null : onMarkAsRead,
                             icon: isMarkingRead
-                                ? const SizedBox(
+                                ? SizedBox(
                                     width: 14,
                                     height: 14,
-                                    child: CircularProgressIndicator(
+                                    child: AppInlineProgressIndicator(
+                                      size: 14,
                                       strokeWidth: 2,
+                                      semanticLabel: l10n.pick(
+                                        vi: 'Đang đánh dấu đã đọc',
+                                        en: 'Marking as read',
+                                      ),
                                     ),
                                   )
                                 : const Icon(Icons.done, size: 18),

--- a/mobile/befam/lib/features/profile/presentation/profile_workspace_page.dart
+++ b/mobile/befam/lib/features/profile/presentation/profile_workspace_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import '../../../core/services/app_locale_controller.dart';
+import '../../../core/widgets/app_feedback_states.dart';
 import '../../../l10n/generated/app_localizations.dart';
 import '../../../l10n/l10n.dart';
 import '../../auth/models/auth_session.dart';
@@ -126,20 +127,14 @@ class _ProfileWorkspacePageState extends State<ProfileWorkspacePage> {
               ListTile(
                 leading: const Icon(Icons.image_outlined),
                 title: Text(
-                  l10n.pick(
-                    vi: 'Xem ảnh hiện tại',
-                    en: 'View current photo',
-                  ),
+                  l10n.pick(vi: 'Xem ảnh hiện tại', en: 'View current photo'),
                 ),
                 onTap: () => Navigator.of(context).pop(_AvatarAction.view),
               ),
               ListTile(
                 leading: const Icon(Icons.file_upload_outlined),
                 title: Text(
-                  l10n.pick(
-                    vi: 'Tải ảnh mới',
-                    en: 'Upload new photo',
-                  ),
+                  l10n.pick(vi: 'Tải ảnh mới', en: 'Upload new photo'),
                 ),
                 onTap: () => Navigator.of(context).pop(_AvatarAction.upload),
               ),
@@ -183,10 +178,7 @@ class _ProfileWorkspacePageState extends State<ProfileWorkspacePage> {
             child: InteractiveViewer(
               minScale: 1,
               maxScale: 4,
-              child: Image.network(
-                profile.avatarUrl!,
-                fit: BoxFit.cover,
-              ),
+              child: Image.network(profile.avatarUrl!, fit: BoxFit.cover),
             ),
           ),
         );
@@ -266,7 +258,12 @@ class _ProfileWorkspacePageState extends State<ProfileWorkspacePage> {
           ),
           body: SafeArea(
             child: _controller.isLoading
-                ? const Center(child: CircularProgressIndicator())
+                ? AppLoadingState(
+                    message: l10n.pick(
+                      vi: 'Đang tải hồ sơ...',
+                      en: 'Loading profile...',
+                    ),
+                  )
                 : !_controller.hasMemberContext
                 ? _ProfileEmptyState(
                     icon: Icons.lock_outline,
@@ -305,6 +302,15 @@ class _ProfileWorkspacePageState extends State<ProfileWorkspacePage> {
                             title: l10n.profileUpdateErrorTitle,
                             description: _controller.errorMessage!,
                             tone: colorScheme.errorContainer,
+                          ),
+                          const SizedBox(height: 8),
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: TextButton.icon(
+                              onPressed: _controller.refresh,
+                              icon: const Icon(Icons.refresh),
+                              label: Text(l10n.profileRefreshAction),
+                            ),
                           ),
                           const SizedBox(height: 20),
                         ],
@@ -1007,10 +1013,7 @@ class _ProfileEditorSheetState extends State<_ProfileEditorSheet> {
 }
 
 class _ProfileSectionCard extends StatelessWidget {
-  const _ProfileSectionCard({
-    required this.title,
-    required this.child,
-  });
+  const _ProfileSectionCard({required this.title, required this.child});
 
   final String title;
   final Widget child;

--- a/mobile/befam/lib/features/relationship/presentation/relationship_inspector_panel.dart
+++ b/mobile/befam/lib/features/relationship/presentation/relationship_inspector_panel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../core/widgets/app_feedback_states.dart';
 import '../../../l10n/generated/app_localizations.dart';
 import '../../../l10n/l10n.dart';
 import '../../auth/models/auth_session.dart';
@@ -352,7 +353,12 @@ class _RelationshipInspectorPanelState
               const SizedBox(height: 16),
             ],
             if (_isLoading)
-              const Center(child: CircularProgressIndicator())
+              AppLoadingState(
+                message: l10n.pick(
+                  vi: 'Đang tải quan hệ...',
+                  en: 'Loading relationships...',
+                ),
+              )
             else ...[
               _RelationshipGroup(
                 title: l10n.relationshipParentsTitle,

--- a/mobile/befam/lib/features/scholarship/presentation/scholarship_workspace_page.dart
+++ b/mobile/befam/lib/features/scholarship/presentation/scholarship_workspace_page.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 
+import '../../../core/widgets/app_feedback_states.dart';
 import '../../auth/models/auth_session.dart';
 import '../models/achievement_submission.dart';
 import '../models/achievement_submission_draft.dart';
@@ -274,7 +275,9 @@ class _ScholarshipWorkspacePageState extends State<ScholarshipWorkspacePage> {
           ),
           body: SafeArea(
             child: _controller.isLoading
-                ? const Center(child: CircularProgressIndicator())
+                ? const AppLoadingState(
+                    message: 'Loading scholarship workspace...',
+                  )
                 : !_controller.permissions.canViewWorkspace
                 ? const Center(
                     child: Padding(

--- a/mobile/befam/test/core/widgets/app_feedback_states_test.dart
+++ b/mobile/befam/test/core/widgets/app_feedback_states_test.dart
@@ -1,0 +1,37 @@
+import 'package:befam/core/widgets/app_feedback_states.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('AppLoadingState shows message and spinner', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: AppLoadingState(message: 'Loading workspace...')),
+      ),
+    );
+
+    expect(find.text('Loading workspace...'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('AppInlineProgressIndicator exposes semantic label', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: AppInlineProgressIndicator(semanticLabel: 'Loading more items'),
+        ),
+      ),
+    );
+
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Semantics &&
+            widget.properties.label == 'Loading more items',
+      ),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- implement Epic: Release Hardening #18 across four stories:
  - REL-RELEASE-001 Accessibility pass (#168)
  - REL-RELEASE-002 Empty/loading/error state audit (#169)
  - REL-RELEASE-005 Store assets checklist (#172)
  - REL-RELEASE-006 Pre-release QA checklist (#173)

## What changed
- added shared accessible feedback widgets:
  - `mobile/befam/lib/core/widgets/app_feedback_states.dart`
- replaced spinner-only loading states with user-readable accessible loading states across major workspaces
- improved accessibility with clearer tooltips/labels for icon-only actions
- added calendar day-tile semantics (solar + lunar + event count context)
- added retry actions on recoverable error states in key workspaces
- added release docs:
  - `docs/05-devops/store-assets-checklist.md`
  - `docs/05-devops/pre-release-qa-checklist.md`
- updated docs/nav:
  - `docs/03-mobile/ui-design.md`
  - `docs/05-devops/ci-cd.md`
  - `mkdocs.yml`

## Validation
- `flutter analyze`
- `flutter test test/core/widgets/app_feedback_states_test.dart test/features/events/event_widget_test.dart test/features/member/member_search_workspace_page_test.dart test/features/genealogy/genealogy_workspace_page_test.dart test/features/notifications/notification_inbox_page_test.dart test/features/relationship/relationship_widget_test.dart`
- `.venv/bin/mkdocs build --strict`
