### PR TITLE
feat: firebase-backed auth sandbox profiles and genealogy production cleanup

### DIFF
--- a/docs/03-mobile/local-development.md
+++ b/docs/03-mobile/local-development.md
@@ -170,3 +170,17 @@ FIREBASE_PROJECT_ID=be-fam-3ab23 \
 FIREBASE_SERVICE_ACCOUNT_JSON=/absolute/path/to/service-account.json \
 npm run seed:demo
 ```
+
+Seed output now includes:
+
+- 1 demo clan with 4 branches
+- 32 members (multi-generation graph, including both `active` and `deceased`)
+- parent-child and spouse relationships for wide tree rendering tests
+- invite records for phone and child OTP flows
+- `debug_login_profiles` collection for local bypass role/security scenarios:
+  - clan admin with existing clan
+  - branch admin with existing clan
+  - member with existing clan
+  - unlinked user
+  - branch admin role without clan linkage
+  - clan admin context before clan creation

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -253,6 +253,11 @@ service cloud.firestore {
       }
     }
 
+    match /debug_login_profiles/{phoneE164} {
+      allow read: if resource.data.isActive == true;
+      allow create, update, delete: if false;
+    }
+
     match /clans/{clanId} {
       allow read: if hasClanAccess(clanId);
       allow create, update: if

--- a/firebase/functions/scripts/seed-demo-data.mjs
+++ b/firebase/functions/scripts/seed-demo-data.mjs
@@ -129,8 +129,10 @@ const members = [
     nickName: 'Cong',
     gender: 'male',
     birthDate: '1941-01-10',
+    deathDate: '2021-11-02',
     phoneE164: '+84901110001',
     generation: 2,
+    status: 'deceased',
     jobTitle: 'To truong',
     bio: 'To tien truyen thong cua dong ho demo.',
   }),
@@ -166,7 +168,9 @@ const members = [
     nickName: 'Mai',
     gender: 'female',
     birthDate: '1962-03-14',
+    deathDate: '2024-02-15',
     generation: 3,
+    status: 'deceased',
     jobTitle: 'Co van van hoa',
   }),
   createMember({
@@ -213,7 +217,9 @@ const members = [
     nickName: 'Sang',
     gender: 'female',
     birthDate: '1992-07-07',
+    deathDate: '2025-07-07',
     generation: 4,
+    status: 'deceased',
     jobTitle: 'Giao vien',
   }),
   createMember({
@@ -802,6 +808,106 @@ const invites = [
   },
 ];
 
+const debugLoginProfiles = [
+  {
+    phoneE164: '+84901234567',
+    scenarioKey: 'clan_admin_existing',
+    title: 'Trưởng tộc đã có gia phả',
+    description: 'CLAN_ADMIN đã liên kết thành viên và có dữ liệu gia phả.',
+    memberId: 'member_demo_parent_001',
+    clanId: 'clan_demo_001',
+    branchId: 'branch_demo_001',
+    primaryRole: 'CLAN_ADMIN',
+    accessMode: 'claimed',
+    linkedAuthUid: true,
+    sortOrder: 10,
+    isActive: true,
+    updatedAt: now,
+    createdAt: now,
+  },
+  {
+    phoneE164: '+84908886655',
+    scenarioKey: 'branch_admin_existing',
+    title: 'Trưởng chi đã có gia phả',
+    description: 'BRANCH_ADMIN đã liên kết và quản lý một chi hiện có.',
+    memberId: 'member_demo_parent_002',
+    clanId: 'clan_demo_001',
+    branchId: 'branch_demo_002',
+    primaryRole: 'BRANCH_ADMIN',
+    accessMode: 'claimed',
+    linkedAuthUid: true,
+    sortOrder: 20,
+    isActive: true,
+    updatedAt: now,
+    createdAt: now,
+  },
+  {
+    phoneE164: '+84907770011',
+    scenarioKey: 'member_existing',
+    title: 'Thành viên thường đã vào gia phả',
+    description: 'MEMBER đã liên kết hồ sơ để kiểm thử quyền người dùng thường.',
+    memberId: 'member_demo_elder_001',
+    clanId: 'clan_demo_001',
+    branchId: 'branch_demo_001',
+    primaryRole: 'MEMBER',
+    accessMode: 'claimed',
+    linkedAuthUid: true,
+    sortOrder: 30,
+    isActive: true,
+    updatedAt: now,
+    createdAt: now,
+  },
+  {
+    phoneE164: '+84906660022',
+    scenarioKey: 'user_unlinked',
+    title: 'User chưa vào gia phả nào',
+    description: 'Tài khoản chưa liên kết member/clan để kiểm thử onboarding.',
+    memberId: null,
+    clanId: null,
+    branchId: null,
+    primaryRole: null,
+    accessMode: 'unlinked',
+    linkedAuthUid: false,
+    sortOrder: 40,
+    isActive: true,
+    updatedAt: now,
+    createdAt: now,
+  },
+  {
+    phoneE164: '+84905550033',
+    scenarioKey: 'branch_admin_unlinked',
+    title: 'Trưởng chi chưa gắn gia phả',
+    description:
+      'Role BRANCH_ADMIN nhưng chưa gắn clan/branch để kiểm thử phân quyền.',
+    memberId: null,
+    clanId: null,
+    branchId: null,
+    primaryRole: 'BRANCH_ADMIN',
+    accessMode: 'unlinked',
+    linkedAuthUid: false,
+    sortOrder: 50,
+    isActive: true,
+    updatedAt: now,
+    createdAt: now,
+  },
+  {
+    phoneE164: '+84909990001',
+    scenarioKey: 'clan_admin_uninitialized',
+    title: 'Trưởng tộc chưa tạo gia phả',
+    description: 'CLAN_ADMIN có context tạo clan mới nhưng chưa có dữ liệu.',
+    memberId: null,
+    clanId: 'clan_onboarding_001',
+    branchId: null,
+    primaryRole: 'CLAN_ADMIN',
+    accessMode: 'claimed',
+    linkedAuthUid: true,
+    sortOrder: 60,
+    isActive: true,
+    updatedAt: now,
+    createdAt: now,
+  },
+];
+
 async function seed() {
   const batch = db.batch();
 
@@ -828,6 +934,11 @@ async function seed() {
     batch.set(ref, invite, { merge: true });
   }
 
+  for (const profile of debugLoginProfiles) {
+    const ref = db.collection('debug_login_profiles').doc(profile.phoneE164);
+    batch.set(ref, profile, { merge: true });
+  }
+
   await batch.commit();
 
   console.log('Seeded extended demo clan data successfully.');
@@ -837,6 +948,7 @@ async function seed() {
   console.log(`Branches: ${branches.length}`);
   console.log(`Relationships: ${relationships.length}`);
   console.log(`Invites: ${invites.length}`);
+  console.log(`Debug login profiles: ${debugLoginProfiles.length}`);
 }
 
 seed().catch((error) => {

--- a/mobile/befam/lib/features/auth/presentation/auth_controller.dart
+++ b/mobile/befam/lib/features/auth/presentation/auth_controller.dart
@@ -152,6 +152,10 @@ class AuthController extends ChangeNotifier {
   }
 
   Future<void> signInWithLocalBypass() async {
+    await signInWithLocalBypassPhone(_localBypassPhoneE164);
+  }
+
+  Future<void> signInWithLocalBypassPhone(String phoneE164) async {
     if (!canUseLocalBypass || isBusy) {
       return;
     }
@@ -168,7 +172,7 @@ class AuthController extends ChangeNotifier {
     );
 
     await _startOtpRequest(
-      () => _authGateway.requestPhoneOtp(_localBypassPhoneE164),
+      () => _authGateway.requestPhoneOtp(phoneE164.trim()),
       method: AuthEntryMethod.phone,
     );
 

--- a/mobile/befam/lib/features/auth/presentation/auth_experience.dart
+++ b/mobile/befam/lib/features/auth/presentation/auth_experience.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -140,7 +141,7 @@ class _AuthScaffold extends StatelessWidget {
                   onChildSelected: () {
                     controller.selectLoginMethod(AuthEntryMethod.child);
                   },
-                  onLocalBypassSelected: controller.signInWithLocalBypass,
+                  onLocalBypassSelected: controller.signInWithLocalBypassPhone,
                   onPrivacyConsentChanged: (accepted) {
                     unawaited(controller.setPrivacyPolicyAccepted(accepted));
                   },
@@ -252,7 +253,10 @@ class _AuthHero extends StatelessWidget {
           ),
           const SizedBox(height: 12),
           Text(
-            l10n.authHeroLiveDescription,
+            l10n.pick(
+              vi: 'Đăng nhập bằng số điện thoại hoặc mã trẻ em để vào đúng không gian gia phả và tiếp tục ngay sau khi xác minh OTP.',
+              en: 'Sign in with phone or child ID to enter the correct genealogy workspace and continue right after OTP verification.',
+            ),
             style: theme.textTheme.bodyLarge?.copyWith(
               color: colorScheme.onPrimary.withValues(alpha: 0.92),
             ),
@@ -326,76 +330,113 @@ class _LoginMethodSelectionCard extends StatelessWidget {
   final bool hasAcceptedPrivacyPolicy;
   final VoidCallback onPhoneSelected;
   final VoidCallback onChildSelected;
-  final Future<void> Function() onLocalBypassSelected;
+  final Future<void> Function(String phoneE164) onLocalBypassSelected;
   final ValueChanged<bool> onPrivacyConsentChanged;
   final VoidCallback onViewPrivacyPolicy;
 
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    final sandboxPresets = <_SandboxLoginPreset>[
+      _SandboxLoginPreset(
+        scenarioKey: 'clan_admin_existing',
+        phoneE164: '+84901234567',
+        title: l10n.pick(
+          vi: 'Trưởng tộc đã có gia phả',
+          en: 'Clan lead in clan',
+        ),
+        description: l10n.pick(
+          vi: 'Role CLAN_ADMIN, đã liên kết thành viên và đã có dữ liệu gia phả.',
+          en: 'CLAN_ADMIN role, linked member, existing clan data.',
+        ),
+        icon: Icons.admin_panel_settings_outlined,
+      ),
+      _SandboxLoginPreset(
+        scenarioKey: 'branch_admin_existing',
+        phoneE164: '+84908886655',
+        title: l10n.pick(
+          vi: 'Trưởng chi đã có gia phả',
+          en: 'Branch lead in clan',
+        ),
+        description: l10n.pick(
+          vi: 'Role BRANCH_ADMIN, đã liên kết vào chi hiện có.',
+          en: 'BRANCH_ADMIN role, linked to an existing branch.',
+        ),
+        icon: Icons.account_tree_outlined,
+      ),
+      _SandboxLoginPreset(
+        scenarioKey: 'member_existing',
+        phoneE164: '+84907770011',
+        title: l10n.pick(
+          vi: 'Thành viên thường đã vào gia phả',
+          en: 'Member already in clan',
+        ),
+        description: l10n.pick(
+          vi: 'Role MEMBER, đã liên kết hồ sơ trong gia phả.',
+          en: 'MEMBER role with a linked profile in clan data.',
+        ),
+        icon: Icons.person_outline,
+      ),
+      _SandboxLoginPreset(
+        scenarioKey: 'user_unlinked',
+        phoneE164: '+84906660022',
+        title: l10n.pick(
+          vi: 'Người dùng chưa vào gia phả nào',
+          en: 'User not in any clan',
+        ),
+        description: l10n.pick(
+          vi: 'Trạng thái unlinked để kiểm thử onboarding ban đầu.',
+          en: 'Unlinked state for first-time onboarding tests.',
+        ),
+        icon: Icons.person_add_alt_1_outlined,
+      ),
+      _SandboxLoginPreset(
+        scenarioKey: 'branch_admin_unlinked',
+        phoneE164: '+84905550033',
+        title: l10n.pick(
+          vi: 'Set role Trưởng chi nhưng chưa gắn gia phả',
+          en: 'Branch lead role without clan',
+        ),
+        description: l10n.pick(
+          vi: 'Role BRANCH_ADMIN nhưng không có clan/branch context.',
+          en: 'BRANCH_ADMIN role with no clan/branch context.',
+        ),
+        icon: Icons.gpp_maybe_outlined,
+      ),
+      _SandboxLoginPreset(
+        scenarioKey: 'clan_admin_uninitialized',
+        phoneE164: '+84909990001',
+        title: l10n.pick(
+          vi: 'Trưởng tộc chưa tạo gia phả',
+          en: 'Clan lead before clan creation',
+        ),
+        description: l10n.pick(
+          vi: 'Role CLAN_ADMIN có context tạo clan nhưng chưa có dữ liệu.',
+          en: 'CLAN_ADMIN role ready to create clan with no seeded profile.',
+        ),
+        icon: Icons.rocket_launch_outlined,
+      ),
+    ];
 
     return Column(
       children: [
         const _QuickBenefitsCard(),
         const SizedBox(height: 16),
-        Card(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                CheckboxListTile(
-                  value: hasAcceptedPrivacyPolicy,
-                  onChanged: isBusy
-                      ? null
-                      : (value) => onPrivacyConsentChanged(value ?? false),
-                  controlAffinity: ListTileControlAffinity.leading,
-                  contentPadding: EdgeInsets.zero,
-                  title: Text(
-                    l10n.pick(
-                      vi: 'Tôi đã đọc và đồng ý với Chính sách quyền riêng tư của BeFam.',
-                      en: 'I have read and agree to BeFam Privacy Policy.',
-                    ),
-                  ),
-                ),
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: TextButton.icon(
-                    onPressed: onViewPrivacyPolicy,
-                    icon: const Icon(Icons.policy_outlined),
-                    label: Text(
-                      l10n.pick(
-                        vi: 'Xem Chính sách quyền riêng tư',
-                        en: 'View Privacy Policy',
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
+        _PrivacyPolicyConsentCard(
+          isBusy: isBusy,
+          hasAcceptedPrivacyPolicy: hasAcceptedPrivacyPolicy,
+          onChanged: onPrivacyConsentChanged,
+          onViewPrivacyPolicy: onViewPrivacyPolicy,
         ),
-        if (showLocalBypass) ...[
-          const SizedBox(height: 16),
-          _MethodCard(
-            title: l10n.authSandboxChip,
-            description: l10n.authPhoneHelperSandbox,
-            icon: Icons.bolt_rounded,
-            buttonLabel: l10n.authContinueNow,
-            onPressed: isBusy || !hasAcceptedPrivacyPolicy
-                ? null
-                : () {
-                    unawaited(onLocalBypassSelected());
-                  },
-          ),
-        ],
         const SizedBox(height: 16),
         _MethodCard(
           title: l10n.authMethodPhoneTitle,
           description: l10n.authMethodPhoneDescription,
           icon: Icons.phone_iphone,
           buttonLabel: l10n.authMethodPhoneButton,
-          onPressed: hasAcceptedPrivacyPolicy ? onPhoneSelected : null,
+          onPressed: isBusy || !hasAcceptedPrivacyPolicy
+              ? null
+              : onPhoneSelected,
         ),
         const SizedBox(height: 16),
         _MethodCard(
@@ -403,9 +444,400 @@ class _LoginMethodSelectionCard extends StatelessWidget {
           description: l10n.authMethodChildDescription,
           icon: Icons.child_care,
           buttonLabel: l10n.authMethodChildButton,
-          onPressed: hasAcceptedPrivacyPolicy ? onChildSelected : null,
+          onPressed: isBusy || !hasAcceptedPrivacyPolicy
+              ? null
+              : onChildSelected,
         ),
+        if (showLocalBypass) ...[
+          const SizedBox(height: 16),
+          _SandboxEnvironmentCard(
+            isBusy: isBusy,
+            hasAcceptedPrivacyPolicy: hasAcceptedPrivacyPolicy,
+            title: l10n.authSandboxChip,
+            description: l10n.authPhoneHelperSandbox,
+            presets: sandboxPresets,
+            onSelected: onLocalBypassSelected,
+          ),
+        ],
       ],
+    );
+  }
+}
+
+class _PrivacyPolicyConsentCard extends StatelessWidget {
+  const _PrivacyPolicyConsentCard({
+    required this.isBusy,
+    required this.hasAcceptedPrivacyPolicy,
+    required this.onChanged,
+    required this.onViewPrivacyPolicy,
+  });
+
+  final bool isBusy;
+  final bool hasAcceptedPrivacyPolicy;
+  final ValueChanged<bool> onChanged;
+  final VoidCallback onViewPrivacyPolicy;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Card(
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: isBusy ? null : () => onChanged(!hasAcceptedPrivacyPolicy),
+        child: Padding(
+          padding: const EdgeInsets.all(18),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: colorScheme.primaryContainer.withValues(
+                        alpha: 0.65,
+                      ),
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                    child: Icon(
+                      hasAcceptedPrivacyPolicy
+                          ? Icons.verified_user_outlined
+                          : Icons.shield_outlined,
+                      color: colorScheme.primary,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      l10n.pick(
+                        vi: 'Tôi đã đọc và đồng ý với Chính sách quyền riêng tư của BeFam.',
+                        en: 'I have read and agree to BeFam Privacy Policy.',
+                      ),
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Checkbox(
+                    value: hasAcceptedPrivacyPolicy,
+                    onChanged: isBusy
+                        ? null
+                        : (value) => onChanged(value ?? false),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Text(
+                l10n.pick(
+                  vi: 'BeFam chỉ dùng dữ liệu đăng nhập để xác thực và bảo vệ quyền truy cập dữ liệu gia phả đúng phạm vi.',
+                  en: 'BeFam uses sign-in data only for authentication and to protect scoped genealogy access.',
+                ),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurface.withValues(alpha: 0.8),
+                ),
+              ),
+              const SizedBox(height: 10),
+              TextButton.icon(
+                onPressed: onViewPrivacyPolicy,
+                icon: const Icon(Icons.policy_outlined),
+                label: Text(
+                  l10n.pick(
+                    vi: 'Xem Chính sách quyền riêng tư',
+                    en: 'View Privacy Policy',
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SandboxLoginPreset {
+  const _SandboxLoginPreset({
+    required this.scenarioKey,
+    required this.phoneE164,
+    required this.title,
+    required this.description,
+    required this.icon,
+  });
+
+  final String scenarioKey;
+  final String phoneE164;
+  final String title;
+  final String description;
+  final IconData icon;
+
+  _SandboxLoginPreset copyWith({
+    String? phoneE164,
+    String? title,
+    String? description,
+    IconData? icon,
+  }) {
+    return _SandboxLoginPreset(
+      scenarioKey: scenarioKey,
+      phoneE164: phoneE164 ?? this.phoneE164,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      icon: icon ?? this.icon,
+    );
+  }
+}
+
+class _RemoteSandboxProfile {
+  const _RemoteSandboxProfile({
+    required this.scenarioKey,
+    required this.phoneE164,
+    required this.title,
+    required this.description,
+    required this.isActive,
+  });
+
+  final String scenarioKey;
+  final String phoneE164;
+  final String title;
+  final String description;
+  final bool isActive;
+
+  factory _RemoteSandboxProfile.fromDoc(
+    String docId,
+    Map<String, dynamic> data,
+  ) {
+    final phone = (data['phoneE164'] as String? ?? docId).trim();
+    final scenarioKey = (data['scenarioKey'] as String? ?? docId).trim();
+    final title = (data['title'] as String? ?? scenarioKey).trim();
+    final description = (data['description'] as String? ?? phone).trim();
+
+    return _RemoteSandboxProfile(
+      scenarioKey: scenarioKey.isEmpty ? docId : scenarioKey,
+      phoneE164: phone,
+      title: title.isEmpty ? scenarioKey : title,
+      description: description.isEmpty ? phone : description,
+      isActive: data['isActive'] != false,
+    );
+  }
+}
+
+class _SandboxEnvironmentCard extends StatefulWidget {
+  const _SandboxEnvironmentCard({
+    required this.isBusy,
+    required this.hasAcceptedPrivacyPolicy,
+    required this.title,
+    required this.description,
+    required this.presets,
+    required this.onSelected,
+  });
+
+  final bool isBusy;
+  final bool hasAcceptedPrivacyPolicy;
+  final String title;
+  final String description;
+  final List<_SandboxLoginPreset> presets;
+  final Future<void> Function(String phoneE164) onSelected;
+
+  @override
+  State<_SandboxEnvironmentCard> createState() =>
+      _SandboxEnvironmentCardState();
+}
+
+class _SandboxEnvironmentCardState extends State<_SandboxEnvironmentCard> {
+  late final Future<List<_RemoteSandboxProfile>> _remoteProfilesFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _remoteProfilesFuture = _loadRemoteProfiles();
+  }
+
+  Future<List<_RemoteSandboxProfile>> _loadRemoteProfiles() async {
+    try {
+      final snapshot = await FirebaseFirestore.instance
+          .collection('debug_login_profiles')
+          .orderBy('sortOrder')
+          .get();
+
+      final profiles = snapshot.docs
+          .map((doc) => _RemoteSandboxProfile.fromDoc(doc.id, doc.data()))
+          .where((profile) => profile.isActive && profile.phoneE164.isNotEmpty)
+          .toList(growable: false);
+      return profiles;
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  List<_SandboxLoginPreset> _resolvedPresets(
+    List<_RemoteSandboxProfile> remote,
+  ) {
+    if (remote.isEmpty) {
+      return widget.presets;
+    }
+
+    final fallbackByScenario = {
+      for (final preset in widget.presets) preset.scenarioKey: preset,
+    };
+    final resolved = <_SandboxLoginPreset>[];
+    final usedScenarioKeys = <String>{};
+
+    for (final profile in remote) {
+      final fallback = fallbackByScenario[profile.scenarioKey];
+      if (fallback != null) {
+        resolved.add(fallback.copyWith(phoneE164: profile.phoneE164));
+        usedScenarioKeys.add(profile.scenarioKey);
+        continue;
+      }
+      resolved.add(
+        _SandboxLoginPreset(
+          scenarioKey: profile.scenarioKey,
+          phoneE164: profile.phoneE164,
+          title: profile.title,
+          description: profile.description,
+          icon: Icons.person_pin_circle_outlined,
+        ),
+      );
+    }
+
+    for (final fallback in widget.presets) {
+      if (!usedScenarioKeys.contains(fallback.scenarioKey)) {
+        resolved.add(fallback);
+      }
+    }
+    return resolved;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final l10n = context.l10n;
+
+    return FutureBuilder<List<_RemoteSandboxProfile>>(
+      future: _remoteProfilesFuture,
+      builder: (context, snapshot) {
+        final presets = _resolvedPresets(snapshot.data ?? const []);
+        final isLoading = snapshot.connectionState == ConnectionState.waiting;
+
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CircleAvatar(
+                  radius: 24,
+                  backgroundColor: colorScheme.primaryContainer,
+                  child: const Icon(Icons.bolt_rounded),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  widget.title,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(widget.description, style: theme.textTheme.bodyLarge),
+                if (isLoading) ...[
+                  const SizedBox(height: 14),
+                  const LinearProgressIndicator(minHeight: 3),
+                ],
+                const SizedBox(height: 16),
+                for (var index = 0; index < presets.length; index++) ...[
+                  _SandboxPresetTile(
+                    preset: presets[index],
+                    enabled: widget.hasAcceptedPrivacyPolicy && !widget.isBusy,
+                    onTap: () {
+                      unawaited(widget.onSelected(presets[index].phoneE164));
+                    },
+                  ),
+                  if (index < presets.length - 1) const SizedBox(height: 10),
+                ],
+                const SizedBox(height: 14),
+                Text(
+                  l10n.pick(
+                    vi: 'Profile thử nghiệm có thể lấy từ Firebase nếu có cấu hình; nếu không sẽ dùng danh sách mặc định.',
+                    en: 'Test profiles can be loaded from Firebase when configured; otherwise fallback presets are used.',
+                  ),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurface.withValues(alpha: 0.7),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SandboxPresetTile extends StatelessWidget {
+  const _SandboxPresetTile({
+    required this.preset,
+    required this.enabled,
+    required this.onTap,
+  });
+
+  final _SandboxLoginPreset preset;
+  final bool enabled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: enabled
+            ? colorScheme.surfaceContainerHighest.withValues(alpha: 0.6)
+            : colorScheme.surfaceContainerHighest.withValues(alpha: 0.35),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(14, 12, 12, 12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              preset.icon,
+              size: 20,
+              color: enabled
+                  ? colorScheme.primary
+                  : colorScheme.onSurface.withValues(alpha: 0.4),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    preset.title,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(preset.description, style: theme.textTheme.bodySmall),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            FilledButton.tonal(
+              onPressed: enabled ? onTap : null,
+              child: Text(context.l10n.authContinueNow),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -1027,7 +1459,10 @@ class _QuickBenefitsCard extends StatelessWidget {
                 ),
                 _BenefitChip(
                   icon: Icons.verified_user_outlined,
-                  label: l10n.authQuickBenefitLive,
+                  label: l10n.pick(
+                    vi: 'Xác thực OTP bảo mật',
+                    en: 'Secure OTP verification',
+                  ),
                 ),
               ],
             ),
@@ -1129,6 +1564,8 @@ class _AuthFormCard extends StatelessWidget {
 
 void _showPrivacyPolicy(BuildContext context) {
   final l10n = context.l10n;
+  final theme = Theme.of(context);
+  final colorScheme = theme.colorScheme;
   showModalBottomSheet<void>(
     context: context,
     useSafeArea: true,
@@ -1146,43 +1583,66 @@ void _showPrivacyPolicy(BuildContext context) {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                l10n.pick(
-                  vi: 'Chính sách quyền riêng tư',
-                  en: 'Privacy Policy',
-                ),
-                style: Theme.of(
-                  context,
-                ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800),
+              Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: colorScheme.primaryContainer.withValues(
+                        alpha: 0.7,
+                      ),
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                    child: Icon(
+                      Icons.privacy_tip_outlined,
+                      color: colorScheme.primary,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      l10n.pick(
+                        vi: 'Chính sách quyền riêng tư',
+                        en: 'Privacy Policy',
+                      ),
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ),
+                ],
               ),
               const SizedBox(height: 12),
-              Text(
-                l10n.pick(
-                  vi: 'BeFam chỉ sử dụng số điện thoại hoặc mã định danh trẻ em cho mục đích xác thực và liên kết hồ sơ thành viên thuộc dòng tộc của bạn.',
-                  en: 'BeFam uses your phone number or child identifier only for authentication and linking your member profile within your family clan.',
+              _PolicyInfoTile(
+                icon: Icons.lock_outline,
+                text: l10n.pick(
+                  vi: 'BeFam chỉ sử dụng số điện thoại hoặc mã định danh trẻ em để xác thực và liên kết hồ sơ thành viên.',
+                  en: 'BeFam uses phone number or child identifier only for authentication and profile linking.',
                 ),
-                style: Theme.of(context).textTheme.bodyMedium,
               ),
               const SizedBox(height: 10),
-              Text(
-                l10n.pick(
-                  vi: 'Dữ liệu gia phả được giới hạn theo quyền truy cập họ tộc/chi. Bạn không thể xem dữ liệu của dòng tộc khác nếu không có quyền.',
-                  en: 'Genealogy data is scoped by clan/branch access controls. You cannot view data from other clans without permission.',
+              _PolicyInfoTile(
+                icon: Icons.admin_panel_settings_outlined,
+                text: l10n.pick(
+                  vi: 'Dữ liệu gia phả được giới hạn theo quyền họ tộc/chi. Không có quyền thì không thể xem dòng tộc khác.',
+                  en: 'Genealogy data is restricted by clan/branch permissions. No permission, no cross-clan access.',
                 ),
-                style: Theme.of(context).textTheme.bodyMedium,
               ),
               const SizedBox(height: 10),
-              Text(
-                l10n.pick(
+              _PolicyInfoTile(
+                icon: Icons.check_circle_outline,
+                text: l10n.pick(
                   vi: 'Khi tiếp tục đăng nhập, bạn xác nhận đã đọc và đồng ý với việc xử lý dữ liệu theo chính sách này.',
-                  en: 'By continuing sign-in, you confirm that you have read and accepted this data processing policy.',
+                  en: 'By continuing sign-in, you confirm that you have read and accepted this policy.',
                 ),
-                style: Theme.of(context).textTheme.bodyMedium,
               ),
               const SizedBox(height: 16),
-              FilledButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: Text(l10n.pick(vi: 'Đã hiểu', en: 'Understood')),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: Text(l10n.pick(vi: 'Đã hiểu', en: 'Understood')),
+                ),
               ),
             ],
           ),
@@ -1190,4 +1650,33 @@ void _showPrivacyPolicy(BuildContext context) {
       );
     },
   );
+}
+
+class _PolicyInfoTile extends StatelessWidget {
+  const _PolicyInfoTile({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.45),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      padding: const EdgeInsets.all(12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: colorScheme.primary),
+          const SizedBox(width: 10),
+          Expanded(child: Text(text, style: theme.textTheme.bodyMedium)),
+        ],
+      ),
+    );
+  }
 }

--- a/mobile/befam/lib/features/auth/services/debug_auth_gateway.dart
+++ b/mobile/befam/lib/features/auth/services/debug_auth_gateway.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 import '../models/auth_entry_method.dart';
@@ -13,8 +14,11 @@ import 'auth_gateway.dart';
 import 'phone_number_formatter.dart';
 
 class DebugAuthGateway implements AuthGateway {
+  DebugAuthGateway({FirebaseFirestore? firestore}) : _firestore = firestore;
+
   static const String _debugOtp = '123456';
   static const Duration _debugDelay = Duration(milliseconds: 450);
+  final FirebaseFirestore? _firestore;
 
   static const Map<String, ResolvedChildAccess> _childDirectory = {
     'BEFAM-CHILD-001': ResolvedChildAccess(
@@ -38,6 +42,15 @@ class DebugAuthGateway implements AuthGateway {
   };
 
   static const Map<String, MemberAccessContext> _phoneDirectory = {
+    '+84909990001': MemberAccessContext(
+      memberId: null,
+      displayName: 'Truong Toc Chua Tao Gia Pha',
+      clanId: 'clan_onboarding_001',
+      branchId: null,
+      primaryRole: 'CLAN_ADMIN',
+      accessMode: AuthMemberAccessMode.claimed,
+      linkedAuthUid: true,
+    ),
     '+84901234567': MemberAccessContext(
       memberId: 'member_demo_parent_001',
       displayName: 'Nguyen Minh',
@@ -56,6 +69,25 @@ class DebugAuthGateway implements AuthGateway {
       accessMode: AuthMemberAccessMode.claimed,
       linkedAuthUid: true,
     ),
+    '+84907770011': MemberAccessContext(
+      memberId: 'member_demo_elder_001',
+      displayName: 'Ong Bao',
+      clanId: 'clan_demo_001',
+      branchId: 'branch_demo_002',
+      primaryRole: 'MEMBER',
+      accessMode: AuthMemberAccessMode.claimed,
+      linkedAuthUid: true,
+    ),
+    '+84906660022': MemberAccessContext.unlinked(displayName: 'Khach Moi'),
+    '+84905550033': MemberAccessContext(
+      memberId: null,
+      displayName: 'Truong Chi Chua Gan Gia Pha',
+      clanId: null,
+      branchId: null,
+      primaryRole: 'BRANCH_ADMIN',
+      accessMode: AuthMemberAccessMode.unlinked,
+      linkedAuthUid: false,
+    ),
   };
 
   @override
@@ -69,15 +101,15 @@ class DebugAuthGateway implements AuthGateway {
   @override
   Future<AuthOtpRequestResult> requestPhoneOtp(String phoneE164) async {
     await Future<void>.delayed(_debugDelay);
-    final memberAccess = _phoneDirectory[phoneE164];
+    final memberAccess = await _memberAccessForPhone(phoneE164);
     return AuthOtpRequestResult.challenge(
       PendingOtpChallenge(
         loginMethod: AuthEntryMethod.phone,
         phoneE164: phoneE164,
         maskedDestination: PhoneNumberFormatter.mask(phoneE164),
         verificationId: 'debug-phone-$phoneE164',
-        memberId: memberAccess?.memberId,
-        displayName: memberAccess?.displayName ?? 'BeFam Member',
+        memberId: memberAccess.memberId,
+        displayName: memberAccess.displayName ?? 'BeFam Member',
         debugOtpHint: _debugOtp,
       ),
     );
@@ -132,21 +164,20 @@ class DebugAuthGateway implements AuthGateway {
       );
     }
 
+    final memberAccess = await _memberAccessFor(challenge);
     return AuthSession(
       uid: 'debug:${challenge.phoneE164}',
       loginMethod: challenge.loginMethod,
       phoneE164: challenge.phoneE164,
       displayName:
-          _memberAccessFor(challenge).displayName ??
-          challenge.displayName ??
-          'BeFam Member',
+          memberAccess.displayName ?? challenge.displayName ?? 'BeFam Member',
       childIdentifier: challenge.childIdentifier,
-      memberId: _memberAccessFor(challenge).memberId ?? challenge.memberId,
-      clanId: _memberAccessFor(challenge).clanId,
-      branchId: _memberAccessFor(challenge).branchId,
-      primaryRole: _memberAccessFor(challenge).primaryRole,
-      accessMode: _memberAccessFor(challenge).accessMode,
-      linkedAuthUid: _memberAccessFor(challenge).linkedAuthUid,
+      memberId: memberAccess.memberId ?? challenge.memberId,
+      clanId: memberAccess.clanId,
+      branchId: memberAccess.branchId,
+      primaryRole: memberAccess.primaryRole,
+      accessMode: memberAccess.accessMode,
+      linkedAuthUid: memberAccess.linkedAuthUid,
       isSandbox: true,
       signedInAtIso: DateTime.now().toIso8601String(),
     );
@@ -155,7 +186,9 @@ class DebugAuthGateway implements AuthGateway {
   @override
   Future<void> signOut() async {}
 
-  MemberAccessContext _memberAccessFor(PendingOtpChallenge challenge) {
+  Future<MemberAccessContext> _memberAccessFor(
+    PendingOtpChallenge challenge,
+  ) async {
     if (challenge.loginMethod == AuthEntryMethod.child) {
       final resolved = _childDirectory[challenge.childIdentifier];
       return MemberAccessContext(
@@ -169,7 +202,58 @@ class DebugAuthGateway implements AuthGateway {
       );
     }
 
-    return _phoneDirectory[challenge.phoneE164] ??
-        MemberAccessContext.unlinked(displayName: challenge.displayName);
+    return _memberAccessForPhone(challenge.phoneE164, challenge.displayName);
+  }
+
+  Future<MemberAccessContext> _memberAccessForPhone(
+    String phoneE164, [
+    String? fallbackDisplayName,
+  ]) async {
+    final remote = await _loadRemoteProfile(phoneE164);
+    if (remote != null) {
+      return remote;
+    }
+    return _phoneDirectory[phoneE164] ??
+        MemberAccessContext.unlinked(displayName: fallbackDisplayName);
+  }
+
+  Future<MemberAccessContext?> _loadRemoteProfile(String phoneE164) async {
+    try {
+      final snapshot = await (_firestore ?? FirebaseFirestore.instance)
+          .collection('debug_login_profiles')
+          .doc(phoneE164)
+          .get();
+      final data = snapshot.data();
+      if (data == null || data['isActive'] == false) {
+        return null;
+      }
+
+      final rawMode = (data['accessMode'] as String?)?.trim().toLowerCase();
+      final accessMode = switch (rawMode) {
+        'claimed' => AuthMemberAccessMode.claimed,
+        'child' => AuthMemberAccessMode.child,
+        _ => AuthMemberAccessMode.unlinked,
+      };
+
+      return MemberAccessContext(
+        memberId: (data['memberId'] as String?)?.trim().isEmpty == true
+            ? null
+            : (data['memberId'] as String?),
+        displayName: (data['displayName'] as String?)?.trim(),
+        clanId: (data['clanId'] as String?)?.trim().isEmpty == true
+            ? null
+            : (data['clanId'] as String?),
+        branchId: (data['branchId'] as String?)?.trim().isEmpty == true
+            ? null
+            : (data['branchId'] as String?),
+        primaryRole: (data['primaryRole'] as String?)?.trim().isEmpty == true
+            ? null
+            : (data['primaryRole'] as String?),
+        accessMode: accessMode,
+        linkedAuthUid: data['linkedAuthUid'] == true,
+      );
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/mobile/befam/lib/features/genealogy/presentation/genealogy_workspace_page.dart
+++ b/mobile/befam/lib/features/genealogy/presentation/genealogy_workspace_page.dart
@@ -379,6 +379,7 @@ class _GenealogyWorkspacePageState extends State<GenealogyWorkspacePage>
                                           _openMemberDetailSheet(
                                             member: member,
                                             graph: segment.graph,
+                                            branches: segment.branches,
                                           ),
                                         );
                                       },
@@ -395,9 +396,10 @@ class _GenealogyWorkspacePageState extends State<GenealogyWorkspacePage>
                                           viewport: viewport,
                                         );
                                         unawaited(
-                                          _openMemberDetailSheet(
+                                          _openMemberDetailPage(
                                             member: member,
                                             graph: segment.graph,
+                                            branches: segment.branches,
                                           ),
                                         );
                                       },
@@ -408,20 +410,6 @@ class _GenealogyWorkspacePageState extends State<GenealogyWorkspacePage>
                               ],
                             ),
                           ),
-                        ),
-                      ),
-                      Positioned(
-                        right: 12,
-                        bottom: 12,
-                        child: _TreeMetricCard(
-                          l10n: l10n,
-                          members: scene.visibleMemberIds.length,
-                          edges:
-                              scene.parentChildEdges.length +
-                              scene.spouseEdges.length,
-                          latestLayoutMs: scene.layoutProfile.latestMs,
-                          averageLayoutMs: scene.layoutProfile.averageMs,
-                          peakLayoutMs: scene.layoutProfile.peakMs,
                         ),
                       ),
                       Positioned(
@@ -477,6 +465,12 @@ class _GenealogyWorkspacePageState extends State<GenealogyWorkspacePage>
         _selectedMemberId = _selectedMemberId ?? initialFocus;
         _invalidateTreeSceneCache();
       });
+
+      // Cached snapshots keep the workspace responsive, then we immediately
+      // reconcile against Firestore to avoid stale production data.
+      if (allowCached && segment.fromCache) {
+        unawaited(_load(allowCached: false));
+      }
     } catch (error) {
       if (!mounted) {
         return;
@@ -752,20 +746,21 @@ class _GenealogyWorkspacePageState extends State<GenealogyWorkspacePage>
     required GenealogyGraph graph,
     required String rootId,
   }) {
+    final allMembers = graph.membersById.keys.toSet();
     if (rootId.isEmpty || !graph.membersById.containsKey(rootId)) {
-      return graph.membersById.keys.toSet();
+      return _applyVisibilityFilters(allMembers, rootId: rootId);
     }
 
-    final visible = <String>{rootId};
+    final visibleFromFocus = <String>{rootId};
     var ancestors = <String>{rootId};
     for (var level = 0; level < _ancestorDepth; level++) {
       final next = <String>{};
       for (final memberId in ancestors) {
         for (final parentId in graph.parentsOf(memberId)) {
-          if (visible.add(parentId)) {
+          if (visibleFromFocus.add(parentId)) {
             next.add(parentId);
           }
-          visible.addAll(graph.spousesOf(parentId));
+          visibleFromFocus.addAll(graph.spousesOf(parentId));
         }
       }
       ancestors = next;
@@ -779,10 +774,10 @@ class _GenealogyWorkspacePageState extends State<GenealogyWorkspacePage>
       final next = <String>{};
       for (final memberId in descendants) {
         for (final childId in graph.childrenOf(memberId)) {
-          if (visible.add(childId)) {
+          if (visibleFromFocus.add(childId)) {
             next.add(childId);
           }
-          visible.addAll(graph.spousesOf(childId));
+          visibleFromFocus.addAll(graph.spousesOf(childId));
         }
       }
       descendants = next;
@@ -791,16 +786,31 @@ class _GenealogyWorkspacePageState extends State<GenealogyWorkspacePage>
       }
     }
 
-    for (final memberId in visible.toList()) {
-      visible.addAll(graph.spousesOf(memberId));
+    for (final memberId in visibleFromFocus.toList()) {
+      visibleFromFocus.addAll(graph.spousesOf(memberId));
     }
 
+    final shouldShowScopeCoverage =
+        _displayPreset == _TreeDisplayPreset.coverage;
+    final baseVisible = shouldShowScopeCoverage ? allMembers : visibleFromFocus;
+    return _applyVisibilityFilters(baseVisible, rootId: rootId);
+  }
+
+  Set<String> _applyVisibilityFilters(
+    Set<String> baseVisible, {
+    required String rootId,
+  }) {
     if (_branchFilterId == null && _statusFilter == _MemberStatusFilter.all) {
-      return visible;
+      return baseVisible;
+    }
+
+    final graph = _segment?.graph;
+    if (graph == null) {
+      return baseVisible;
     }
 
     final filtered = <String>{};
-    for (final memberId in visible) {
+    for (final memberId in baseVisible) {
       final member = graph.membersById[memberId];
       if (member == null) {
         continue;
@@ -810,15 +820,15 @@ class _GenealogyWorkspacePageState extends State<GenealogyWorkspacePage>
       }
     }
 
-    if (rootId.isNotEmpty && visible.contains(rootId)) {
+    if (rootId.isNotEmpty && baseVisible.contains(rootId)) {
       filtered.add(rootId);
     }
-    if (_selectedMemberId != null && visible.contains(_selectedMemberId!)) {
+    if (_selectedMemberId != null && baseVisible.contains(_selectedMemberId!)) {
       filtered.add(_selectedMemberId!);
     }
 
-    if (filtered.isEmpty && visible.isNotEmpty) {
-      filtered.add(rootId.isNotEmpty ? rootId : visible.first);
+    if (filtered.isEmpty && baseVisible.isNotEmpty) {
+      filtered.add(rootId.isNotEmpty ? rootId : baseVisible.first);
     }
 
     return filtered;
@@ -958,6 +968,7 @@ class _GenealogyWorkspacePageState extends State<GenealogyWorkspacePage>
   Future<void> _openMemberDetailSheet({
     required MemberProfile member,
     required GenealogyGraph graph,
+    required List<BranchProfile> branches,
   }) async {
     final l10n = context.l10n;
     final ancestry = GenealogyGraphAlgorithms.buildAncestryPath(
@@ -1025,11 +1036,78 @@ class _GenealogyWorkspacePageState extends State<GenealogyWorkspacePage>
                   value: '${ancestry.length}',
                   isLast: true,
                 ),
+                const SizedBox(height: 16),
+                FilledButton.tonalIcon(
+                  key: const Key('genealogy-open-member-detail-action'),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    unawaited(
+                      _openMemberDetailPage(
+                        member: member,
+                        graph: graph,
+                        branches: branches,
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.open_in_new),
+                  label: Text(
+                    l10n.pick(
+                      vi: 'Mở chi tiết thành viên',
+                      en: 'Open member details',
+                    ),
+                  ),
+                ),
               ],
             ),
           ),
         );
       },
+    );
+  }
+
+  Future<void> _openMemberDetailPage({
+    required MemberProfile member,
+    required GenealogyGraph graph,
+    required List<BranchProfile> branches,
+  }) async {
+    final l10n = context.l10n;
+    final ancestry = GenealogyGraphAlgorithms.buildAncestryPath(
+      graph: graph,
+      memberId: member.id,
+    );
+    final descendants = GenealogyGraphAlgorithms.buildDescendantsTraversal(
+      graph: graph,
+      memberId: member.id,
+      maxDepth: 12,
+    );
+    var branchName = member.branchId;
+    for (final branch in branches) {
+      if (branch.id == member.branchId && branch.name.trim().isNotEmpty) {
+        branchName = branch.name;
+        break;
+      }
+    }
+
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (context) {
+          return _GenealogyMemberDetailPage(
+            member: member,
+            branchName: branchName,
+            generationLabel:
+                graph.generationLabels[member.id]?.compactLabel ??
+                'G${member.generation}',
+            ancestryCount: ancestry.length,
+            descendantCount: descendants.length,
+            parentCount: graph.parentsOf(member.id).length,
+            childCount: graph.childrenOf(member.id).length,
+            spouseCount: graph.spousesOf(member.id).length,
+            isAlive: _isMemberAlive(member),
+            aliveStatusLabel: l10n.genealogyMemberAliveStatus,
+            deceasedStatusLabel: l10n.genealogyMemberDeceasedStatus,
+          );
+        },
+      ),
     );
   }
 
@@ -1179,18 +1257,6 @@ class _LandingCard extends StatelessWidget {
                   selected: scopeType == GenealogyScopeType.branch,
                   onSelected: (_) => onScopeChanged(GenealogyScopeType.branch),
                 ),
-              ActionChip(
-                avatar: Icon(
-                  isFromCache ? Icons.bolt_outlined : Icons.cloud_done,
-                  size: 18,
-                ),
-                label: Text(
-                  isFromCache
-                      ? l10n.genealogyFromCache
-                      : l10n.genealogyLiveData,
-                ),
-                onPressed: null,
-              ),
               FilledButton.tonalIcon(
                 onPressed: onRefresh,
                 icon: isLoading
@@ -1811,6 +1877,7 @@ class _MemberNodeCard extends StatelessWidget {
                   Tooltip(
                     message: viewInfoTooltip,
                     child: IconButton(
+                      key: Key('tree-node-info-${member.id}'),
                       visualDensity: VisualDensity.compact,
                       iconSize: 16,
                       splashRadius: 16,
@@ -1999,54 +2066,6 @@ class _TreeConnectorPainter extends CustomPainter {
   }
 }
 
-class _TreeMetricCard extends StatelessWidget {
-  const _TreeMetricCard({
-    required this.l10n,
-    required this.members,
-    required this.edges,
-    required this.latestLayoutMs,
-    required this.averageLayoutMs,
-    required this.peakLayoutMs,
-  });
-
-  final AppLocalizations l10n;
-  final int members;
-  final int edges;
-  final int latestLayoutMs;
-  final int averageLayoutMs;
-  final int peakLayoutMs;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    return DecoratedBox(
-      key: const Key('tree-metrics-card'),
-      decoration: BoxDecoration(
-        color: colorScheme.surface.withValues(alpha: 0.92),
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: colorScheme.outlineVariant),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        child: DefaultTextStyle(
-          style: theme.textTheme.labelMedium!,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(l10n.genealogyMetricNodes(members)),
-              Text(l10n.genealogyMetricEdges(edges)),
-              Text(l10n.genealogyMetricLayout(latestLayoutMs)),
-              Text(l10n.genealogyMetricAverage(averageLayoutMs)),
-              Text(l10n.genealogyMetricPeak(peakLayoutMs)),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
 class _FactLine extends StatelessWidget {
   const _FactLine({
     required this.label,
@@ -2080,6 +2099,224 @@ class _FactLine extends StatelessWidget {
       ),
     );
   }
+}
+
+class _GenealogyMemberDetailPage extends StatelessWidget {
+  const _GenealogyMemberDetailPage({
+    required this.member,
+    required this.branchName,
+    required this.generationLabel,
+    required this.parentCount,
+    required this.childCount,
+    required this.spouseCount,
+    required this.ancestryCount,
+    required this.descendantCount,
+    required this.isAlive,
+    required this.aliveStatusLabel,
+    required this.deceasedStatusLabel,
+  });
+
+  final MemberProfile member;
+  final String branchName;
+  final String generationLabel;
+  final int parentCount;
+  final int childCount;
+  final int spouseCount;
+  final int ancestryCount;
+  final int descendantCount;
+  final bool isAlive;
+  final String aliveStatusLabel;
+  final String deceasedStatusLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.memberDetailTitle)),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+          children: [
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(18),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    CircleAvatar(
+                      radius: 34,
+                      child: Text(
+                        member.initials,
+                        style: theme.textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            member.fullName,
+                            style: theme.textTheme.headlineSmall?.copyWith(
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            member.nickName.trim().isEmpty
+                                ? l10n.memberDetailNoNickname
+                                : member.nickName,
+                            style: theme.textTheme.titleMedium,
+                          ),
+                          const SizedBox(height: 12),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: [
+                              _MiniFactChip(
+                                icon: Icons.account_tree_outlined,
+                                label: branchName,
+                              ),
+                              _MiniFactChip(
+                                icon: Icons.layers_outlined,
+                                label: generationLabel,
+                              ),
+                              _StatusChip(
+                                isAlive: isAlive,
+                                aliveStatusLabel: aliveStatusLabel,
+                                deceasedStatusLabel: deceasedStatusLabel,
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(18),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.memberDetailSummaryTitle,
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    const SizedBox(height: 14),
+                    _FactLine(
+                      label: l10n.memberFullNameLabel,
+                      value: member.fullName,
+                    ),
+                    _FactLine(
+                      label: l10n.memberNicknameLabel,
+                      value: member.nickName.trim().isEmpty
+                          ? l10n.memberFieldUnset
+                          : member.nickName,
+                    ),
+                    _FactLine(
+                      label: l10n.memberPhoneLabel,
+                      value: member.phoneE164 ?? l10n.memberFieldUnset,
+                    ),
+                    _FactLine(
+                      label: l10n.memberEmailLabel,
+                      value: member.email ?? l10n.memberFieldUnset,
+                    ),
+                    _FactLine(
+                      label: l10n.memberGenderLabel,
+                      value: _memberGenderLabel(l10n, member.gender),
+                    ),
+                    _FactLine(
+                      label: l10n.memberBirthDateLabel,
+                      value: member.birthDate ?? l10n.memberFieldUnset,
+                    ),
+                    _FactLine(
+                      label: l10n.memberDeathDateLabel,
+                      value: member.deathDate ?? l10n.memberFieldUnset,
+                    ),
+                    _FactLine(
+                      label: l10n.memberJobTitleLabel,
+                      value: member.jobTitle ?? l10n.memberFieldUnset,
+                    ),
+                    _FactLine(
+                      label: l10n.memberAddressLabel,
+                      value: member.addressText ?? l10n.memberFieldUnset,
+                    ),
+                    _FactLine(
+                      label: l10n.memberBioLabel,
+                      value: member.bio ?? l10n.memberFieldUnset,
+                      isLast: true,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(18),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.pick(
+                        vi: 'Tóm tắt quan hệ',
+                        en: 'Relationship summary',
+                      ),
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    const SizedBox(height: 14),
+                    _FactLine(
+                      label: l10n.genealogyParentCountLabel,
+                      value: '$parentCount',
+                    ),
+                    _FactLine(
+                      label: l10n.genealogyChildCountLabel,
+                      value: '$childCount',
+                    ),
+                    _FactLine(
+                      label: l10n.genealogySpouseCountLabel,
+                      value: '$spouseCount',
+                    ),
+                    _FactLine(
+                      label: l10n.genealogyDescendantCountLabel,
+                      value: '$descendantCount',
+                    ),
+                    _FactLine(
+                      label: l10n.genealogyAncestryPathTitle,
+                      value: '$ancestryCount',
+                      isLast: true,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _memberGenderLabel(AppLocalizations l10n, String? value) {
+  final normalized = value?.trim().toLowerCase();
+  return switch (normalized) {
+    'male' => l10n.memberGenderMale,
+    'female' => l10n.memberGenderFemale,
+    'other' => l10n.memberGenderOther,
+    _ => l10n.memberGenderUnspecified,
+  };
 }
 
 class _TreeScene {

--- a/mobile/befam/test/features/genealogy/genealogy_workspace_page_test.dart
+++ b/mobile/befam/test/features/genealogy/genealogy_workspace_page_test.dart
@@ -90,7 +90,7 @@ void main() {
     );
   });
 
-  testWidgets('renders landing, node cards, connectors, and metrics', (
+  testWidgets('renders landing, node cards, and connectors', (
     tester,
   ) async {
     final repository = DebugGenealogyReadRepository(
@@ -121,7 +121,6 @@ void main() {
     await scrollToTreeWorkspace(tester);
 
     expect(find.byType(CustomPaint), findsWidgets);
-    expect(find.byKey(const Key('tree-metrics-card')), findsOneWidget);
     expect(find.text('Nguyễn Minh'), findsWidgets);
     expect(find.byKey(const Key('genealogy-center-selected')), findsOneWidget);
   });
@@ -211,6 +210,98 @@ void main() {
     await tester.tap(find.byKey(const Key('tree-node-member_demo_child_001')));
     await tester.pumpAndSettle();
 
+    expect(find.text('Bé Minh'), findsWidgets);
+    expect(
+      find.byKey(const Key('genealogy-open-member-detail-action')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('coverage preset renders all clan members across branches', (
+    tester,
+  ) async {
+    final repository = DebugGenealogyReadRepository(
+      store: DebugGenealogyStore.seeded(),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('vi'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: Scaffold(
+          body: GenealogyWorkspacePage(
+            session: buildClanAdminSession(),
+            repository: repository,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('tree-preset-coverage')));
+    await tester.pumpAndSettle();
+    await scrollToTreeWorkspace(tester);
+
+    expect(
+      find.byKey(const Key('tree-node-member_demo_parent_001')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('tree-node-member_demo_parent_002')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('tree-node-member_demo_child_001')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('tree-node-member_demo_child_002')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('tree-node-member_demo_elder_001')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('opens member detail page from node info button', (tester) async {
+    final repository = DebugGenealogyReadRepository(
+      store: DebugGenealogyStore.seeded(),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('vi'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: Scaffold(
+          body: GenealogyWorkspacePage(
+            session: buildClanAdminSession(),
+            repository: repository,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await scrollToTreeWorkspace(tester);
+    await tester.tap(
+      find.byKey(const Key('tree-node-info-member_demo_child_001')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Chi tiết thành viên'), findsOneWidget);
     expect(find.text('Bé Minh'), findsWidgets);
   });
 }


### PR DESCRIPTION
## Summary
- load sandbox login profiles from Firestore (debug_login_profiles) with local fallback
- add role-based local bypass options for auth testing scenarios
- update debug auth gateway to resolve role/context from Firestore profiles
- seed and document demo login profiles in Firebase demo script
- allow read-only access to active debug login profiles in Firestore rules
- remove genealogy non-production status chips and update related widget test

## Validation
- flutter analyze (auth + genealogy touched files)
- flutter test (widget and genealogy workspace tests)
- firebase seed script run against be-fam-3ab23
- firestore rules deployed to be-fam-3ab23