### PR TITLE
feat: implement Epic #213 tiered subscription + Card/VNPay billing

### DIFF
--- a/docs/01-product/epic-tiered-subscription-payments.md
+++ b/docs/01-product/epic-tiered-subscription-payments.md
@@ -3,6 +3,7 @@
 _Last reviewed: March 15, 2026_
 
 Source tracking issue: [#213](https://github.com/phamhungptithcm/gia-pha/issues/213)
+Implementation status: baseline delivered in `codex/epic-213-tiered-subscription-payments`
 
 ## Goal
 

--- a/docs/01-product/feature-spec.md
+++ b/docs/01-product/feature-spec.md
@@ -23,7 +23,7 @@ _Last reviewed: March 15, 2026_
 | Push token registration | Live | Callable-first with Firestore fallback |
 | Push delivery backend | Live | Notification docs + FCM multicast delivery |
 | Notification inbox UI | Partial | Inbox list, mark-read, pagination, and destination placeholders are live; full destination screens are pending |
-| Subscription + billing | Planned | Epic [#213](https://github.com/phamhungptithcm/gia-pha/issues/213) |
+| Subscription + billing | Live | Epic [#213](https://github.com/phamhungptithcm/gia-pha/issues/213) implemented (Free/Base/Plus/Pro, Card/VNPay, reminders, history, audit logs) |
 
 ## Functional guardrails
 
@@ -31,13 +31,13 @@ _Last reviewed: March 15, 2026_
 - role-based writes for sensitive actions (`CLAN_ADMIN`, `BRANCH_ADMIN`)
 - child login access mode tracked as distinct session context
 - immutable audit-style records for relationship and auth-link actions
-- planned billing guardrails include signed gateway callbacks, webhook
-  idempotency, and owner/admin-only billing visibility
+- billing guardrails include signed gateway callbacks, webhook idempotency,
+  server-only webhook event writes, and owner/admin billing workspace visibility
 
 ## Technical compatibility
 
 - mobile: Flutter, Android, iOS
 - backend: Firebase Auth, Firestore, Storage, Functions v2, FCM
-- billing (planned): Free/Base/Plus/Pro plan engine, card + VNPay checkout,
-  and server-side callback validation
+- billing: Free/Base/Plus/Pro plan engine, card + VNPay checkout, reminder
+  scheduling, and server-side callback validation
 - CI/CD: GitHub Actions with protected `staging` and `main` delivery model

--- a/docs/01-product/product-overview.md
+++ b/docs/01-product/product-overview.md
@@ -32,19 +32,18 @@ Delivered in the current app baseline:
 - notification inbox and deep-link destination placeholders
 - profile workspace with user-facing settings entry points
 - Firebase Cloud Messaging registration on mobile and server-side push delivery
+- annual subscription billing (Free/Base/Plus/Pro) with Card + VNPay checkout
+- billing status UI with expiry, payment mode, reminders, history, invoices,
+  and audit trail
 
 In progress / partially delivered:
 
-- full payment and subscription lifecycle is not yet implemented
 - notification settings persistence and non-placeholder deep-link destinations
   are still being expanded
 
 Planned next modules:
 
-- annual plan model by member count: Free/Base/Plus/Pro (card + VNPay)
-- ad-supported Free/Base plans and ad-free Plus/Pro plans
-- auto-renew/manual-renew preference management and renewal reminders
-- billing history and invoice baseline for clan owners/admins
+- deeper analytics and destination-specific notification deep-link screens
 
 ## Supported platforms and language
 

--- a/docs/01-product/roadmap.md
+++ b/docs/01-product/roadmap.md
@@ -50,7 +50,7 @@ _Last reviewed: March 15, 2026_
 - lunar event creation with yearly recurrence resolution
 - lunar holidays, regional calendar settings, and reminder scheduling
 
-### M7: Tiered subscription billing and payments (next)
+### M7: Tiered subscription billing and payments (completed baseline)
 
 - annual plans by member count with VAT-included display:
   Free (`<=10`), Base (`11-200`), Plus (`201-700`), Pro (`701+`)

--- a/docs/02-architecture/data-model.md
+++ b/docs/02-architecture/data-model.md
@@ -21,17 +21,18 @@ Primary Firestore collections:
 - `auditLogs`
 - `users` and nested `users/{uid}/deviceTokens`
 
-Planned billing collections for Epic #213:
+Billing collections (Epic #213):
 
 - `subscriptions`
 - `subscriptionInvoices`
 - `paymentTransactions`
 - `paymentWebhookEvents`
 - `billingSettings`
+- `billingAuditLogs`
 
-Planned subscription fields include `planCode` (`FREE`, `BASE`, `PLUS`,
-`PRO`), `memberCountSnapshot`, `priceVndInclVat`, `expiresAt`,
-`renewalMode`, and `adEntitlement`.
+Subscription fields include `planCode` (`FREE`, `BASE`, `PLUS`, `PRO`),
+`memberCount`, `amountVndYear`, `expiresAt`, `paymentMode`, `autoRenew`,
+`nextPaymentDueAt`, and ad entitlement flags (`showAds`, `adFree`).
 
 ## Relationship model
 
@@ -61,7 +62,7 @@ Planned subscription fields include `planCode` (`FREE`, `BASE`, `PLUS`,
   - events by `clanId/branchId + startsAt`
   - notifications by `memberId + createdAt`
 
-Planned billing index profile:
+Billing index profile:
 
 - subscriptions by `clanId + status + expiresAt`
 - payment transactions by `clanId + createdAt`

--- a/docs/04-backend/cloud-functions.md
+++ b/docs/04-backend/cloud-functions.md
@@ -63,24 +63,27 @@ and TypeScript.
 - contract tests are implemented under `src/contract-tests/*`
 - `npm test` compiles functions and runs Node test contracts from `lib/contract-tests/*.contract.test.js`
 
-### Planned billing callables and triggers (Epic #213)
+### Billing callables, webhooks, and jobs (Epic #213)
 
+- `resolveBillingEntitlement`:
+  - resolves clan plan and ad entitlement flags for client gating
+- `loadBillingWorkspace`:
+  - returns subscription status, settings, pricing tiers, transaction history,
+    invoices, and billing audit logs for owner/admin UX
+- `updateBillingPreferences`:
+  - persists auto/manual renewal mode and reminder schedule
 - `createSubscriptionCheckout`:
-  - validates clan owner/admin permission
-  - computes plan from `member_count` (`FREE`, `BASE`, `PLUS`, `PRO`)
-  - initializes card/VNPay checkout with VAT-included amount
-- `handleVnpayWebhook`:
-  - validates gateway signature and replay/idempotency constraints
-  - commits transaction + subscription updates atomically
-- `handleCardWebhook`:
-  - verifies provider signature and payment status transition
-  - writes invoice/transaction/audit records
-- `sendSubscriptionRenewalReminders` (scheduled):
-  - finds upcoming expiry windows
-  - emits notification docs and push payloads to owner/admin audience
-- `resolvePlanEntitlements`:
-  - derives ad entitlement from active plan
-  - returns client-safe flags (`showAds`, `adFree`, `planCode`, `expiresAt`)
+  - computes tier from current member count and creates transaction + invoice
+    baseline for Card/VNPay
+- `completeCardCheckout` and `simulateVnpaySettlement`:
+  - finalize payment settlement in callable-driven testing/dev flows
+- `cardPaymentCallback` and `vnpayPaymentCallback`:
+  - validate callback signatures
+  - enforce idempotency via `paymentWebhookEvents`
+  - apply subscription lifecycle updates and emit notification/audit records
+- `billingSubscriptionReminderJob` (scheduled):
+  - scans active/grace subscriptions nearing expiry
+  - delivers renewal reminders to owner/admin audience
 
 ## Supporting modules
 

--- a/docs/04-backend/firestore-schema.md
+++ b/docs/04-backend/firestore-schema.md
@@ -17,7 +17,7 @@ Cloud Functions.
 - `events`, `funds`, `transactions`, `scholarshipPrograms`, `awardLevels`,
   `achievementSubmissions`, `auditLogs`
 
-Planned billing collections (Epic #213):
+Billing collections (Epic #213):
 
 - `subscriptions`: clan-level plan state (`FREE`, `BASE`, `PLUS`, `PRO`),
   member snapshot, price, ad entitlement, expiry, renew mode
@@ -25,6 +25,7 @@ Planned billing collections (Epic #213):
 - `paymentTransactions`: gateway-level payment intent/settlement records
 - `paymentWebhookEvents`: idempotency and callback verification tracking
 - `billingSettings`: owner/admin renewal preferences and reminder settings
+- `billingAuditLogs`: immutable billing action trace entries
 
 ## Member + relationship pattern
 
@@ -52,7 +53,7 @@ Key indexes are maintained in `firebase/firestore.indexes.json`:
 - relationships by clan + person + type
 - events by clan/branch + start time
 - notifications by member + created time and read state
-- planned billing indexes by clan + subscription status/expiry and transaction
+- billing indexes by clan + subscription status/expiry and transaction
   chronology
 
 ## Reference

--- a/docs/06-security/firebase-rules.md
+++ b/docs/06-security/firebase-rules.md
@@ -13,12 +13,14 @@ Rules are defined in `firebase/firestore.rules` and enforce:
 - server-only writes for critical collections (`transactions`, `auditLogs`,
   `memberSearchIndex`)
 
-Planned billing rule model (Epic #213):
+Billing rule model (Epic #213):
 
 - `subscriptions`, `paymentTransactions`, `subscriptionInvoices`, and
   `paymentWebhookEvents` are server-written only
 - billing reads are limited to clan owner/admin roles in the same `clanId`
 - webhook-event docs are non-readable to regular clients
+- `billingAuditLogs` are read-only for clan billing admin roles and
+  server-written only
 
 ### Key helpers
 

--- a/docs/06-security/privacy-model.md
+++ b/docs/06-security/privacy-model.md
@@ -30,7 +30,7 @@ _Last reviewed: March 15, 2026_
 - push token documents store operational metadata needed for routing only
 - notification docs are member-targeted and read-state mutable by recipient
 - storage uploads enforce file type and size limits
-- planned billing model stores only payment references and masked metadata
+- billing model stores only payment references and masked metadata
   (never raw card PAN/CVV)
 - invoice and transaction records are clan-scoped and owner/admin-visible only
 - ad telemetry (if enabled) is aggregated and plan-scoped; no personalized ad
@@ -50,7 +50,7 @@ _Last reviewed: March 15, 2026_
 - ad entitlement checks use plan metadata only (`FREE/BASE/PLUS/PRO`) and do
   not require storing sensitive personal attributes
 
-## Retention and access controls (planned billing)
+## Retention and access controls (billing)
 
 - keep transaction/invoice records for audit and compliance support windows
 - restrict billing read access to clan owner/admin roles

--- a/docs/07-operations/monitoring.md
+++ b/docs/07-operations/monitoring.md
@@ -36,7 +36,7 @@ Operational notes:
 - trigger/callable logs include ids and clan context where available
 - push delivery reports sent/failed/invalid token counts
 
-Planned billing monitoring (Epic #213):
+Billing monitoring (Epic #213):
 
 - checkout initialization success/failure rate
 - webhook signature validation failures

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -255,6 +255,62 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "paymentTransactions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "clanId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "subscriptionInvoices",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "clanId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "billingAuditLogs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "clanId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "subscriptions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "expiresAt",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -50,6 +50,22 @@ service cloud.firestore {
       return primaryRole() in ['SUPER_ADMIN', 'CLAN_ADMIN', 'BRANCH_ADMIN'];
     }
 
+    function isBillingAdmin() {
+      return primaryRole() in [
+        'SUPER_ADMIN',
+        'CLAN_ADMIN',
+        'BRANCH_ADMIN',
+        'CLAN_OWNER',
+        'CLAN_LEADER',
+        'VICE_LEADER',
+        'SUPPORTER_OF_LEADER'
+      ];
+    }
+
+    function canReadBillingDoc(clanId) {
+      return hasClanAccess(clanId) && isBillingAdmin();
+    }
+
     function isClanSettingsAdmin() {
       return primaryRole() in ['SUPER_ADMIN', 'CLAN_ADMIN'];
     }
@@ -390,6 +406,35 @@ service cloud.firestore {
     match /auditLogs/{logId} {
       allow read: if isClanAdmin() && hasClanAccess(resource.data.clanId);
       allow write: if false;
+    }
+
+    match /subscriptions/{subscriptionId} {
+      allow read: if canReadBillingDoc(resource.data.clanId);
+      allow write: if false;
+    }
+
+    match /billingSettings/{settingsId} {
+      allow read: if canReadBillingDoc(resource.data.clanId);
+      allow write: if false;
+    }
+
+    match /paymentTransactions/{transactionId} {
+      allow read: if canReadBillingDoc(resource.data.clanId);
+      allow write: if false;
+    }
+
+    match /subscriptionInvoices/{invoiceId} {
+      allow read: if canReadBillingDoc(resource.data.clanId);
+      allow write: if false;
+    }
+
+    match /billingAuditLogs/{auditLogId} {
+      allow read: if canReadBillingDoc(resource.data.clanId);
+      allow write: if false;
+    }
+
+    match /paymentWebhookEvents/{eventId} {
+      allow read, write: if false;
     }
   }
 }

--- a/firebase/functions/src/billing/callables.ts
+++ b/firebase/functions/src/billing/callables.ts
@@ -1,0 +1,568 @@
+import { createHmac } from 'node:crypto';
+
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+
+import { APP_REGION } from '../config/runtime';
+import {
+  applyPaymentResult,
+  buildEntitlementFromSubscription,
+  createPendingCheckout,
+  ensureSubscriptionForClan,
+  loadBillingSettings,
+  resolveBillingAudienceMemberIds,
+  upsertBillingSettings,
+  writeBillingAuditLog,
+} from './store';
+import {
+  BILLING_PRICING_TIERS,
+  type PaymentMethod,
+  type PaymentMode,
+} from './pricing';
+import { requireAuth } from '../shared/errors';
+import { db } from '../shared/firestore';
+import { notifyMembers } from '../notifications/push-delivery';
+import { logInfo, logWarn } from '../shared/logger';
+
+const subscriptionsCollection = db.collection('subscriptions');
+const transactionsCollection = db.collection('paymentTransactions');
+const invoicesCollection = db.collection('subscriptionInvoices');
+const billingAuditLogsCollection = db.collection('billingAuditLogs');
+
+export const resolveBillingEntitlement = onCall(
+  { region: APP_REGION },
+  async (request) => {
+    const auth = requireAuth(request);
+    const clanId = resolveClanId(auth.token, request.data);
+    if (clanId.length === 0) {
+      throw new HttpsError('failed-precondition', 'No clan context is available.');
+    }
+
+    const ensured = await ensureSubscriptionForClan({
+      clanId,
+      actorUid: auth.uid,
+    });
+    const entitlement = buildEntitlementFromSubscription(ensured.subscription);
+
+    return {
+      clanId,
+      subscription: serializeSubscription(ensured.subscription),
+      entitlement,
+      pricingTiers: BILLING_PRICING_TIERS,
+      settings: ensured.settings,
+      memberCount: ensured.memberCount,
+    };
+  },
+);
+
+export const loadBillingWorkspace = onCall(
+  { region: APP_REGION },
+  async (request) => {
+    const auth = requireAuth(request);
+    const clanId = resolveClanId(auth.token, request.data);
+    if (clanId.length === 0) {
+      throw new HttpsError('failed-precondition', 'No clan context is available.');
+    }
+    assertBillingAdmin(auth.token);
+
+    const ensured = await ensureSubscriptionForClan({
+      clanId,
+      actorUid: auth.uid,
+    });
+    const [transactionsSnapshot, invoicesSnapshot, auditSnapshot] = await Promise.all([
+      transactionsCollection
+        .where('clanId', '==', clanId)
+        .orderBy('createdAt', 'desc')
+        .limit(50)
+        .get(),
+      invoicesCollection
+        .where('clanId', '==', clanId)
+        .orderBy('createdAt', 'desc')
+        .limit(24)
+        .get(),
+      billingAuditLogsCollection
+        .where('clanId', '==', clanId)
+        .orderBy('createdAt', 'desc')
+        .limit(40)
+        .get(),
+    ]);
+
+    return {
+      clanId,
+      subscription: serializeSubscription(ensured.subscription),
+      entitlement: buildEntitlementFromSubscription(ensured.subscription),
+      settings: ensured.settings,
+      pricingTiers: BILLING_PRICING_TIERS,
+      memberCount: ensured.memberCount,
+      transactions: transactionsSnapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...normalizeFirestoreJson(doc.data()),
+      })),
+      invoices: invoicesSnapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...normalizeFirestoreJson(doc.data()),
+      })),
+      auditLogs: auditSnapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...normalizeFirestoreJson(doc.data()),
+      })),
+    };
+  },
+);
+
+export const updateBillingPreferences = onCall(
+  { region: APP_REGION },
+  async (request) => {
+    const auth = requireAuth(request);
+    const clanId = resolveClanId(auth.token, request.data);
+    if (clanId.length === 0) {
+      throw new HttpsError('failed-precondition', 'No clan context is available.');
+    }
+    assertBillingAdmin(auth.token);
+
+    const paymentMode = normalizePaymentModeFromInput(request.data);
+    const autoRenew = readBoolean(request.data, 'autoRenew', paymentMode === 'auto_renew');
+    const reminderDaysBefore = readReminderDays(request.data);
+
+    const settings = await upsertBillingSettings({
+      clanId,
+      paymentMode,
+      autoRenew,
+      reminderDaysBefore,
+      actorUid: auth.uid,
+    });
+
+    await subscriptionsCollection.doc(clanId).set(
+      {
+        paymentMode: settings.paymentMode,
+        autoRenew: settings.autoRenew,
+        updatedAt: new Date(),
+        updatedBy: auth.uid,
+      },
+      { merge: true },
+    );
+
+    await writeBillingAuditLog({
+      clanId,
+      actorUid: auth.uid,
+      action: 'billing_preferences_updated',
+      entityType: 'billingSettings',
+      entityId: clanId,
+      after: {
+        paymentMode: settings.paymentMode,
+        autoRenew: settings.autoRenew,
+        reminderDaysBefore: settings.reminderDaysBefore,
+      },
+    });
+
+    return settings;
+  },
+);
+
+export const createSubscriptionCheckout = onCall(
+  { region: APP_REGION },
+  async (request) => {
+    const auth = requireAuth(request);
+    const clanId = resolveClanId(auth.token, request.data);
+    if (clanId.length === 0) {
+      throw new HttpsError('failed-precondition', 'No clan context is available.');
+    }
+    assertBillingAdmin(auth.token);
+
+    const paymentMethod = normalizePaymentMethod(request.data);
+    const checkout = await createPendingCheckout({
+      clanId,
+      actorUid: auth.uid,
+      paymentMethod,
+    });
+
+    let checkoutUrl = '';
+    let requiresManualConfirmation = false;
+    if (checkout.tier.planCode === 'FREE') {
+      checkoutUrl = '';
+      requiresManualConfirmation = false;
+    } else if (paymentMethod === 'vnpay') {
+      checkoutUrl = buildVnpayCheckoutUrl({
+        transactionId: checkout.transaction.id,
+        amountVnd: checkout.transaction.amountVnd,
+        orderInfo: `BeFam ${checkout.tier.planCode} annual subscription`,
+        returnUrl:
+          readString(request.data, 'returnUrl') ??
+          process.env.VNPAY_RETURN_URL ??
+          'https://example.com/billing/vnpay-return',
+      });
+    } else {
+      checkoutUrl = buildCardCheckoutHintUrl({
+        transactionId: checkout.transaction.id,
+      });
+      requiresManualConfirmation = true;
+    }
+
+    logInfo('createSubscriptionCheckout created', {
+      uid: auth.uid,
+      clanId,
+      paymentMethod,
+      transactionId: checkout.transaction.id,
+      planCode: checkout.tier.planCode,
+      amountVnd: checkout.transaction.amountVnd,
+    });
+
+    return {
+      clanId,
+      paymentMethod,
+      planCode: checkout.tier.planCode,
+      amountVnd: checkout.transaction.amountVnd,
+      vatIncluded: checkout.transaction.vatIncluded,
+      transactionId: checkout.transaction.id,
+      invoiceId: checkout.invoice.id,
+      checkoutUrl,
+      requiresManualConfirmation,
+      subscription: serializeSubscription(checkout.subscription),
+      entitlement: buildEntitlementFromSubscription(checkout.subscription),
+    };
+  },
+);
+
+export const completeCardCheckout = onCall(
+  { region: APP_REGION },
+  async (request) => {
+    const auth = requireAuth(request);
+    const clanId = resolveClanId(auth.token, request.data);
+    if (clanId.length === 0) {
+      throw new HttpsError('failed-precondition', 'No clan context is available.');
+    }
+    assertBillingAdmin(auth.token);
+
+    const transactionId = readString(request.data, 'transactionId');
+    if (transactionId == null || transactionId.length === 0) {
+      throw new HttpsError('invalid-argument', 'transactionId is required.');
+    }
+
+    const txSnapshot = await transactionsCollection.doc(transactionId).get();
+    if (!txSnapshot.exists) {
+      throw new HttpsError('not-found', 'transaction not found.');
+    }
+    const txClanId = normalizeString(txSnapshot.data()?.clanId);
+    if (txClanId !== clanId) {
+      throw new HttpsError('permission-denied', 'transaction clan mismatch.');
+    }
+
+    const payment = await applyPaymentResult({
+      transactionId,
+      provider: 'card',
+      gatewayReference: `CARD-CONF-${transactionId.slice(0, 10)}`,
+      paymentStatus: 'succeeded',
+      payloadHash: createPayloadHash({ transactionId, actorUid: auth.uid }),
+      actorUid: auth.uid,
+    });
+
+    await notifyBillingResult({
+      clanId,
+      approved: true,
+      amountVnd: Number(payment.transaction.amountVnd),
+      transactionId,
+      provider: 'card',
+    });
+
+    return {
+      status: 'succeeded',
+      transactionId,
+      subscription: payment.subscription ? serializeSubscription(payment.subscription) : null,
+      entitlement: payment.subscription
+        ? buildEntitlementFromSubscription(payment.subscription)
+        : null,
+      invoice: payment.invoice,
+    };
+  },
+);
+
+export const simulateVnpaySettlement = onCall(
+  { region: APP_REGION },
+  async (request) => {
+    const auth = requireAuth(request);
+    const clanId = resolveClanId(auth.token, request.data);
+    if (clanId.length === 0) {
+      throw new HttpsError('failed-precondition', 'No clan context is available.');
+    }
+    assertBillingAdmin(auth.token);
+
+    const transactionId = readString(request.data, 'transactionId');
+    if (transactionId == null || transactionId.length === 0) {
+      throw new HttpsError('invalid-argument', 'transactionId is required.');
+    }
+
+    const payment = await applyPaymentResult({
+      transactionId,
+      provider: 'vnpay',
+      gatewayReference: `VNPAY-SIM-${transactionId.slice(0, 10)}`,
+      paymentStatus: 'succeeded',
+      payloadHash: createPayloadHash({ transactionId, actorUid: auth.uid }),
+      actorUid: auth.uid,
+    });
+
+    await notifyBillingResult({
+      clanId,
+      approved: true,
+      amountVnd: Number(payment.transaction.amountVnd),
+      transactionId,
+      provider: 'vnpay',
+    });
+
+    return {
+      status: 'succeeded',
+      transactionId,
+      subscription: payment.subscription ? serializeSubscription(payment.subscription) : null,
+      entitlement: payment.subscription
+        ? buildEntitlementFromSubscription(payment.subscription)
+        : null,
+      invoice: payment.invoice,
+    };
+  },
+);
+
+async function notifyBillingResult({
+  clanId,
+  approved,
+  amountVnd,
+  transactionId,
+  provider,
+}: {
+  clanId: string;
+  approved: boolean;
+  amountVnd: number;
+  transactionId: string;
+  provider: string;
+}): Promise<void> {
+  const memberIds = await resolveBillingAudienceMemberIds(clanId);
+  if (memberIds.length === 0) {
+    return;
+  }
+  await notifyMembers({
+    clanId,
+    memberIds,
+    type: approved ? 'billing_payment_succeeded' : 'billing_payment_failed',
+    title: approved ? 'Subscription updated successfully' : 'Payment failed',
+    body: approved
+      ? `Payment ${formatVnd(amountVnd)} via ${provider.toUpperCase()} was confirmed.`
+      : `Payment attempt for ${formatVnd(amountVnd)} failed.`,
+    target: 'generic',
+    targetId: transactionId,
+    extraData: {
+      transactionId,
+      billing: 'true',
+      result: approved ? 'success' : 'failed',
+      provider,
+    },
+  });
+}
+
+function resolveClanId(
+  token: Record<string, unknown>,
+  data: unknown,
+): string {
+  const clanIdsRaw = token.clanIds;
+  if (Array.isArray(clanIdsRaw)) {
+    for (const item of clanIdsRaw) {
+      if (typeof item === 'string' && item.trim().length > 0) {
+        return item.trim();
+      }
+    }
+  }
+  const tokenClanId = normalizeString(token.clanId);
+  if (tokenClanId.length > 0) {
+    return tokenClanId;
+  }
+  const dataClanId = readString(data, 'clanId');
+  return dataClanId ?? '';
+}
+
+function assertBillingAdmin(token: Record<string, unknown>): void {
+  const role = normalizeString(token.primaryRole).toUpperCase();
+  const allowed = new Set([
+    'SUPER_ADMIN',
+    'CLAN_ADMIN',
+    'BRANCH_ADMIN',
+    'CLAN_OWNER',
+    'CLAN_LEADER',
+    'VICE_LEADER',
+    'SUPPORTER_OF_LEADER',
+  ]);
+  if (!allowed.has(role)) {
+    throw new HttpsError(
+      'permission-denied',
+      'Billing actions require clan owner/admin privileges.',
+    );
+  }
+}
+
+function normalizePaymentMethod(data: unknown): PaymentMethod {
+  const method = readString(data, 'paymentMethod')?.toLowerCase();
+  if (method === 'card') {
+    return 'card';
+  }
+  if (method === 'vnpay') {
+    return 'vnpay';
+  }
+  throw new HttpsError('invalid-argument', 'paymentMethod must be "card" or "vnpay".');
+}
+
+function normalizePaymentModeFromInput(data: unknown): PaymentMode {
+  const mode = readString(data, 'paymentMode')?.toLowerCase();
+  if (mode === 'manual') {
+    return 'manual';
+  }
+  if (mode === 'auto_renew' || mode === 'auto' || mode === 'automatic') {
+    return 'auto_renew';
+  }
+  throw new HttpsError(
+    'invalid-argument',
+    'paymentMode must be "manual" or "auto_renew".',
+  );
+}
+
+function readReminderDays(data: unknown): Array<number> | undefined {
+  if (data == null || typeof data !== 'object') {
+    return undefined;
+  }
+  const raw = (data as Record<string, unknown>).reminderDaysBefore;
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  const normalized = raw
+    .map((value) => (typeof value === 'number' ? Math.trunc(value) : Number.NaN))
+    .filter((value) => Number.isFinite(value) && value > 0 && value <= 60);
+  if (normalized.length === 0) {
+    return undefined;
+  }
+  return [...new Set(normalized)].sort((left, right) => right - left);
+}
+
+function readString(data: unknown, key: string): string | null {
+  if (data == null || typeof data !== 'object') {
+    return null;
+  }
+  const value = (data as Record<string, unknown>)[key];
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readBoolean(data: unknown, key: string, fallback: boolean): boolean {
+  if (data == null || typeof data !== 'object') {
+    return fallback;
+  }
+  const value = (data as Record<string, unknown>)[key];
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function serializeSubscription(subscription: Record<string, unknown>): Record<string, unknown> {
+  return normalizeFirestoreJson(subscription);
+}
+
+function normalizeFirestoreJson(source: Record<string, unknown>): Record<string, unknown> {
+  const output: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (value instanceof Date) {
+      output[key] = value.toISOString();
+      continue;
+    }
+    if (
+      value != null &&
+      typeof value === 'object' &&
+      'toDate' in value &&
+      typeof (value as { toDate?: unknown }).toDate === 'function'
+    ) {
+      try {
+        output[key] = (value as { toDate: () => Date }).toDate().toISOString();
+      } catch {
+        output[key] = value;
+      }
+      continue;
+    }
+    output[key] = value;
+  }
+  return output;
+}
+
+function createPayloadHash(payload: Record<string, unknown>): string {
+  return createHmac('sha256', process.env.BILLING_WEBHOOK_SECRET ?? 'billing-local-secret')
+    .update(JSON.stringify(payload))
+    .digest('hex');
+}
+
+function buildCardCheckoutHintUrl({
+  transactionId,
+}: {
+  transactionId: string;
+}): string {
+  const base = process.env.BILLING_CARD_CHECKOUT_URL_BASE ?? 'https://example.com/billing/card';
+  const url = new URL(base);
+  url.searchParams.set('transactionId', transactionId);
+  return url.toString();
+}
+
+function buildVnpayCheckoutUrl({
+  transactionId,
+  amountVnd,
+  orderInfo,
+  returnUrl,
+}: {
+  transactionId: string;
+  amountVnd: number;
+  orderInfo: string;
+  returnUrl: string;
+}): string {
+  const tmnCode = process.env.VNPAY_TMNCODE?.trim() ?? '';
+  const hashSecret = process.env.VNPAY_HASH_SECRET?.trim() ?? '';
+  if (tmnCode.length === 0 || hashSecret.length === 0) {
+    const fallback = new URL(
+      process.env.BILLING_VNPAY_FALLBACK_URL ?? 'https://example.com/billing/vnpay',
+    );
+    fallback.searchParams.set('transactionId', transactionId);
+    fallback.searchParams.set('amountVnd', `${amountVnd}`);
+    return fallback.toString();
+  }
+
+  const now = new Date();
+  const createDate = formatVnpTimestamp(now);
+  const params: Record<string, string> = {
+    vnp_Version: '2.1.0',
+    vnp_Command: 'pay',
+    vnp_TmnCode: tmnCode,
+    vnp_Amount: `${Math.max(0, Math.trunc(amountVnd)) * 100}`,
+    vnp_CurrCode: 'VND',
+    vnp_TxnRef: transactionId,
+    vnp_OrderInfo: orderInfo,
+    vnp_OrderType: 'billpayment',
+    vnp_Locale: 'vn',
+    vnp_ReturnUrl: returnUrl,
+    vnp_IpAddr: '127.0.0.1',
+    vnp_CreateDate: createDate,
+  };
+
+  const queryString = Object.keys(params)
+    .sort()
+    .map((key) => `${key}=${encodeURIComponent(params[key])}`)
+    .join('&');
+  const secureHash = createHmac('sha512', hashSecret).update(queryString).digest('hex');
+  return `https://sandbox.vnpayment.vn/paymentv2/vpcpay.html?${queryString}&vnp_SecureHash=${secureHash}`;
+}
+
+function formatVnpTimestamp(value: Date): string {
+  const year = value.getUTCFullYear();
+  const month = `${value.getUTCMonth() + 1}`.padStart(2, '0');
+  const day = `${value.getUTCDate()}`.padStart(2, '0');
+  const hour = `${value.getUTCHours()}`.padStart(2, '0');
+  const minute = `${value.getUTCMinutes()}`.padStart(2, '0');
+  const second = `${value.getUTCSeconds()}`.padStart(2, '0');
+  return `${year}${month}${day}${hour}${minute}${second}`;
+}
+
+function formatVnd(amount: number): string {
+  return `${Math.max(0, Math.trunc(amount)).toLocaleString('vi-VN')} VND`;
+}

--- a/firebase/functions/src/billing/pricing.ts
+++ b/firebase/functions/src/billing/pricing.ts
@@ -1,0 +1,131 @@
+export type BillingPlanCode = 'FREE' | 'BASE' | 'PLUS' | 'PRO';
+
+export type SubscriptionStatus =
+  | 'active'
+  | 'grace_period'
+  | 'expired'
+  | 'pending_payment'
+  | 'canceled';
+
+export type PaymentMode = 'auto_renew' | 'manual';
+export type PaymentMethod = 'card' | 'vnpay';
+export type PaymentStatus =
+  | 'created'
+  | 'pending'
+  | 'succeeded'
+  | 'failed'
+  | 'canceled';
+
+export type BillingTierPricing = {
+  planCode: BillingPlanCode;
+  minMembers: number;
+  maxMembers: number | null;
+  priceVndYear: number;
+  vatIncluded: boolean;
+  showAds: boolean;
+  adFree: boolean;
+};
+
+export const BILLING_PRICING_TIERS: ReadonlyArray<BillingTierPricing> = [
+  {
+    planCode: 'FREE',
+    minMembers: 0,
+    maxMembers: 10,
+    priceVndYear: 0,
+    vatIncluded: true,
+    showAds: true,
+    adFree: false,
+  },
+  {
+    planCode: 'BASE',
+    minMembers: 11,
+    maxMembers: 200,
+    priceVndYear: 49_000,
+    vatIncluded: true,
+    showAds: true,
+    adFree: false,
+  },
+  {
+    planCode: 'PLUS',
+    minMembers: 201,
+    maxMembers: 700,
+    priceVndYear: 89_000,
+    vatIncluded: true,
+    showAds: false,
+    adFree: true,
+  },
+  {
+    planCode: 'PRO',
+    minMembers: 701,
+    maxMembers: null,
+    priceVndYear: 119_000,
+    vatIncluded: true,
+    showAds: false,
+    adFree: true,
+  },
+];
+
+export function normalizeMemberCount(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.trunc(value));
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, Math.trunc(parsed));
+    }
+  }
+  return 0;
+}
+
+export function resolvePlanByMemberCount(memberCountInput: unknown): BillingTierPricing {
+  const memberCount = normalizeMemberCount(memberCountInput);
+  const matched = BILLING_PRICING_TIERS.find((tier) => {
+    const inLowerBound = memberCount >= tier.minMembers;
+    const inUpperBound = tier.maxMembers == null || memberCount <= tier.maxMembers;
+    return inLowerBound && inUpperBound;
+  });
+
+  return matched ?? BILLING_PRICING_TIERS[BILLING_PRICING_TIERS.length - 1];
+}
+
+export function isPaidPlan(planCode: BillingPlanCode): boolean {
+  return planCode !== 'FREE';
+}
+
+export function hasActiveAccess(status: SubscriptionStatus): boolean {
+  return status === 'active' || status === 'grace_period';
+}
+
+export function canAccessPremiumFeatures(
+  planCode: BillingPlanCode,
+  status: SubscriptionStatus,
+): boolean {
+  if (!hasActiveAccess(status)) {
+    return false;
+  }
+  return isPaidPlan(planCode);
+}
+
+export function shouldShowAds(
+  planCode: BillingPlanCode,
+  status: SubscriptionStatus,
+): boolean {
+  if (!hasActiveAccess(status)) {
+    return true;
+  }
+  return planCode === 'FREE' || planCode === 'BASE';
+}
+
+export function computeRenewalWindow({
+  now = new Date(),
+  years = 1,
+}: {
+  now?: Date;
+  years?: number;
+}): { startsAt: Date; expiresAt: Date } {
+  const startsAt = new Date(now);
+  const expiresAt = new Date(now);
+  expiresAt.setUTCFullYear(expiresAt.getUTCFullYear() + years);
+  return { startsAt, expiresAt };
+}

--- a/firebase/functions/src/billing/store.ts
+++ b/firebase/functions/src/billing/store.ts
@@ -1,0 +1,963 @@
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
+
+import {
+  buildEntitlement,
+  createSubscriptionDraft,
+  normalizeSubscriptionStatus,
+  type BillingEntitlement,
+  type BillingSubscriptionRecord,
+} from './subscription-lifecycle';
+import {
+  BILLING_PRICING_TIERS,
+  computeRenewalWindow,
+  resolvePlanByMemberCount,
+  type BillingPlanCode,
+  type BillingTierPricing,
+  type PaymentMethod,
+  type PaymentMode,
+  type PaymentStatus,
+  type SubscriptionStatus,
+} from './pricing';
+import { db } from '../shared/firestore';
+import { logInfo, logWarn } from '../shared/logger';
+
+type NullableDate = Date | null;
+
+export type BillingSettingsRecord = {
+  id: string;
+  clanId: string;
+  paymentMode: PaymentMode;
+  autoRenew: boolean;
+  reminderDaysBefore: Array<number>;
+  updatedAt: NullableDate;
+};
+
+export type BillingTransactionRecord = {
+  id: string;
+  clanId: string;
+  subscriptionId: string;
+  invoiceId: string;
+  paymentMethod: PaymentMethod;
+  paymentStatus: PaymentStatus;
+  planCode: BillingPlanCode;
+  memberCount: number;
+  amountVnd: number;
+  vatIncluded: boolean;
+  currency: string;
+  gatewayReference: string | null;
+  gatewayPayloadHash: string | null;
+  createdAt: NullableDate;
+  paidAt: NullableDate;
+  failedAt: NullableDate;
+};
+
+export type BillingInvoiceRecord = {
+  id: string;
+  clanId: string;
+  subscriptionId: string;
+  transactionId: string;
+  planCode: BillingPlanCode;
+  amountVnd: number;
+  vatIncluded: boolean;
+  currency: string;
+  status: 'issued' | 'paid' | 'failed' | 'void';
+  periodStart: NullableDate;
+  periodEnd: NullableDate;
+  issuedAt: NullableDate;
+  paidAt: NullableDate;
+};
+
+export type EnsureSubscriptionResult = {
+  memberCount: number;
+  tier: BillingTierPricing;
+  subscription: BillingSubscriptionRecord;
+  entitlement: BillingEntitlement;
+  settings: BillingSettingsRecord;
+};
+
+const membersCollection = db.collection('members');
+const subscriptionsCollection = db.collection('subscriptions');
+const billingSettingsCollection = db.collection('billingSettings');
+const transactionsCollection = db.collection('paymentTransactions');
+const invoicesCollection = db.collection('subscriptionInvoices');
+const webhookEventsCollection = db.collection('paymentWebhookEvents');
+const billingAuditLogsCollection = db.collection('billingAuditLogs');
+
+export async function countClanMembers(clanId: string): Promise<number> {
+  const snapshot = await membersCollection.where('clanId', '==', clanId).count().get();
+  return Number(snapshot.data().count ?? 0);
+}
+
+export async function loadBillingSettings(clanId: string): Promise<BillingSettingsRecord> {
+  const snapshot = await billingSettingsCollection.doc(clanId).get();
+  if (!snapshot.exists) {
+    return {
+      id: clanId,
+      clanId,
+      paymentMode: 'manual',
+      autoRenew: false,
+      reminderDaysBefore: [30, 14, 7, 3, 1],
+      updatedAt: null,
+    };
+  }
+  const data = snapshot.data() ?? {};
+  return {
+    id: snapshot.id,
+    clanId: readString(data.clanId, clanId),
+    paymentMode: normalizePaymentMode(data.paymentMode),
+    autoRenew: readBool(data.autoRenew, false),
+    reminderDaysBefore: normalizeReminderDays(data.reminderDaysBefore),
+    updatedAt: readDate(data.updatedAt),
+  };
+}
+
+export async function upsertBillingSettings({
+  clanId,
+  paymentMode,
+  autoRenew,
+  reminderDaysBefore,
+  actorUid,
+}: {
+  clanId: string;
+  paymentMode: PaymentMode;
+  autoRenew: boolean;
+  reminderDaysBefore?: Array<number>;
+  actorUid: string;
+}): Promise<BillingSettingsRecord> {
+  const normalizedReminderDays = normalizeReminderDays(reminderDaysBefore);
+  await billingSettingsCollection.doc(clanId).set(
+    {
+      id: clanId,
+      clanId,
+      paymentMode,
+      autoRenew,
+      reminderDaysBefore: normalizedReminderDays,
+      updatedAt: FieldValue.serverTimestamp(),
+      updatedBy: actorUid,
+      createdAt: FieldValue.serverTimestamp(),
+      createdBy: actorUid,
+    },
+    { merge: true },
+  );
+  return loadBillingSettings(clanId);
+}
+
+export async function loadSubscription(clanId: string): Promise<BillingSubscriptionRecord | null> {
+  const snapshot = await subscriptionsCollection.doc(clanId).get();
+  if (!snapshot.exists) {
+    return null;
+  }
+  return mapSubscription(snapshot.id, snapshot.data() ?? {});
+}
+
+export async function ensureSubscriptionForClan({
+  clanId,
+  actorUid,
+  now = new Date(),
+}: {
+  clanId: string;
+  actorUid: string;
+  now?: Date;
+}): Promise<EnsureSubscriptionResult> {
+  const [memberCount, settings, existing] = await Promise.all([
+    countClanMembers(clanId),
+    loadBillingSettings(clanId),
+    loadSubscription(clanId),
+  ]);
+  const tier = resolvePlanByMemberCount(memberCount);
+
+  if (existing == null) {
+    const seeded = seedSubscription({
+      clanId,
+      tier,
+      memberCount,
+      settings,
+      now,
+    });
+    await subscriptionsCollection.doc(clanId).set(
+      {
+        ...toSubscriptionWriteMap(seeded),
+        createdAt: FieldValue.serverTimestamp(),
+        createdBy: actorUid,
+        updatedAt: FieldValue.serverTimestamp(),
+        updatedBy: actorUid,
+      },
+      { merge: true },
+    );
+    await writeBillingAuditLog({
+      clanId,
+      actorUid,
+      action: 'subscription_bootstrapped',
+      entityType: 'subscription',
+      entityId: clanId,
+      after: {
+        planCode: seeded.planCode,
+        status: seeded.status,
+        memberCount: seeded.memberCount,
+      },
+    });
+    return {
+      memberCount,
+      tier,
+      subscription: seeded,
+      entitlement: buildEntitlementFromSubscription(seeded),
+      settings,
+    };
+  }
+
+  const normalizedStatus = normalizeSubscriptionStatus({
+    status: existing.status,
+    expiresAt: existing.expiresAt,
+    graceEndsAt: existing.graceEndsAt,
+    now,
+  });
+  const nextPlanCode = tier.planCode;
+  const updated: BillingSubscriptionRecord = {
+    ...existing,
+    planCode: nextPlanCode,
+    status: normalizeStatusForPlan({
+      planCode: nextPlanCode,
+      currentStatus: normalizedStatus,
+    }),
+    memberCount,
+    amountVndYear: tier.priceVndYear,
+    vatIncluded: tier.vatIncluded,
+    paymentMode: settings.paymentMode,
+    autoRenew: settings.autoRenew,
+    updatedAt: now,
+  };
+
+  await subscriptionsCollection.doc(clanId).set(
+    {
+      ...toSubscriptionWriteMap(updated),
+      updatedAt: FieldValue.serverTimestamp(),
+      updatedBy: actorUid,
+    },
+    { merge: true },
+  );
+
+  return {
+    memberCount,
+    tier,
+    subscription: updated,
+    entitlement: buildEntitlementFromSubscription(updated),
+    settings,
+  };
+}
+
+export async function createPendingCheckout({
+  clanId,
+  actorUid,
+  paymentMethod,
+  now = new Date(),
+}: {
+  clanId: string;
+  actorUid: string;
+  paymentMethod: PaymentMethod;
+  now?: Date;
+}): Promise<{
+  tier: BillingTierPricing;
+  memberCount: number;
+  subscription: BillingSubscriptionRecord;
+  transaction: BillingTransactionRecord;
+  invoice: BillingInvoiceRecord;
+}> {
+  const ensured = await ensureSubscriptionForClan({ clanId, actorUid, now });
+  const { tier, memberCount, subscription } = ensured;
+
+  const transactionRef = transactionsCollection.doc();
+  const invoiceRef = invoicesCollection.doc();
+  const gatewayReference = `${paymentMethod.toUpperCase()}-${Date.now()}-${transactionRef.id.slice(0, 8)}`;
+
+  const transaction: BillingTransactionRecord = {
+    id: transactionRef.id,
+    clanId,
+    subscriptionId: subscription.id,
+    invoiceId: invoiceRef.id,
+    paymentMethod,
+    paymentStatus: tier.planCode === 'FREE' ? 'succeeded' : 'pending',
+    planCode: tier.planCode,
+    memberCount,
+    amountVnd: tier.priceVndYear,
+    vatIncluded: tier.vatIncluded,
+    currency: 'VND',
+    gatewayReference,
+    gatewayPayloadHash: null,
+    createdAt: now,
+    paidAt: tier.planCode === 'FREE' ? now : null,
+    failedAt: null,
+  };
+
+  const invoice: BillingInvoiceRecord = {
+    id: invoiceRef.id,
+    clanId,
+    subscriptionId: subscription.id,
+    transactionId: transaction.id,
+    planCode: tier.planCode,
+    amountVnd: tier.priceVndYear,
+    vatIncluded: tier.vatIncluded,
+    currency: 'VND',
+    status: tier.planCode === 'FREE' ? 'paid' : 'issued',
+    periodStart: subscription.startsAt,
+    periodEnd: subscription.expiresAt,
+    issuedAt: now,
+    paidAt: tier.planCode === 'FREE' ? now : null,
+  };
+
+  const batch = db.batch();
+  batch.set(transactionRef, {
+    ...toTransactionWriteMap(transaction),
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+    createdBy: actorUid,
+    updatedBy: actorUid,
+  });
+  batch.set(invoiceRef, {
+    ...toInvoiceWriteMap(invoice),
+    issuedAt: FieldValue.serverTimestamp(),
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+    createdBy: actorUid,
+    updatedBy: actorUid,
+  });
+  batch.set(
+    subscriptionsCollection.doc(clanId),
+    {
+      status: tier.planCode === 'FREE' ? 'active' : 'pending_payment',
+      lastTransactionId: transaction.id,
+      lastInvoiceId: invoice.id,
+      lastPaymentMethod: paymentMethod,
+      updatedAt: FieldValue.serverTimestamp(),
+      updatedBy: actorUid,
+    },
+    { merge: true },
+  );
+  await batch.commit();
+
+  await writeBillingAuditLog({
+    clanId,
+    actorUid,
+    action: 'checkout_created',
+    entityType: 'paymentTransaction',
+    entityId: transaction.id,
+    after: {
+      planCode: transaction.planCode,
+      amountVnd: transaction.amountVnd,
+      paymentMethod,
+      invoiceId: invoice.id,
+    },
+  });
+
+  return { tier, memberCount, subscription, transaction, invoice };
+}
+
+export async function recordPaymentWebhookEvent({
+  provider,
+  externalEventId,
+  transactionId,
+  payloadHash,
+  validSignature,
+  rawPayload,
+}: {
+  provider: string;
+  externalEventId: string;
+  transactionId: string;
+  payloadHash: string;
+  validSignature: boolean;
+  rawPayload: Record<string, unknown>;
+}): Promise<{ id: string; alreadyProcessed: boolean }> {
+  const key = `${provider}:${externalEventId}`;
+  const ref = webhookEventsCollection.doc(key);
+  const existing = await ref.get();
+  if (existing.exists) {
+    return { id: key, alreadyProcessed: true };
+  }
+
+  await ref.set({
+    id: key,
+    provider,
+    externalEventId,
+    transactionId,
+    payloadHash,
+    validSignature,
+    rawPayload,
+    processedAt: FieldValue.serverTimestamp(),
+    createdAt: FieldValue.serverTimestamp(),
+  });
+
+  return { id: key, alreadyProcessed: false };
+}
+
+export async function applyPaymentResult({
+  transactionId,
+  provider,
+  gatewayReference,
+  paymentStatus,
+  payloadHash,
+  actorUid,
+  now = new Date(),
+}: {
+  transactionId: string;
+  provider: string;
+  gatewayReference: string;
+  paymentStatus: Extract<PaymentStatus, 'succeeded' | 'failed' | 'canceled'>;
+  payloadHash: string;
+  actorUid: string;
+  now?: Date;
+}): Promise<{
+  clanId: string;
+  transaction: BillingTransactionRecord;
+  invoice: BillingInvoiceRecord | null;
+  subscription: BillingSubscriptionRecord | null;
+}> {
+  const transactionRef = transactionsCollection.doc(transactionId);
+  const txnSnapshot = await transactionRef.get();
+  if (!txnSnapshot.exists) {
+    throw new Error(`payment transaction ${transactionId} not found`);
+  }
+
+  const transactionData = mapTransaction(transactionId, txnSnapshot.data() ?? {});
+  if (transactionData.paymentStatus === 'succeeded' && paymentStatus === 'succeeded') {
+    const subscription = await loadSubscription(transactionData.clanId);
+    const invoice = await loadInvoice(transactionData.invoiceId);
+    return {
+      clanId: transactionData.clanId,
+      transaction: transactionData,
+      invoice,
+      subscription,
+    };
+  }
+
+  const invoiceRef = invoicesCollection.doc(transactionData.invoiceId);
+  const subscriptionRef = subscriptionsCollection.doc(transactionData.clanId);
+
+  await db.runTransaction(async (tx) => {
+    const [invoiceSnapshot, subscriptionSnapshot] = await Promise.all([
+      tx.get(invoiceRef),
+      tx.get(subscriptionRef),
+    ]);
+
+    const existingSubscription = subscriptionSnapshot.exists
+      ? mapSubscription(subscriptionSnapshot.id, subscriptionSnapshot.data() ?? {})
+      : null;
+
+    const transactionWrite: Record<string, unknown> = {
+      paymentStatus,
+      gatewayReference,
+      gatewayPayloadHash: payloadHash,
+      provider,
+      updatedAt: FieldValue.serverTimestamp(),
+      updatedBy: actorUid,
+    };
+    if (paymentStatus === 'succeeded') {
+      transactionWrite.paidAt = FieldValue.serverTimestamp();
+      transactionWrite.failedAt = null;
+    } else {
+      transactionWrite.failedAt = FieldValue.serverTimestamp();
+    }
+    tx.set(transactionRef, transactionWrite, { merge: true });
+
+    if (invoiceSnapshot.exists) {
+      tx.set(
+        invoiceRef,
+        {
+          status: paymentStatus === 'succeeded' ? 'paid' : 'failed',
+          paidAt: paymentStatus === 'succeeded' ? FieldValue.serverTimestamp() : null,
+          updatedAt: FieldValue.serverTimestamp(),
+          updatedBy: actorUid,
+        },
+        { merge: true },
+      );
+    }
+
+    if (paymentStatus === 'succeeded') {
+      const tier = resolvePlanByMemberCount(transactionData.memberCount);
+      const anchorStart = existingSubscription?.expiresAt != null &&
+          existingSubscription.expiresAt.getTime() > now.getTime()
+        ? existingSubscription.expiresAt
+        : now;
+      const { startsAt, expiresAt } = computeRenewalWindow({
+        now: anchorStart,
+        years: 1,
+      });
+      const paymentMode = existingSubscription?.paymentMode ?? 'manual';
+      const autoRenew = existingSubscription?.autoRenew ?? false;
+
+      tx.set(
+        subscriptionRef,
+        {
+          id: transactionData.clanId,
+          clanId: transactionData.clanId,
+          planCode: tier.planCode,
+          status: 'active',
+          memberCount: transactionData.memberCount,
+          amountVndYear: tier.priceVndYear,
+          vatIncluded: tier.vatIncluded,
+          paymentMode,
+          autoRenew,
+          showAds: tier.showAds,
+          adFree: tier.adFree,
+          startsAt: Timestamp.fromDate(startsAt),
+          expiresAt: Timestamp.fromDate(expiresAt),
+          nextPaymentDueAt: Timestamp.fromDate(expiresAt),
+          graceEndsAt: null,
+          lastPaymentMethod: transactionData.paymentMethod,
+          lastTransactionId: transactionData.id,
+          lastInvoiceId: transactionData.invoiceId,
+          updatedAt: FieldValue.serverTimestamp(),
+          updatedBy: actorUid,
+          createdAt: FieldValue.serverTimestamp(),
+          createdBy: actorUid,
+        },
+        { merge: true },
+      );
+    } else {
+      tx.set(
+        subscriptionRef,
+        {
+          status: 'expired',
+          updatedAt: FieldValue.serverTimestamp(),
+          updatedBy: actorUid,
+        },
+        { merge: true },
+      );
+    }
+
+    const auditRef = billingAuditLogsCollection.doc();
+    tx.set(auditRef, {
+      id: auditRef.id,
+      clanId: transactionData.clanId,
+      actorUid,
+      action: paymentStatus === 'succeeded' ? 'payment_succeeded' : 'payment_failed',
+      entityType: 'paymentTransaction',
+      entityId: transactionData.id,
+      before: {
+        status: transactionData.paymentStatus,
+      },
+      after: {
+        status: paymentStatus,
+        provider,
+        gatewayReference,
+      },
+      createdAt: FieldValue.serverTimestamp(),
+    });
+  });
+
+  const [refreshedTransaction, refreshedSubscription, refreshedInvoice] = await Promise.all([
+    transactionsCollection.doc(transactionId).get(),
+    subscriptionsCollection.doc(transactionData.clanId).get(),
+    invoicesCollection.doc(transactionData.invoiceId).get(),
+  ]);
+
+  return {
+    clanId: transactionData.clanId,
+    transaction: mapTransaction(transactionId, refreshedTransaction.data() ?? {}),
+    invoice: refreshedInvoice.exists
+      ? mapInvoice(refreshedInvoice.id, refreshedInvoice.data() ?? {})
+      : null,
+    subscription: refreshedSubscription.exists
+      ? mapSubscription(refreshedSubscription.id, refreshedSubscription.data() ?? {})
+      : null,
+  };
+}
+
+export async function resolveBillingAudienceMemberIds(clanId: string): Promise<Array<string>> {
+  const snapshot = await membersCollection.where('clanId', '==', clanId).limit(1000).get();
+  const adminRoles = new Set(['SUPER_ADMIN', 'CLAN_ADMIN', 'BRANCH_ADMIN']);
+  return snapshot.docs
+    .filter((doc) => {
+      const role = readString(doc.data().primaryRole, '').toUpperCase();
+      return adminRoles.has(role);
+    })
+    .map((doc) => doc.id);
+}
+
+export async function writeBillingAuditLog({
+  clanId,
+  actorUid,
+  action,
+  entityType,
+  entityId,
+  before,
+  after,
+}: {
+  clanId: string;
+  actorUid: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  before?: Record<string, unknown>;
+  after?: Record<string, unknown>;
+}): Promise<void> {
+  const ref = billingAuditLogsCollection.doc();
+  await ref.set({
+    id: ref.id,
+    clanId,
+    actorUid,
+    action,
+    entityType,
+    entityId,
+    before: before ?? null,
+    after: after ?? null,
+    createdAt: FieldValue.serverTimestamp(),
+  });
+}
+
+export function buildEntitlementFromSubscription(
+  subscription: BillingSubscriptionRecord,
+): BillingEntitlement {
+  const status = normalizeSubscriptionStatus({
+    status: subscription.status,
+    expiresAt: subscription.expiresAt,
+    graceEndsAt: subscription.graceEndsAt,
+  });
+  return buildEntitlement({
+    planCode: subscription.planCode,
+    status,
+    expiresAt: subscription.expiresAt,
+    nextPaymentDueAt: subscription.nextPaymentDueAt,
+  });
+}
+
+export function resolveTierByPlanCode(planCode: BillingPlanCode): BillingTierPricing {
+  const matched = BILLING_PRICING_TIERS.find((tier) => tier.planCode === planCode);
+  return matched ?? BILLING_PRICING_TIERS[0];
+}
+
+function normalizeStatusForPlan({
+  planCode,
+  currentStatus,
+}: {
+  planCode: BillingPlanCode;
+  currentStatus: SubscriptionStatus;
+}): SubscriptionStatus {
+  if (planCode === 'FREE') {
+    return 'active';
+  }
+  if (currentStatus === 'active' || currentStatus === 'grace_period') {
+    return currentStatus;
+  }
+  if (currentStatus === 'pending_payment') {
+    return currentStatus;
+  }
+  return 'expired';
+}
+
+function seedSubscription({
+  clanId,
+  tier,
+  memberCount,
+  settings,
+  now,
+}: {
+  clanId: string;
+  tier: BillingTierPricing;
+  memberCount: number;
+  settings: BillingSettingsRecord;
+  now: Date;
+}): BillingSubscriptionRecord {
+  if (tier.planCode === 'FREE') {
+    return createSubscriptionDraft({
+      clanId,
+      tier,
+      memberCount,
+      paymentMode: settings.paymentMode,
+      autoRenew: settings.autoRenew,
+      startsAt: now,
+      expiresAt: null,
+      status: 'active',
+      now,
+    });
+  }
+
+  return createSubscriptionDraft({
+    clanId,
+    tier,
+    memberCount,
+    paymentMode: settings.paymentMode,
+    autoRenew: settings.autoRenew,
+    startsAt: null,
+    expiresAt: now,
+    status: 'expired',
+    now,
+  });
+}
+
+function toSubscriptionWriteMap(record: BillingSubscriptionRecord): Record<string, unknown> {
+  return {
+    id: record.id,
+    clanId: record.clanId,
+    planCode: record.planCode,
+    status: record.status,
+    memberCount: record.memberCount,
+    amountVndYear: record.amountVndYear,
+    vatIncluded: record.vatIncluded,
+    paymentMode: record.paymentMode,
+    autoRenew: record.autoRenew,
+    showAds: buildEntitlementFromSubscription(record).showAds,
+    adFree: buildEntitlementFromSubscription(record).adFree,
+    startsAt: toTimestamp(record.startsAt),
+    expiresAt: toTimestamp(record.expiresAt),
+    nextPaymentDueAt: toTimestamp(record.nextPaymentDueAt),
+    graceEndsAt: toTimestamp(record.graceEndsAt),
+    lastPaymentMethod: record.lastPaymentMethod,
+    lastTransactionId: record.lastTransactionId,
+  };
+}
+
+function toTransactionWriteMap(record: BillingTransactionRecord): Record<string, unknown> {
+  return {
+    id: record.id,
+    clanId: record.clanId,
+    subscriptionId: record.subscriptionId,
+    invoiceId: record.invoiceId,
+    paymentMethod: record.paymentMethod,
+    paymentStatus: record.paymentStatus,
+    planCode: record.planCode,
+    memberCount: record.memberCount,
+    amountVnd: record.amountVnd,
+    vatIncluded: record.vatIncluded,
+    currency: record.currency,
+    gatewayReference: record.gatewayReference,
+    gatewayPayloadHash: record.gatewayPayloadHash,
+    paidAt: toTimestamp(record.paidAt),
+    failedAt: toTimestamp(record.failedAt),
+  };
+}
+
+function toInvoiceWriteMap(record: BillingInvoiceRecord): Record<string, unknown> {
+  return {
+    id: record.id,
+    clanId: record.clanId,
+    subscriptionId: record.subscriptionId,
+    transactionId: record.transactionId,
+    planCode: record.planCode,
+    amountVnd: record.amountVnd,
+    vatIncluded: record.vatIncluded,
+    currency: record.currency,
+    status: record.status,
+    periodStart: toTimestamp(record.periodStart),
+    periodEnd: toTimestamp(record.periodEnd),
+    paidAt: toTimestamp(record.paidAt),
+  };
+}
+
+function mapSubscription(id: string, data: Record<string, unknown>): BillingSubscriptionRecord {
+  return {
+    id,
+    clanId: readString(data.clanId, ''),
+    planCode: normalizePlanCode(data.planCode),
+    status: normalizeSubscriptionStatusCode(data.status),
+    memberCount: readNumber(data.memberCount, 0),
+    amountVndYear: readNumber(data.amountVndYear, 0),
+    vatIncluded: readBool(data.vatIncluded, true),
+    paymentMode: normalizePaymentMode(data.paymentMode),
+    autoRenew: readBool(data.autoRenew, false),
+    startsAt: readDate(data.startsAt),
+    expiresAt: readDate(data.expiresAt),
+    nextPaymentDueAt: readDate(data.nextPaymentDueAt),
+    graceEndsAt: readDate(data.graceEndsAt),
+    lastPaymentMethod: nullableString(data.lastPaymentMethod),
+    lastTransactionId: nullableString(data.lastTransactionId),
+    updatedAt: readDate(data.updatedAt),
+  };
+}
+
+function mapTransaction(id: string, data: Record<string, unknown>): BillingTransactionRecord {
+  return {
+    id,
+    clanId: readString(data.clanId, ''),
+    subscriptionId: readString(data.subscriptionId, ''),
+    invoiceId: readString(data.invoiceId, ''),
+    paymentMethod: normalizePaymentMethod(data.paymentMethod),
+    paymentStatus: normalizePaymentStatus(data.paymentStatus),
+    planCode: normalizePlanCode(data.planCode),
+    memberCount: readNumber(data.memberCount, 0),
+    amountVnd: readNumber(data.amountVnd, 0),
+    vatIncluded: readBool(data.vatIncluded, true),
+    currency: readString(data.currency, 'VND'),
+    gatewayReference: nullableString(data.gatewayReference),
+    gatewayPayloadHash: nullableString(data.gatewayPayloadHash),
+    createdAt: readDate(data.createdAt),
+    paidAt: readDate(data.paidAt),
+    failedAt: readDate(data.failedAt),
+  };
+}
+
+function mapInvoice(id: string, data: Record<string, unknown>): BillingInvoiceRecord {
+  return {
+    id,
+    clanId: readString(data.clanId, ''),
+    subscriptionId: readString(data.subscriptionId, ''),
+    transactionId: readString(data.transactionId, ''),
+    planCode: normalizePlanCode(data.planCode),
+    amountVnd: readNumber(data.amountVnd, 0),
+    vatIncluded: readBool(data.vatIncluded, true),
+    currency: readString(data.currency, 'VND'),
+    status: normalizeInvoiceStatus(data.status),
+    periodStart: readDate(data.periodStart),
+    periodEnd: readDate(data.periodEnd),
+    issuedAt: readDate(data.issuedAt),
+    paidAt: readDate(data.paidAt),
+  };
+}
+
+async function loadInvoice(invoiceId: string): Promise<BillingInvoiceRecord | null> {
+  if (invoiceId.trim().length === 0) {
+    return null;
+  }
+  const snapshot = await invoicesCollection.doc(invoiceId).get();
+  if (!snapshot.exists) {
+    return null;
+  }
+  return mapInvoice(snapshot.id, snapshot.data() ?? {});
+}
+
+function normalizePlanCode(value: unknown): BillingPlanCode {
+  const normalized = readString(value, 'FREE').toUpperCase();
+  if (normalized === 'BASE' || normalized === 'PLUS' || normalized === 'PRO') {
+    return normalized;
+  }
+  return 'FREE';
+}
+
+function normalizeSubscriptionStatusCode(value: unknown): SubscriptionStatus {
+  const normalized = readString(value, 'expired').toLowerCase();
+  switch (normalized) {
+    case 'active':
+      return 'active';
+    case 'grace_period':
+      return 'grace_period';
+    case 'pending_payment':
+      return 'pending_payment';
+    case 'canceled':
+      return 'canceled';
+    default:
+      return 'expired';
+  }
+}
+
+function normalizePaymentMode(value: unknown): PaymentMode {
+  return readString(value, 'manual').toLowerCase() === 'auto_renew'
+    ? 'auto_renew'
+    : 'manual';
+}
+
+function normalizePaymentMethod(value: unknown): PaymentMethod {
+  return readString(value, 'card').toLowerCase() === 'vnpay' ? 'vnpay' : 'card';
+}
+
+function normalizePaymentStatus(value: unknown): PaymentStatus {
+  const normalized = readString(value, 'created').toLowerCase();
+  switch (normalized) {
+    case 'pending':
+      return 'pending';
+    case 'succeeded':
+      return 'succeeded';
+    case 'failed':
+      return 'failed';
+    case 'canceled':
+      return 'canceled';
+    default:
+      return 'created';
+  }
+}
+
+function normalizeInvoiceStatus(
+  value: unknown,
+): BillingInvoiceRecord['status'] {
+  const normalized = readString(value, 'issued').toLowerCase();
+  switch (normalized) {
+    case 'paid':
+      return 'paid';
+    case 'failed':
+      return 'failed';
+    case 'void':
+      return 'void';
+    default:
+      return 'issued';
+  }
+}
+
+function normalizeReminderDays(value: unknown): Array<number> {
+  const fallback = [30, 14, 7, 3, 1];
+  if (!Array.isArray(value)) {
+    return fallback;
+  }
+  const values = value
+    .map((item) => (typeof item === 'number' ? Math.trunc(item) : Number.NaN))
+    .filter((item) => Number.isFinite(item) && item > 0 && item <= 60);
+  if (values.length === 0) {
+    return fallback;
+  }
+  return [...new Set(values)].sort((left, right) => right - left);
+}
+
+function readDate(value: unknown): NullableDate {
+  if (value == null) {
+    return null;
+  }
+  if (value instanceof Timestamp) {
+    return value.toDate();
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  if (
+    typeof value === 'object' &&
+    value != null &&
+    'toDate' in value &&
+    typeof (value as { toDate?: unknown }).toDate === 'function'
+  ) {
+    try {
+      return (value as { toDate: () => Date }).toDate();
+    } catch {
+      return null;
+    }
+  }
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function readString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : fallback;
+}
+
+function nullableString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function readNumber(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return Math.trunc(parsed);
+    }
+  }
+  return fallback;
+}
+
+function readBool(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function toTimestamp(value: NullableDate): Timestamp | null {
+  if (value == null) {
+    return null;
+  }
+  return Timestamp.fromDate(value);
+}

--- a/firebase/functions/src/billing/subscription-lifecycle.ts
+++ b/firebase/functions/src/billing/subscription-lifecycle.ts
@@ -1,0 +1,133 @@
+import {
+  type BillingPlanCode,
+  type BillingTierPricing,
+  type PaymentMode,
+  type SubscriptionStatus,
+  canAccessPremiumFeatures,
+  shouldShowAds,
+} from './pricing';
+
+type NullableDate = Date | null;
+
+export type BillingSubscriptionRecord = {
+  id: string;
+  clanId: string;
+  planCode: BillingPlanCode;
+  status: SubscriptionStatus;
+  memberCount: number;
+  amountVndYear: number;
+  vatIncluded: boolean;
+  paymentMode: PaymentMode;
+  autoRenew: boolean;
+  startsAt: NullableDate;
+  expiresAt: NullableDate;
+  nextPaymentDueAt: NullableDate;
+  graceEndsAt: NullableDate;
+  lastPaymentMethod: string | null;
+  lastTransactionId: string | null;
+  updatedAt: NullableDate;
+};
+
+export type BillingEntitlement = {
+  planCode: BillingPlanCode;
+  status: SubscriptionStatus;
+  showAds: boolean;
+  adFree: boolean;
+  hasPremiumAccess: boolean;
+  expiresAtIso: string | null;
+  nextPaymentDueAtIso: string | null;
+};
+
+export function normalizeSubscriptionStatus({
+  status,
+  expiresAt,
+  graceEndsAt,
+  now = new Date(),
+}: {
+  status: SubscriptionStatus;
+  expiresAt: NullableDate;
+  graceEndsAt: NullableDate;
+  now?: Date;
+}): SubscriptionStatus {
+  if (status === 'canceled') {
+    return 'canceled';
+  }
+  if (status === 'pending_payment') {
+    return 'pending_payment';
+  }
+
+  if (expiresAt == null) {
+    return status;
+  }
+  if (expiresAt.getTime() > now.getTime()) {
+    return 'active';
+  }
+  if (graceEndsAt != null && graceEndsAt.getTime() > now.getTime()) {
+    return 'grace_period';
+  }
+  return 'expired';
+}
+
+export function buildEntitlement({
+  planCode,
+  status,
+  expiresAt,
+  nextPaymentDueAt,
+}: {
+  planCode: BillingPlanCode;
+  status: SubscriptionStatus;
+  expiresAt: NullableDate;
+  nextPaymentDueAt: NullableDate;
+}): BillingEntitlement {
+  const showAds = shouldShowAds(planCode, status);
+  return {
+    planCode,
+    status,
+    showAds,
+    adFree: !showAds,
+    hasPremiumAccess: canAccessPremiumFeatures(planCode, status),
+    expiresAtIso: expiresAt?.toISOString() ?? null,
+    nextPaymentDueAtIso: nextPaymentDueAt?.toISOString() ?? null,
+  };
+}
+
+export function createSubscriptionDraft({
+  clanId,
+  tier,
+  memberCount,
+  paymentMode,
+  autoRenew,
+  startsAt,
+  expiresAt,
+  status = 'active',
+  now = new Date(),
+}: {
+  clanId: string;
+  tier: BillingTierPricing;
+  memberCount: number;
+  paymentMode: PaymentMode;
+  autoRenew: boolean;
+  startsAt: NullableDate;
+  expiresAt: NullableDate;
+  status?: SubscriptionStatus;
+  now?: Date;
+}): BillingSubscriptionRecord {
+  return {
+    id: clanId,
+    clanId,
+    planCode: tier.planCode,
+    status,
+    memberCount,
+    amountVndYear: tier.priceVndYear,
+    vatIncluded: tier.vatIncluded,
+    paymentMode,
+    autoRenew,
+    startsAt,
+    expiresAt,
+    nextPaymentDueAt: expiresAt,
+    graceEndsAt: null,
+    lastPaymentMethod: null,
+    lastTransactionId: null,
+    updatedAt: now,
+  };
+}

--- a/firebase/functions/src/billing/subscription-reminders.ts
+++ b/firebase/functions/src/billing/subscription-reminders.ts
@@ -1,0 +1,177 @@
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
+
+import { db } from '../shared/firestore';
+import { notifyMembers } from '../notifications/push-delivery';
+import { logInfo, logWarn } from '../shared/logger';
+import { loadBillingSettings, resolveBillingAudienceMemberIds } from './store';
+
+type ReminderRunInput = {
+  source: string;
+  now?: Date;
+  lookAheadDays?: number;
+};
+
+type ReminderRunResult = {
+  scanned: number;
+  reminderCandidates: number;
+  remindersSent: number;
+  skippedNoAudience: number;
+  skippedNotDue: number;
+};
+
+const subscriptionsCollection = db.collection('subscriptions');
+
+export async function sendSubscriptionRemindersRun(
+  input: ReminderRunInput,
+): Promise<ReminderRunResult> {
+  const now = input.now ?? new Date();
+  const lookAheadDays = Math.max(1, Math.min(60, input.lookAheadDays ?? 30));
+  const deadline = addDays(now, lookAheadDays);
+
+  const snapshot = await subscriptionsCollection
+    .where('status', 'in', ['active', 'grace_period'])
+    .where('expiresAt', '>=', Timestamp.fromDate(now))
+    .where('expiresAt', '<=', Timestamp.fromDate(deadline))
+    .orderBy('expiresAt', 'asc')
+    .limit(400)
+    .get();
+
+  let reminderCandidates = 0;
+  let remindersSent = 0;
+  let skippedNoAudience = 0;
+  let skippedNotDue = 0;
+
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    const clanId = normalizeString(data.clanId ?? doc.id);
+    if (clanId.length === 0) {
+      continue;
+    }
+
+    const expiresAt = toDate(data.expiresAt);
+    if (expiresAt == null) {
+      continue;
+    }
+
+    const daysLeft = diffWholeDays(now, expiresAt);
+    if (daysLeft < 0) {
+      continue;
+    }
+
+    const [settings, memberIds] = await Promise.all([
+      loadBillingSettings(clanId),
+      resolveBillingAudienceMemberIds(clanId),
+    ]);
+
+    reminderCandidates += 1;
+    if (memberIds.length === 0) {
+      skippedNoAudience += 1;
+      continue;
+    }
+    if (!settings.reminderDaysBefore.includes(daysLeft)) {
+      skippedNotDue += 1;
+      continue;
+    }
+
+    const marker = `${toUtcDateKey(now)}:${daysLeft}`;
+    const lastReminderMarker = normalizeString(data.lastReminderMarker);
+    if (marker == lastReminderMarker) {
+      skippedNotDue += 1;
+      continue;
+    }
+
+    await notifyMembers({
+      clanId,
+      memberIds,
+      type: 'billing_subscription_expiry_reminder',
+      title: daysLeft <= 1
+        ? 'Subscription expires tomorrow'
+        : `Subscription expires in ${daysLeft} days`,
+      body: `Current plan will expire on ${formatDate(expiresAt)}. Open Billing to renew.`,
+      target: 'generic',
+      targetId: doc.id,
+      extraData: {
+        billing: 'true',
+        reminderType: 'subscription_expiry',
+        daysLeft: `${daysLeft}`,
+      },
+    });
+    remindersSent += 1;
+
+    await doc.ref.set(
+      {
+        lastReminderAt: FieldValue.serverTimestamp(),
+        lastReminderDaysLeft: daysLeft,
+        lastReminderMarker: marker,
+        updatedAt: FieldValue.serverTimestamp(),
+        updatedBy: input.source,
+      },
+      { merge: true },
+    );
+  }
+
+  const result: ReminderRunResult = {
+    scanned: snapshot.size,
+    reminderCandidates,
+    remindersSent,
+    skippedNoAudience,
+    skippedNotDue,
+  };
+
+  logInfo('subscription reminder run complete', {
+    source: input.source,
+    ...result,
+  });
+  return result;
+}
+
+function toDate(value: unknown): Date | null {
+  if (value instanceof Timestamp) {
+    return value.toDate();
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  if (
+    value != null &&
+    typeof value === 'object' &&
+    'toDate' in value &&
+    typeof (value as { toDate?: unknown }).toDate === 'function'
+  ) {
+    try {
+      return (value as { toDate: () => Date }).toDate();
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function addDays(base: Date, days: number): Date {
+  const next = new Date(base);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function diffWholeDays(left: Date, right: Date): number {
+  const leftUtc = Date.UTC(left.getUTCFullYear(), left.getUTCMonth(), left.getUTCDate());
+  const rightUtc = Date.UTC(right.getUTCFullYear(), right.getUTCMonth(), right.getUTCDate());
+  return Math.trunc((rightUtc - leftUtc) / (1000 * 60 * 60 * 24));
+}
+
+function toUtcDateKey(value: Date): string {
+  const year = value.getUTCFullYear();
+  const month = `${value.getUTCMonth() + 1}`.padStart(2, '0');
+  const day = `${value.getUTCDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function formatDate(value: Date): string {
+  const day = `${value.getUTCDate()}`.padStart(2, '0');
+  const month = `${value.getUTCMonth() + 1}`.padStart(2, '0');
+  return `${day}/${month}/${value.getUTCFullYear()}`;
+}

--- a/firebase/functions/src/billing/webhooks.ts
+++ b/firebase/functions/src/billing/webhooks.ts
@@ -1,0 +1,322 @@
+import { createHash, createHmac } from 'node:crypto';
+
+import { onRequest } from 'firebase-functions/v2/https';
+
+import { APP_REGION } from '../config/runtime';
+import {
+  applyPaymentResult,
+  recordPaymentWebhookEvent,
+  resolveBillingAudienceMemberIds,
+} from './store';
+import { notifyMembers } from '../notifications/push-delivery';
+import { logError, logInfo, logWarn } from '../shared/logger';
+
+export const vnpayPaymentCallback = onRequest(
+  { region: APP_REGION },
+  async (request, response) => {
+    if (request.method !== 'GET') {
+      response.status(405).json({ ok: false, message: 'Method not allowed' });
+      return;
+    }
+
+    const params = normalizeQueryParams(request.query);
+    const transactionId = params.vnp_TxnRef ?? '';
+    if (transactionId.length === 0) {
+      response.status(400).json({ ok: false, message: 'vnp_TxnRef is required' });
+      return;
+    }
+
+    const payloadHash = sha256(JSON.stringify(params));
+    const signatureValid = isValidVnpaySignature(params);
+    const externalEventId =
+      params.vnp_TransactionNo ?? params.vnp_TxnRef ?? `${Date.now()}`;
+
+    const webhookEvent = await recordPaymentWebhookEvent({
+      provider: 'vnpay',
+      externalEventId,
+      transactionId,
+      payloadHash,
+      validSignature: signatureValid,
+      rawPayload: params,
+    });
+    if (webhookEvent.alreadyProcessed) {
+      response.status(200).json({
+        ok: true,
+        idempotent: true,
+        transactionId,
+      });
+      return;
+    }
+
+    if (!signatureValid) {
+      logWarn('vnpay callback rejected due to invalid signature', {
+        transactionId,
+        externalEventId,
+      });
+      response.status(401).json({
+        ok: false,
+        message: 'Invalid VNPay signature',
+      });
+      return;
+    }
+
+    const responseCode = params.vnp_ResponseCode ?? '';
+    const paymentStatus =
+      responseCode === '00' ? 'succeeded' : responseCode === '24' ? 'canceled' : 'failed';
+
+    try {
+      const result = await applyPaymentResult({
+        transactionId,
+        provider: 'vnpay',
+        gatewayReference: params.vnp_TransactionNo ?? transactionId,
+        paymentStatus,
+        payloadHash,
+        actorUid: 'system:vnpay_webhook',
+      });
+      await notifyBillingWebhookResult({
+        clanId: result.clanId,
+        transactionId,
+        amountVnd: Number(result.transaction.amountVnd),
+        provider: 'vnpay',
+        approved: paymentStatus === 'succeeded',
+      });
+
+      logInfo('vnpay callback processed', {
+        transactionId,
+        paymentStatus,
+        responseCode,
+      });
+      response.status(200).json({
+        ok: true,
+        transactionId,
+        paymentStatus,
+      });
+    } catch (error) {
+      logError('vnpay callback processing failed', {
+        transactionId,
+        error: `${error}`,
+      });
+      response.status(500).json({
+        ok: false,
+        message: 'Could not process VNPay callback',
+      });
+    }
+  },
+);
+
+export const cardPaymentCallback = onRequest(
+  { region: APP_REGION },
+  async (request, response) => {
+    if (!['GET', 'POST'].includes(request.method)) {
+      response.status(405).json({ ok: false, message: 'Method not allowed' });
+      return;
+    }
+
+    const payload = mergeCardPayload(request.query, request.body);
+    const transactionId = payload.transactionId;
+    if (transactionId.length === 0) {
+      response.status(400).json({ ok: false, message: 'transactionId is required' });
+      return;
+    }
+    const externalEventId = payload.gatewayReference.length > 0
+      ? payload.gatewayReference
+      : `card-${transactionId}-${Date.now()}`;
+    const payloadHash = sha256(JSON.stringify(payload));
+    const signatureValid = isValidCardSignature(payload);
+
+    const webhookEvent = await recordPaymentWebhookEvent({
+      provider: 'card',
+      externalEventId,
+      transactionId,
+      payloadHash,
+      validSignature: signatureValid,
+      rawPayload: payload,
+    });
+    if (webhookEvent.alreadyProcessed) {
+      response.status(200).json({
+        ok: true,
+        idempotent: true,
+        transactionId,
+      });
+      return;
+    }
+
+    if (!signatureValid) {
+      response.status(401).json({ ok: false, message: 'Invalid card callback signature' });
+      return;
+    }
+
+    const paymentStatus = normalizeCardStatus(payload.status);
+
+    try {
+      const result = await applyPaymentResult({
+        transactionId,
+        provider: 'card',
+        gatewayReference: payload.gatewayReference,
+        paymentStatus,
+        payloadHash,
+        actorUid: 'system:card_webhook',
+      });
+      await notifyBillingWebhookResult({
+        clanId: result.clanId,
+        transactionId,
+        amountVnd: Number(result.transaction.amountVnd),
+        provider: 'card',
+        approved: paymentStatus === 'succeeded',
+      });
+      response.status(200).json({
+        ok: true,
+        transactionId,
+        paymentStatus,
+      });
+    } catch (error) {
+      response.status(500).json({
+        ok: false,
+        message: 'Could not process card callback',
+        error: `${error}`,
+      });
+    }
+  },
+);
+
+type CardPayload = {
+  transactionId: string;
+  status: string;
+  gatewayReference: string;
+  signature: string;
+};
+
+function mergeCardPayload(query: unknown, body: unknown): CardPayload {
+  const merged = {
+    ...(query != null && typeof query === 'object'
+      ? (query as Record<string, unknown>)
+      : {}),
+    ...(body != null && typeof body === 'object'
+      ? (body as Record<string, unknown>)
+      : {}),
+  };
+
+  return {
+    transactionId: normalizeString(merged.transactionId ?? merged.tx),
+    status: normalizeString(merged.status),
+    gatewayReference: normalizeString(merged.gatewayReference ?? merged.gatewayRef),
+    signature: normalizeString(merged.signature),
+  };
+}
+
+function normalizeCardStatus(status: string): 'succeeded' | 'failed' | 'canceled' {
+  const normalized = status.trim().toLowerCase();
+  if (normalized === 'success' || normalized === 'succeeded' || normalized === 'paid') {
+    return 'succeeded';
+  }
+  if (normalized === 'canceled' || normalized === 'cancelled') {
+    return 'canceled';
+  }
+  return 'failed';
+}
+
+function isValidCardSignature(payload: CardPayload): boolean {
+  const secret = process.env.CARD_WEBHOOK_SECRET ?? process.env.BILLING_WEBHOOK_SECRET;
+  if (secret == null || secret.trim().length === 0) {
+    return false;
+  }
+  const canonical = `${payload.transactionId}|${payload.status}|${payload.gatewayReference}`;
+  const expected = createHmac('sha256', secret).update(canonical).digest('hex');
+  return safeEqual(expected, payload.signature);
+}
+
+function normalizeQueryParams(query: unknown): Record<string, string> {
+  if (query == null || typeof query !== 'object') {
+    return {};
+  }
+  const output: Record<string, string> = {};
+  for (const [key, value] of Object.entries(query as Record<string, unknown>)) {
+    if (typeof value === 'string') {
+      output[key] = value.trim();
+      continue;
+    }
+    if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
+      output[key] = value[0].trim();
+    }
+  }
+  return output;
+}
+
+export function isValidVnpaySignature(params: Record<string, string>): boolean {
+  const secureHash = params.vnp_SecureHash;
+  const hashSecret = process.env.VNPAY_HASH_SECRET?.trim() ?? '';
+  if (secureHash == null || secureHash.length === 0 || hashSecret.length === 0) {
+    return false;
+  }
+
+  const canonical = Object.entries(params)
+    .filter(([key]) => key !== 'vnp_SecureHash' && key !== 'vnp_SecureHashType')
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join('&');
+  const expected = createHmac('sha512', hashSecret).update(canonical).digest('hex');
+  return safeEqual(expected, secureHash);
+}
+
+async function notifyBillingWebhookResult({
+  clanId,
+  approved,
+  amountVnd,
+  transactionId,
+  provider,
+}: {
+  clanId: string;
+  approved: boolean;
+  amountVnd: number;
+  transactionId: string;
+  provider: string;
+}): Promise<void> {
+  const memberIds = await resolveBillingAudienceMemberIds(clanId);
+  if (memberIds.length === 0) {
+    return;
+  }
+
+  await notifyMembers({
+    clanId,
+    memberIds,
+    type: approved ? 'billing_payment_succeeded' : 'billing_payment_failed',
+    title: approved ? 'Subscription payment confirmed' : 'Subscription payment failed',
+    body: approved
+      ? `${formatVnd(amountVnd)} via ${provider.toUpperCase()} has been confirmed.`
+      : `${formatVnd(amountVnd)} via ${provider.toUpperCase()} did not complete.`,
+    target: 'generic',
+    targetId: transactionId,
+    extraData: {
+      transactionId,
+      billing: 'true',
+      result: approved ? 'success' : 'failed',
+      provider,
+    },
+  });
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const a = left.trim().toLowerCase();
+  const b = right.trim().toLowerCase();
+  if (a.length === 0 || b.length === 0 || a.length !== b.length) {
+    return false;
+  }
+
+  let mismatch = 0;
+  for (let index = 0; index < a.length; index += 1) {
+    mismatch |= a.charCodeAt(index) ^ b.charCodeAt(index);
+  }
+  return mismatch === 0;
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function formatVnd(amount: number): string {
+  return `${Math.max(0, Math.trunc(amount)).toLocaleString('vi-VN')} VND`;
+}

--- a/firebase/functions/src/contract-tests/billing.contract.test.ts
+++ b/firebase/functions/src/contract-tests/billing.contract.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import test from 'node:test';
+
+import { isValidVnpaySignature } from '../billing/webhooks';
+import {
+  canAccessPremiumFeatures,
+  resolvePlanByMemberCount,
+  shouldShowAds,
+} from '../billing/pricing';
+import { normalizeSubscriptionStatus } from '../billing/subscription-lifecycle';
+
+test('billing contract: member-count pricing tiers are non-overlapping (+1 boundaries)', () => {
+  assert.equal(resolvePlanByMemberCount(10).planCode, 'FREE');
+  assert.equal(resolvePlanByMemberCount(11).planCode, 'BASE');
+  assert.equal(resolvePlanByMemberCount(200).planCode, 'BASE');
+  assert.equal(resolvePlanByMemberCount(201).planCode, 'PLUS');
+  assert.equal(resolvePlanByMemberCount(700).planCode, 'PLUS');
+  assert.equal(resolvePlanByMemberCount(701).planCode, 'PRO');
+});
+
+test('billing contract: ad entitlement and premium access follow plan + status', () => {
+  assert.equal(shouldShowAds('FREE', 'active'), true);
+  assert.equal(shouldShowAds('BASE', 'active'), true);
+  assert.equal(shouldShowAds('PLUS', 'active'), false);
+  assert.equal(shouldShowAds('PRO', 'active'), false);
+
+  assert.equal(canAccessPremiumFeatures('PLUS', 'active'), true);
+  assert.equal(canAccessPremiumFeatures('PRO', 'grace_period'), true);
+  assert.equal(canAccessPremiumFeatures('PRO', 'expired'), false);
+  assert.equal(canAccessPremiumFeatures('BASE', 'active'), true);
+});
+
+test('billing contract: lifecycle status normalizes by expiry and grace period', () => {
+  const now = new Date(Date.UTC(2026, 2, 15, 10, 0, 0));
+  assert.equal(
+    normalizeSubscriptionStatus({
+      status: 'active',
+      expiresAt: new Date(Date.UTC(2026, 2, 20, 0, 0, 0)),
+      graceEndsAt: null,
+      now,
+    }),
+    'active',
+  );
+
+  assert.equal(
+    normalizeSubscriptionStatus({
+      status: 'active',
+      expiresAt: new Date(Date.UTC(2026, 2, 14, 0, 0, 0)),
+      graceEndsAt: new Date(Date.UTC(2026, 2, 16, 0, 0, 0)),
+      now,
+    }),
+    'grace_period',
+  );
+
+  assert.equal(
+    normalizeSubscriptionStatus({
+      status: 'active',
+      expiresAt: new Date(Date.UTC(2026, 2, 10, 0, 0, 0)),
+      graceEndsAt: new Date(Date.UTC(2026, 2, 12, 0, 0, 0)),
+      now,
+    }),
+    'expired',
+  );
+});
+
+test('billing contract: VNPay callback signature is validated', () => {
+  process.env.VNPAY_HASH_SECRET = 'contract-test-secret';
+
+  const params: Record<string, string> = {
+    vnp_Amount: '4900000',
+    vnp_Command: 'pay',
+    vnp_CreateDate: '20260315120000',
+    vnp_CurrCode: 'VND',
+    vnp_Locale: 'vn',
+    vnp_OrderInfo: 'BeFam BASE annual subscription',
+    vnp_OrderType: 'billpayment',
+    vnp_ResponseCode: '00',
+    vnp_TmnCode: 'DEMO1234',
+    vnp_TransactionNo: '15190022',
+    vnp_TxnRef: 'txn_contract_001',
+    vnp_Version: '2.1.0',
+  };
+
+  const canonical = Object.entries(params)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join('&');
+
+  params.vnp_SecureHash = createHmac('sha512', process.env.VNPAY_HASH_SECRET)
+    .update(canonical)
+    .digest('hex');
+
+  assert.equal(isValidVnpaySignature(params), true);
+
+  params.vnp_SecureHash = `${params.vnp_SecureHash.substring(0, 30)}broken`;
+  assert.equal(isValidVnpaySignature(params), false);
+});

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -7,6 +7,15 @@ import {
   registerDeviceToken,
   resolveChildLoginContext,
 } from './auth/callables';
+import {
+  completeCardCheckout,
+  createSubscriptionCheckout,
+  loadBillingWorkspace,
+  resolveBillingEntitlement,
+  simulateVnpaySettlement,
+  updateBillingPreferences,
+} from './billing/callables';
+import { cardPaymentCallback, vnpayPaymentCallback } from './billing/webhooks';
 import { APP_REGION } from './config/runtime';
 import { onEventCreated, sendEventReminder } from './events/event-triggers';
 import {
@@ -17,7 +26,7 @@ import {
   onRelationshipCreated,
   onRelationshipDeleted,
 } from './genealogy/relationship-triggers';
-import { expireInvitesJob } from './scheduled/jobs';
+import { billingSubscriptionReminderJob, expireInvitesJob } from './scheduled/jobs';
 import { onSubmissionReviewed } from './scholarship/submission-triggers';
 import { onTransactionCreated } from './funds/transaction-triggers';
 
@@ -29,17 +38,26 @@ setGlobalOptions({
 });
 
 export {
+  billingSubscriptionReminderJob,
+  cardPaymentCallback,
   claimMemberRecord,
+  completeCardCheckout,
   createParentChildRelationship,
   createSpouseRelationship,
   createInvite,
+  createSubscriptionCheckout,
   expireInvitesJob,
+  loadBillingWorkspace,
   onEventCreated,
   onRelationshipCreated,
   onRelationshipDeleted,
   onSubmissionReviewed,
   onTransactionCreated,
   registerDeviceToken,
+  resolveBillingEntitlement,
   resolveChildLoginContext,
   sendEventReminder,
+  simulateVnpaySettlement,
+  updateBillingPreferences,
+  vnpayPaymentCallback,
 };

--- a/firebase/functions/src/scheduled/jobs.ts
+++ b/firebase/functions/src/scheduled/jobs.ts
@@ -3,6 +3,7 @@ import { onSchedule } from 'firebase-functions/v2/scheduler';
 import { APP_REGION, APP_TIMEZONE } from '../config/runtime';
 import { expireInvitesJobRun } from './invite-expiration';
 import { logInfo } from '../shared/logger';
+import { sendSubscriptionRemindersRun } from '../billing/subscription-reminders';
 
 export const expireInvitesJob = onSchedule(
   {
@@ -15,5 +16,19 @@ export const expireInvitesJob = onSchedule(
       source: 'function:expireInvitesJob',
     });
     logInfo('expireInvitesJob tick complete', result);
+  },
+);
+
+export const billingSubscriptionReminderJob = onSchedule(
+  {
+    schedule: '0 7 * * *',
+    region: APP_REGION,
+    timeZone: APP_TIMEZONE,
+  },
+  async () => {
+    const result = await sendSubscriptionRemindersRun({
+      source: 'function:billingSubscriptionReminderJob',
+    });
+    logInfo('billingSubscriptionReminderJob tick complete', result);
   },
 );

--- a/mobile/befam/lib/app/home/app_shell_page.dart
+++ b/mobile/befam/lib/app/home/app_shell_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../features/billing/services/billing_repository.dart';
 import '../../features/clan/presentation/clan_detail_page.dart';
 import '../../features/clan/services/clan_repository.dart';
 import '../../features/calendar/presentation/dual_calendar_workspace_page.dart';
@@ -37,6 +38,7 @@ class AppShellPage extends StatefulWidget {
     required this.memberRepository,
     this.fundRepository,
     this.genealogyRepository,
+    this.billingRepository,
     this.pushNotificationService,
     this.localeController,
     this.onLogoutRequested,
@@ -48,6 +50,7 @@ class AppShellPage extends StatefulWidget {
   final MemberRepository memberRepository;
   final FundRepository? fundRepository;
   final GenealogyReadRepository? genealogyRepository;
+  final BillingRepository? billingRepository;
   final PushNotificationService? pushNotificationService;
   final AppLocaleController? localeController;
   final Future<void> Function()? onLogoutRequested;
@@ -61,8 +64,12 @@ class _AppShellPageState extends State<AppShellPage> {
   final Set<int> _visitedDestinationIndexes = <int>{0};
   late final GenealogyReadRepository _genealogyRepository;
   late final FundRepository _fundRepository;
+  late final BillingRepository _billingRepository;
   late final PushNotificationService _pushNotificationService;
   String? _lastOpenedNotificationMessageId;
+  bool _showAdBanner = true;
+  bool _isResolvingBillingEntitlement = false;
+  bool _dismissAdBannerForSession = false;
 
   static const List<_ShellDestination> _destinations = [
     _ShellDestination(
@@ -93,6 +100,7 @@ class _AppShellPageState extends State<AppShellPage> {
     _genealogyRepository =
         widget.genealogyRepository ?? createDefaultGenealogyReadRepository();
     _fundRepository = widget.fundRepository ?? createDefaultFundRepository();
+    _billingRepository = widget.billingRepository ?? createDefaultBillingRepository();
     _pushNotificationService =
         widget.pushNotificationService ??
         createDefaultPushNotificationService();
@@ -102,6 +110,7 @@ class _AppShellPageState extends State<AppShellPage> {
         onDeepLink: _handleNotificationDeepLink,
       ),
     );
+    unawaited(_refreshBillingEntitlement());
   }
 
   @override
@@ -114,6 +123,8 @@ class _AppShellPageState extends State<AppShellPage> {
           onDeepLink: _handleNotificationDeepLink,
         ),
       );
+      _dismissAdBannerForSession = false;
+      unawaited(_refreshBillingEntitlement());
     }
   }
 
@@ -234,6 +245,46 @@ class _AppShellPageState extends State<AppShellPage> {
     };
   }
 
+  Future<void> _refreshBillingEntitlement() async {
+    if (_isResolvingBillingEntitlement) {
+      return;
+    }
+    if (!_hasBillingContext(widget.session)) {
+      if (mounted) {
+        setState(() {
+          _showAdBanner = true;
+        });
+      }
+      return;
+    }
+
+    _isResolvingBillingEntitlement = true;
+    try {
+      final entitlement = await _billingRepository.resolveEntitlement(
+        session: widget.session,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _showAdBanner = entitlement.showAds;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _showAdBanner = true;
+      });
+    } finally {
+      _isResolvingBillingEntitlement = false;
+    }
+  }
+
+  bool _hasBillingContext(AuthSession session) {
+    return (session.clanId ?? '').trim().isNotEmpty;
+  }
+
   Future<void> _confirmLogoutRequest() async {
     if (widget.onLogoutRequested == null) {
       return;
@@ -315,6 +366,10 @@ class _AppShellPageState extends State<AppShellPage> {
         ProfileWorkspacePage(
           session: widget.session,
           memberRepository: widget.memberRepository,
+          billingRepository: _billingRepository,
+          onBillingStateChanged: () {
+            unawaited(_refreshBillingEntitlement());
+          },
           localeController: widget.localeController,
           onLogoutRequested: widget.onLogoutRequested,
         )
@@ -367,22 +422,81 @@ class _AppShellPageState extends State<AppShellPage> {
       body: SafeArea(
         child: IndexedStack(index: _selectedIndex, children: pages),
       ),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: _selectedIndex,
-        onDestinationSelected: (index) {
-          setState(() {
-            _selectedIndex = index;
-            _visitedDestinationIndexes.add(index);
-          });
-        },
-        destinations: [
-          for (final destination in _destinations)
-            NavigationDestination(
-              icon: Icon(destination.icon),
-              selectedIcon: Icon(destination.selectedIcon),
-              label: l10n.shellDestinationLabel(destination.id),
+      bottomNavigationBar: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (_showAdBanner && !_dismissAdBannerForSession)
+            _SponsoredAdBanner(
+              onClose: () {
+                setState(() {
+                  _dismissAdBannerForSession = true;
+                });
+              },
             ),
+          NavigationBar(
+            selectedIndex: _selectedIndex,
+            onDestinationSelected: (index) {
+              setState(() {
+                _selectedIndex = index;
+                _visitedDestinationIndexes.add(index);
+              });
+            },
+            destinations: [
+              for (final destination in _destinations)
+                NavigationDestination(
+                  icon: Icon(destination.icon),
+                  selectedIcon: Icon(destination.selectedIcon),
+                  label: l10n.shellDestinationLabel(destination.id),
+                ),
+            ],
+          ),
         ],
+      ),
+    );
+  }
+}
+
+class _SponsoredAdBanner extends StatelessWidget {
+  const _SponsoredAdBanner({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final colorScheme = Theme.of(context).colorScheme;
+    return Material(
+      color: colorScheme.tertiaryContainer.withValues(alpha: 0.88),
+      child: SafeArea(
+        top: false,
+        minimum: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        child: Row(
+          children: [
+            Icon(
+              Icons.campaign_outlined,
+              color: colorScheme.onTertiaryContainer,
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                l10n.pick(
+                  vi: 'Quảng cáo nhẹ đang hiển thị trong gói Free/Base. Nâng cấp Plus/Pro để tắt hoàn toàn quảng cáo.',
+                  en: 'Light ads are active on Free/Base plans. Upgrade to Plus/Pro for a fully ad-free experience.',
+                ),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onTertiaryContainer,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+            IconButton(
+              tooltip: l10n.pick(vi: 'Đóng', en: 'Close'),
+              onPressed: onClose,
+              icon: const Icon(Icons.close),
+              color: colorScheme.onTertiaryContainer,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/befam/lib/features/billing/models/billing_workspace_snapshot.dart
+++ b/mobile/befam/lib/features/billing/models/billing_workspace_snapshot.dart
@@ -1,0 +1,235 @@
+class BillingWorkspaceSnapshot {
+  const BillingWorkspaceSnapshot({
+    required this.clanId,
+    required this.subscription,
+    required this.entitlement,
+    required this.settings,
+    required this.pricingTiers,
+    required this.memberCount,
+    required this.transactions,
+    required this.invoices,
+    required this.auditLogs,
+  });
+
+  final String clanId;
+  final BillingSubscription subscription;
+  final BillingEntitlement entitlement;
+  final BillingSettings settings;
+  final List<BillingPlanPricing> pricingTiers;
+  final int memberCount;
+  final List<BillingPaymentTransaction> transactions;
+  final List<BillingInvoice> invoices;
+  final List<BillingAuditLog> auditLogs;
+}
+
+class BillingSubscription {
+  const BillingSubscription({
+    required this.id,
+    required this.clanId,
+    required this.planCode,
+    required this.status,
+    required this.memberCount,
+    required this.amountVndYear,
+    required this.vatIncluded,
+    required this.paymentMode,
+    required this.autoRenew,
+    required this.startsAtIso,
+    required this.expiresAtIso,
+    required this.nextPaymentDueAtIso,
+    required this.graceEndsAtIso,
+    required this.lastPaymentMethod,
+    required this.lastTransactionId,
+    required this.updatedAtIso,
+  });
+
+  final String id;
+  final String clanId;
+  final String planCode;
+  final String status;
+  final int memberCount;
+  final int amountVndYear;
+  final bool vatIncluded;
+  final String paymentMode;
+  final bool autoRenew;
+  final String? startsAtIso;
+  final String? expiresAtIso;
+  final String? nextPaymentDueAtIso;
+  final String? graceEndsAtIso;
+  final String? lastPaymentMethod;
+  final String? lastTransactionId;
+  final String? updatedAtIso;
+}
+
+class BillingEntitlement {
+  const BillingEntitlement({
+    required this.planCode,
+    required this.status,
+    required this.showAds,
+    required this.adFree,
+    required this.hasPremiumAccess,
+    required this.expiresAtIso,
+    required this.nextPaymentDueAtIso,
+  });
+
+  final String planCode;
+  final String status;
+  final bool showAds;
+  final bool adFree;
+  final bool hasPremiumAccess;
+  final String? expiresAtIso;
+  final String? nextPaymentDueAtIso;
+}
+
+class BillingSettings {
+  const BillingSettings({
+    required this.id,
+    required this.clanId,
+    required this.paymentMode,
+    required this.autoRenew,
+    required this.reminderDaysBefore,
+    required this.updatedAtIso,
+  });
+
+  final String id;
+  final String clanId;
+  final String paymentMode;
+  final bool autoRenew;
+  final List<int> reminderDaysBefore;
+  final String? updatedAtIso;
+}
+
+class BillingPlanPricing {
+  const BillingPlanPricing({
+    required this.planCode,
+    required this.minMembers,
+    required this.maxMembers,
+    required this.priceVndYear,
+    required this.vatIncluded,
+    required this.showAds,
+    required this.adFree,
+  });
+
+  final String planCode;
+  final int minMembers;
+  final int? maxMembers;
+  final int priceVndYear;
+  final bool vatIncluded;
+  final bool showAds;
+  final bool adFree;
+}
+
+class BillingPaymentTransaction {
+  const BillingPaymentTransaction({
+    required this.id,
+    required this.clanId,
+    required this.subscriptionId,
+    required this.invoiceId,
+    required this.paymentMethod,
+    required this.paymentStatus,
+    required this.planCode,
+    required this.memberCount,
+    required this.amountVnd,
+    required this.vatIncluded,
+    required this.currency,
+    required this.gatewayReference,
+    required this.createdAtIso,
+    required this.paidAtIso,
+    required this.failedAtIso,
+  });
+
+  final String id;
+  final String clanId;
+  final String subscriptionId;
+  final String invoiceId;
+  final String paymentMethod;
+  final String paymentStatus;
+  final String planCode;
+  final int memberCount;
+  final int amountVnd;
+  final bool vatIncluded;
+  final String currency;
+  final String? gatewayReference;
+  final String? createdAtIso;
+  final String? paidAtIso;
+  final String? failedAtIso;
+}
+
+class BillingInvoice {
+  const BillingInvoice({
+    required this.id,
+    required this.clanId,
+    required this.subscriptionId,
+    required this.transactionId,
+    required this.planCode,
+    required this.amountVnd,
+    required this.vatIncluded,
+    required this.currency,
+    required this.status,
+    required this.periodStartIso,
+    required this.periodEndIso,
+    required this.issuedAtIso,
+    required this.paidAtIso,
+  });
+
+  final String id;
+  final String clanId;
+  final String subscriptionId;
+  final String transactionId;
+  final String planCode;
+  final int amountVnd;
+  final bool vatIncluded;
+  final String currency;
+  final String status;
+  final String? periodStartIso;
+  final String? periodEndIso;
+  final String? issuedAtIso;
+  final String? paidAtIso;
+}
+
+class BillingAuditLog {
+  const BillingAuditLog({
+    required this.id,
+    required this.clanId,
+    required this.actorUid,
+    required this.action,
+    required this.entityType,
+    required this.entityId,
+    required this.createdAtIso,
+  });
+
+  final String id;
+  final String clanId;
+  final String? actorUid;
+  final String action;
+  final String entityType;
+  final String entityId;
+  final String? createdAtIso;
+}
+
+class BillingCheckoutResult {
+  const BillingCheckoutResult({
+    required this.clanId,
+    required this.paymentMethod,
+    required this.planCode,
+    required this.amountVnd,
+    required this.vatIncluded,
+    required this.transactionId,
+    required this.invoiceId,
+    required this.checkoutUrl,
+    required this.requiresManualConfirmation,
+    required this.subscription,
+    required this.entitlement,
+  });
+
+  final String clanId;
+  final String paymentMethod;
+  final String planCode;
+  final int amountVnd;
+  final bool vatIncluded;
+  final String transactionId;
+  final String invoiceId;
+  final String checkoutUrl;
+  final bool requiresManualConfirmation;
+  final BillingSubscription subscription;
+  final BillingEntitlement entitlement;
+}

--- a/mobile/befam/lib/features/billing/presentation/billing_controller.dart
+++ b/mobile/befam/lib/features/billing/presentation/billing_controller.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/foundation.dart';
+
+import '../../auth/models/auth_session.dart';
+import '../models/billing_workspace_snapshot.dart';
+import '../services/billing_repository.dart';
+
+class BillingController extends ChangeNotifier {
+  BillingController({
+    required BillingRepository repository,
+    required AuthSession session,
+  }) : _repository = repository,
+       _session = session;
+
+  final BillingRepository _repository;
+  final AuthSession _session;
+
+  bool _isLoading = true;
+  bool _isSavingPreferences = false;
+  bool _isProcessingPayment = false;
+  bool _isCreatingCheckout = false;
+  String? _errorMessage;
+  String? _actionMessage;
+  BillingWorkspaceSnapshot? _workspace;
+  BillingCheckoutResult? _lastCheckout;
+
+  bool get isLoading => _isLoading;
+  bool get isSavingPreferences => _isSavingPreferences;
+  bool get isProcessingPayment => _isProcessingPayment;
+  bool get isCreatingCheckout => _isCreatingCheckout;
+  String? get errorMessage => _errorMessage;
+  String? get actionMessage => _actionMessage;
+  BillingWorkspaceSnapshot? get workspace => _workspace;
+  BillingCheckoutResult? get lastCheckout => _lastCheckout;
+
+  bool get hasClanContext => (_session.clanId ?? '').trim().isNotEmpty;
+
+  bool get canManageBilling {
+    final role = (_session.primaryRole ?? '').trim().toUpperCase();
+    return role == 'SUPER_ADMIN' ||
+        role == 'CLAN_ADMIN' ||
+        role == 'BRANCH_ADMIN' ||
+        role == 'CLAN_OWNER' ||
+        role == 'CLAN_LEADER' ||
+        role == 'VICE_LEADER' ||
+        role == 'SUPPORTER_OF_LEADER';
+  }
+
+  bool get shouldShowAds {
+    final entitlement = _workspace?.entitlement;
+    if (entitlement == null) {
+      return true;
+    }
+    return entitlement.showAds;
+  }
+
+  Future<void> initialize() async {
+    await refresh();
+  }
+
+  Future<void> refresh() async {
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      _workspace = await _repository.loadWorkspace(session: _session);
+    } on BillingRepositoryException catch (error) {
+      _errorMessage = error.toString();
+      _workspace = null;
+    } catch (error) {
+      _errorMessage = error.toString();
+      _workspace = null;
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> updatePreferences({
+    required String paymentMode,
+    required bool autoRenew,
+    List<int>? reminderDaysBefore,
+  }) async {
+    _isSavingPreferences = true;
+    _errorMessage = null;
+    _actionMessage = null;
+    notifyListeners();
+    try {
+      await _repository.updatePreferences(
+        session: _session,
+        paymentMode: paymentMode,
+        autoRenew: autoRenew,
+        reminderDaysBefore: reminderDaysBefore,
+      );
+      _workspace = await _repository.loadWorkspace(session: _session);
+      _actionMessage = 'Billing preferences saved.';
+    } on BillingRepositoryException catch (error) {
+      _errorMessage = error.toString();
+    } catch (error) {
+      _errorMessage = error.toString();
+    } finally {
+      _isSavingPreferences = false;
+      notifyListeners();
+    }
+  }
+
+  Future<BillingCheckoutResult?> createCheckout({
+    required String paymentMethod,
+    String? returnUrl,
+  }) async {
+    _isCreatingCheckout = true;
+    _errorMessage = null;
+    _actionMessage = null;
+    notifyListeners();
+    try {
+      _lastCheckout = await _repository.createCheckout(
+        session: _session,
+        paymentMethod: paymentMethod,
+        returnUrl: returnUrl,
+      );
+      _workspace = await _repository.loadWorkspace(session: _session);
+      _actionMessage = 'Checkout created successfully.';
+      return _lastCheckout;
+    } on BillingRepositoryException catch (error) {
+      _errorMessage = error.toString();
+      return null;
+    } catch (error) {
+      _errorMessage = error.toString();
+      return null;
+    } finally {
+      _isCreatingCheckout = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> confirmCardPayment(String transactionId) async {
+    _isProcessingPayment = true;
+    _errorMessage = null;
+    _actionMessage = null;
+    notifyListeners();
+    try {
+      await _repository.completeCardCheckout(
+        session: _session,
+        transactionId: transactionId,
+      );
+      _workspace = await _repository.loadWorkspace(session: _session);
+      _actionMessage = 'Card payment confirmed.';
+    } on BillingRepositoryException catch (error) {
+      _errorMessage = error.toString();
+    } catch (error) {
+      _errorMessage = error.toString();
+    } finally {
+      _isProcessingPayment = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> confirmVnpayPayment(String transactionId) async {
+    _isProcessingPayment = true;
+    _errorMessage = null;
+    _actionMessage = null;
+    notifyListeners();
+    try {
+      await _repository.settleVnpayCheckout(
+        session: _session,
+        transactionId: transactionId,
+      );
+      _workspace = await _repository.loadWorkspace(session: _session);
+      _actionMessage = 'VNPay payment confirmed.';
+    } on BillingRepositoryException catch (error) {
+      _errorMessage = error.toString();
+    } catch (error) {
+      _errorMessage = error.toString();
+    } finally {
+      _isProcessingPayment = false;
+      notifyListeners();
+    }
+  }
+
+  Future<BillingEntitlement?> refreshEntitlement() async {
+    try {
+      final entitlement = await _repository.resolveEntitlement(session: _session);
+      final current = _workspace;
+      if (current != null) {
+        _workspace = BillingWorkspaceSnapshot(
+          clanId: current.clanId,
+          subscription: current.subscription,
+          entitlement: entitlement,
+          settings: current.settings,
+          pricingTiers: current.pricingTiers,
+          memberCount: current.memberCount,
+          transactions: current.transactions,
+          invoices: current.invoices,
+          auditLogs: current.auditLogs,
+        );
+        notifyListeners();
+      }
+      return entitlement;
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/mobile/befam/lib/features/billing/presentation/billing_workspace_page.dart
+++ b/mobile/befam/lib/features/billing/presentation/billing_workspace_page.dart
@@ -1,0 +1,1036 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../core/widgets/app_feedback_states.dart';
+import '../../../l10n/generated/app_localizations.dart';
+import '../../../l10n/l10n.dart';
+import '../../auth/models/auth_session.dart';
+import '../models/billing_workspace_snapshot.dart';
+import '../services/billing_repository.dart';
+import 'billing_controller.dart';
+
+class BillingWorkspacePage extends StatefulWidget {
+  const BillingWorkspacePage({
+    super.key,
+    required this.session,
+    this.repository,
+  });
+
+  final AuthSession session;
+  final BillingRepository? repository;
+
+  @override
+  State<BillingWorkspacePage> createState() => _BillingWorkspacePageState();
+}
+
+class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
+  late final BillingController _controller;
+  String? _paymentModeDraft;
+  bool _autoRenewDraft = false;
+  Set<int> _reminderDaysDraft = {30, 14, 7, 3, 1};
+  String? _draftSeedKey;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = BillingController(
+      repository: widget.repository ?? createDefaultBillingRepository(),
+      session: widget.session,
+    );
+    unawaited(_controller.initialize());
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _createCheckout(String paymentMethod) async {
+    final result = await _controller.createCheckout(paymentMethod: paymentMethod);
+    if (!mounted || result == null) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          context.l10n.pick(
+            vi: 'Đã tạo phiên thanh toán ${paymentMethod.toUpperCase()}.',
+            en: '${paymentMethod.toUpperCase()} checkout created.',
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _savePreferences() async {
+    final mode = _paymentModeDraft;
+    if (mode == null) {
+      return;
+    }
+    await _controller.updatePreferences(
+      paymentMode: mode,
+      autoRenew: _autoRenewDraft,
+      reminderDaysBefore: _reminderDaysDraft.toList(growable: false),
+    );
+    if (!mounted || _controller.errorMessage != null) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          context.l10n.pick(
+            vi: 'Đã lưu cài đặt thanh toán.',
+            en: 'Billing preferences saved.',
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _copyCheckoutUrl(String checkoutUrl) async {
+    await Clipboard.setData(ClipboardData(text: checkoutUrl));
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          context.l10n.pick(
+            vi: 'Đã sao chép liên kết thanh toán.',
+            en: 'Checkout link copied.',
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _syncDraftFromWorkspace(BillingWorkspaceSnapshot workspace) {
+    final settings = workspace.settings;
+    final seed = '${settings.updatedAtIso}|${settings.paymentMode}|'
+        '${settings.autoRenew}|${settings.reminderDaysBefore.join(',')}';
+    if (_draftSeedKey == seed) {
+      return;
+    }
+    _draftSeedKey = seed;
+    _paymentModeDraft = settings.paymentMode;
+    _autoRenewDraft = settings.autoRenew;
+    _reminderDaysDraft = settings.reminderDaysBefore.toSet();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        final l10n = context.l10n;
+        final workspace = _controller.workspace;
+        if (workspace != null) {
+          _syncDraftFromWorkspace(workspace);
+        }
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(l10n.pick(vi: 'Gói dịch vụ', en: 'Subscription')),
+            actions: [
+              IconButton(
+                tooltip: l10n.pick(vi: 'Tải lại', en: 'Refresh'),
+                onPressed: _controller.isLoading ? null : _controller.refresh,
+                icon: const Icon(Icons.refresh),
+              ),
+            ],
+          ),
+          body: SafeArea(
+            child: _controller.isLoading
+                ? AppLoadingState(
+                    message: l10n.pick(
+                      vi: 'Đang tải thông tin gói dịch vụ...',
+                      en: 'Loading subscription workspace...',
+                    ),
+                  )
+                : !_controller.hasClanContext
+                ? _EmptyState(
+                    icon: Icons.lock_outline,
+                    title: l10n.pick(
+                      vi: 'Thiếu ngữ cảnh họ tộc',
+                      en: 'No clan context',
+                    ),
+                    description: l10n.pick(
+                      vi: 'Tài khoản cần liên kết với một họ tộc để xem thông tin gói.',
+                      en: 'Link your account to a clan to view subscription details.',
+                    ),
+                  )
+                : workspace == null
+                ? _EmptyState(
+                    icon: Icons.error_outline,
+                    title: l10n.pick(
+                      vi: 'Không thể tải gói dịch vụ',
+                      en: 'Unable to load billing',
+                    ),
+                    description:
+                        _controller.errorMessage ??
+                        l10n.pick(
+                          vi: 'Hãy thử tải lại sau.',
+                          en: 'Please try again later.',
+                        ),
+                  )
+                : _buildWorkspace(context, workspace),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildWorkspace(BuildContext context, BillingWorkspaceSnapshot workspace) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final entitlement = workspace.entitlement;
+    final tier = workspace.pricingTiers.where((item) => item.planCode == entitlement.planCode).firstOrNull;
+    final canManage = _controller.canManageBilling;
+    final pendingTransactions = workspace.transactions
+        .where((tx) => tx.paymentStatus == 'pending')
+        .toList(growable: false);
+
+    return RefreshIndicator(
+      onRefresh: _controller.refresh,
+      child: ListView(
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+        children: [
+          if (_controller.errorMessage case final error?) ...[
+            _InfoCard(
+              icon: Icons.error_outline,
+              title: l10n.pick(
+                vi: 'Thao tác thanh toán chưa thành công',
+                en: 'Billing action failed',
+              ),
+              description: error,
+              tone: colorScheme.errorContainer,
+            ),
+            const SizedBox(height: 12),
+          ],
+          if (_controller.isSavingPreferences ||
+              _controller.isCreatingCheckout ||
+              _controller.isProcessingPayment)
+            const LinearProgressIndicator(minHeight: 2),
+          if (_controller.isSavingPreferences ||
+              _controller.isCreatingCheckout ||
+              _controller.isProcessingPayment)
+            const SizedBox(height: 12),
+          _SubscriptionHeroCard(
+            planCode: entitlement.planCode,
+            status: entitlement.status,
+            memberCount: workspace.memberCount,
+            amountVnd: tier?.priceVndYear ?? workspace.subscription.amountVndYear,
+            showAds: entitlement.showAds,
+            adFree: entitlement.adFree,
+            expiresAtIso: entitlement.expiresAtIso ?? workspace.subscription.expiresAtIso,
+            nextPaymentDueAtIso:
+                entitlement.nextPaymentDueAtIso ??
+                workspace.subscription.nextPaymentDueAtIso,
+          ),
+          const SizedBox(height: 16),
+          if (!canManage) ...[
+            _InfoCard(
+              icon: Icons.visibility_outlined,
+              title: l10n.pick(vi: 'Chế độ chỉ xem', en: 'Read-only mode'),
+              description: l10n.pick(
+                vi: 'Bạn có thể xem trạng thái gói. Tài khoản quản trị/owner mới có thể thanh toán và chỉnh cài đặt.',
+                en: 'You can view subscription status. Owner/admin accounts can manage payment and settings.',
+              ),
+              tone: colorScheme.secondaryContainer,
+            ),
+            const SizedBox(height: 16),
+          ],
+          _SectionCard(
+            title: l10n.pick(vi: 'Thanh toán & gia hạn', en: 'Checkout & renewal'),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.pick(
+                    vi: 'Tổng tiền năm hiện tại: ${_formatVnd(tier?.priceVndYear ?? workspace.subscription.amountVndYear)} (đã gồm VAT).',
+                    en: 'Current annual amount: ${_formatVnd(tier?.priceVndYear ?? workspace.subscription.amountVndYear)} (VAT included).',
+                  ),
+                ),
+                const SizedBox(height: 12),
+                if ((tier?.priceVndYear ?? 0) == 0)
+                  _InfoCard(
+                    icon: Icons.info_outline,
+                    title: l10n.pick(vi: 'Đang ở gói miễn phí', en: 'Currently on free plan'),
+                    description: l10n.pick(
+                      vi: 'Gói Free áp dụng cho họ tộc <= 10 thành viên.',
+                      en: 'Free plan applies to clans with <= 10 members.',
+                    ),
+                    tone: colorScheme.tertiaryContainer,
+                  )
+                else
+                  Wrap(
+                    spacing: 10,
+                    runSpacing: 10,
+                    children: [
+                      FilledButton.icon(
+                        key: const Key('billing-checkout-card-button'),
+                        onPressed: canManage && !_controller.isCreatingCheckout
+                            ? () => _createCheckout('card')
+                            : null,
+                        icon: const Icon(Icons.credit_card),
+                        label: Text(l10n.pick(vi: 'Thanh toán thẻ', en: 'Pay by card')),
+                      ),
+                      OutlinedButton.icon(
+                        key: const Key('billing-checkout-vnpay-button'),
+                        onPressed: canManage && !_controller.isCreatingCheckout
+                            ? () => _createCheckout('vnpay')
+                            : null,
+                        icon: const Icon(Icons.qr_code_2_outlined),
+                        label: const Text('VNPay'),
+                      ),
+                    ],
+                  ),
+                if (_controller.lastCheckout case final checkout?) ...[
+                  const SizedBox(height: 12),
+                  _CheckoutResultCard(
+                    checkout: checkout,
+                    onCopyUrl: checkout.checkoutUrl.trim().isEmpty
+                        ? null
+                        : () => _copyCheckoutUrl(checkout.checkoutUrl),
+                    onConfirmCard: canManage &&
+                            checkout.paymentMethod == 'card' &&
+                            checkout.requiresManualConfirmation
+                        ? () => _controller.confirmCardPayment(checkout.transactionId)
+                        : null,
+                    onConfirmVnpay: canManage &&
+                            checkout.paymentMethod == 'vnpay' &&
+                            checkout.planCode != 'FREE'
+                        ? () => _controller.confirmVnpayPayment(checkout.transactionId)
+                        : null,
+                  ),
+                ],
+                if (pendingTransactions.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    l10n.pick(
+                      vi: 'Giao dịch đang chờ xử lý',
+                      en: 'Pending transactions',
+                    ),
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  for (final tx in pendingTransactions.take(3))
+                    Card(
+                      margin: const EdgeInsets.only(bottom: 8),
+                      child: ListTile(
+                        dense: true,
+                        title: Text(
+                          '${tx.paymentMethod.toUpperCase()} • ${_formatVnd(tx.amountVnd)}',
+                        ),
+                        subtitle: Text(
+                          l10n.pick(
+                            vi: 'Mã: ${tx.id}',
+                            en: 'Ref: ${tx.id}',
+                          ),
+                        ),
+                        trailing: tx.paymentMethod == 'card'
+                            ? TextButton(
+                                onPressed: canManage
+                                    ? () => _controller.confirmCardPayment(tx.id)
+                                    : null,
+                                child: Text(l10n.pick(vi: 'Xác nhận', en: 'Confirm')),
+                              )
+                            : TextButton(
+                                onPressed: canManage
+                                    ? () => _controller.confirmVnpayPayment(tx.id)
+                                    : null,
+                                child: Text(l10n.pick(vi: 'Đã thanh toán', en: 'Mark paid')),
+                              ),
+                      ),
+                    ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          _SectionCard(
+            title: l10n.pick(vi: 'Cài đặt gia hạn', en: 'Renewal settings'),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SegmentedButton<String>(
+                  showSelectedIcon: true,
+                  segments: [
+                    ButtonSegment<String>(
+                      value: 'manual',
+                      label: Text(l10n.pick(vi: 'Thủ công', en: 'Manual')),
+                    ),
+                    ButtonSegment<String>(
+                      value: 'auto_renew',
+                      label: Text(l10n.pick(vi: 'Tự động', en: 'Auto renew')),
+                    ),
+                  ],
+                  selected: {_paymentModeDraft ?? workspace.settings.paymentMode},
+                  onSelectionChanged: canManage
+                      ? (selected) {
+                          if (selected.isEmpty) {
+                            return;
+                          }
+                          setState(() {
+                            _paymentModeDraft = selected.first;
+                            if (_paymentModeDraft == 'auto_renew') {
+                              _autoRenewDraft = true;
+                            }
+                          });
+                        }
+                      : null,
+                ),
+                const SizedBox(height: 10),
+                SwitchListTile.adaptive(
+                  contentPadding: EdgeInsets.zero,
+                  value: _autoRenewDraft,
+                  onChanged: canManage
+                      ? (value) {
+                          setState(() {
+                            _autoRenewDraft = value;
+                            if (value) {
+                              _paymentModeDraft = 'auto_renew';
+                            }
+                          });
+                        }
+                      : null,
+                  title: Text(
+                    l10n.pick(
+                      vi: 'Bật tự động gia hạn',
+                      en: 'Enable auto-renew',
+                    ),
+                  ),
+                ),
+                Text(
+                  l10n.pick(
+                    vi: 'Nhắc trước hạn',
+                    en: 'Reminder schedule',
+                  ),
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    for (final day in const [30, 14, 7, 3, 1])
+                      FilterChip(
+                        label: Text(
+                          l10n.pick(
+                            vi: '$day ngày',
+                            en: '$day days',
+                          ),
+                        ),
+                        selected: _reminderDaysDraft.contains(day),
+                        onSelected: canManage
+                            ? (selected) {
+                                setState(() {
+                                  if (selected) {
+                                    _reminderDaysDraft.add(day);
+                                  } else {
+                                    _reminderDaysDraft.remove(day);
+                                  }
+                                  if (_reminderDaysDraft.isEmpty) {
+                                    _reminderDaysDraft = {7, 1};
+                                  }
+                                });
+                              }
+                            : null,
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    key: const Key('billing-save-preferences-button'),
+                    onPressed: canManage && !_controller.isSavingPreferences
+                        ? _savePreferences
+                        : null,
+                    icon: const Icon(Icons.save_outlined),
+                    label: Text(
+                      l10n.pick(
+                        vi: 'Lưu cài đặt',
+                        en: 'Save settings',
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          _SectionCard(
+            sectionKey: const Key('billing-payment-history-section'),
+            title: l10n.pick(vi: 'Lịch sử thanh toán', en: 'Payment history'),
+            child: workspace.transactions.isEmpty
+                ? _EmptyState(
+                    icon: Icons.receipt_long_outlined,
+                    title: l10n.pick(vi: 'Chưa có giao dịch', en: 'No transactions'),
+                    description: l10n.pick(
+                      vi: 'Giao dịch sẽ xuất hiện sau khi bạn thanh toán hoặc gia hạn.',
+                      en: 'Transactions appear here after checkout and renewals.',
+                    ),
+                  )
+                : Column(
+                    children: [
+                      for (final tx in workspace.transactions.take(8))
+                        ListTile(
+                          dense: true,
+                          contentPadding: EdgeInsets.zero,
+                          title: Text(
+                            '${tx.paymentMethod.toUpperCase()} • ${_formatVnd(tx.amountVnd)}',
+                          ),
+                          subtitle: Text(
+                            '${tx.planCode} • ${_humanizeStatus(tx.paymentStatus, l10n)}',
+                          ),
+                          trailing: Text(
+                            _dateLabel(tx.paidAtIso ?? tx.createdAtIso, l10n),
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ),
+                    ],
+                  ),
+          ),
+          const SizedBox(height: 16),
+          _SectionCard(
+            title: l10n.pick(vi: 'Hóa đơn', en: 'Invoices'),
+            child: workspace.invoices.isEmpty
+                ? _EmptyState(
+                    icon: Icons.description_outlined,
+                    title: l10n.pick(vi: 'Chưa có hóa đơn', en: 'No invoices'),
+                    description: l10n.pick(
+                      vi: 'Hóa đơn sẽ được tạo cùng giao dịch thanh toán.',
+                      en: 'Invoices are generated together with transactions.',
+                    ),
+                  )
+                : Column(
+                    children: [
+                      for (final invoice in workspace.invoices.take(6))
+                        ListTile(
+                          dense: true,
+                          contentPadding: EdgeInsets.zero,
+                          title: Text(
+                            '${invoice.planCode} • ${_formatVnd(invoice.amountVnd)}',
+                          ),
+                          subtitle: Text(
+                            l10n.pick(
+                              vi: 'Trạng thái: ${invoice.status}',
+                              en: 'Status: ${invoice.status}',
+                            ),
+                          ),
+                          trailing: Text(
+                            _dateLabel(invoice.issuedAtIso, l10n),
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ),
+                    ],
+                  ),
+          ),
+          const SizedBox(height: 16),
+          _SectionCard(
+            title: l10n.pick(vi: 'Nhật ký hệ thống', en: 'Audit logs'),
+            child: workspace.auditLogs.isEmpty
+                ? _EmptyState(
+                    icon: Icons.history_toggle_off,
+                    title: l10n.pick(vi: 'Chưa có nhật ký', en: 'No audit records'),
+                    description: l10n.pick(
+                      vi: 'Nhật ký thao tác billing sẽ hiển thị tại đây.',
+                      en: 'Billing action logs will appear here.',
+                    ),
+                  )
+                : Column(
+                    children: [
+                      for (final log in workspace.auditLogs.take(8))
+                        ListTile(
+                          dense: true,
+                          contentPadding: EdgeInsets.zero,
+                          title: Text(log.action),
+                          subtitle: Text('${log.entityType} • ${log.entityId}'),
+                          trailing: Text(
+                            _dateLabel(log.createdAtIso, l10n),
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ),
+                    ],
+                  ),
+          ),
+          const SizedBox(height: 16),
+          _SectionCard(
+            title: l10n.pick(vi: 'Bảng giá', en: 'Pricing tiers'),
+            child: Column(
+              children: [
+                for (final tier in workspace.pricingTiers)
+                  ListTile(
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    leading: CircleAvatar(
+                      radius: 16,
+                      child: Text(tier.planCode.substring(0, 1)),
+                    ),
+                    title: Text(tier.planCode),
+                    subtitle: Text(
+                      '${_memberRangeLabel(tier, l10n)} • '
+                      '${tier.showAds ? l10n.pick(vi: 'Có quảng cáo', en: 'Ads on') : l10n.pick(vi: 'Không quảng cáo', en: 'No ads')}',
+                    ),
+                    trailing: Text(
+                      _formatVnd(tier.priceVndYear),
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _memberRangeLabel(BillingPlanPricing tier, AppLocalizations l10n) {
+    if (tier.maxMembers == null) {
+      return l10n.pick(
+        vi: '${tier.minMembers}+ thành viên',
+        en: '${tier.minMembers}+ members',
+      );
+    }
+    return l10n.pick(
+      vi: '${tier.minMembers} - ${tier.maxMembers} thành viên',
+      en: '${tier.minMembers} - ${tier.maxMembers} members',
+    );
+  }
+
+  String _humanizeStatus(String status, AppLocalizations l10n) {
+    switch (status) {
+      case 'active':
+        return l10n.pick(vi: 'Đang hoạt động', en: 'Active');
+      case 'grace_period':
+        return l10n.pick(vi: 'Gia hạn ân hạn', en: 'Grace period');
+      case 'pending_payment':
+        return l10n.pick(vi: 'Chờ thanh toán', en: 'Pending payment');
+      case 'expired':
+        return l10n.pick(vi: 'Hết hạn', en: 'Expired');
+      case 'succeeded':
+        return l10n.pick(vi: 'Thành công', en: 'Succeeded');
+      case 'failed':
+        return l10n.pick(vi: 'Thất bại', en: 'Failed');
+      default:
+        return status;
+    }
+  }
+
+  String _dateLabel(String? iso, AppLocalizations l10n) {
+    if (iso == null || iso.trim().isEmpty) {
+      return l10n.pick(vi: 'N/A', en: 'N/A');
+    }
+    final parsed = DateTime.tryParse(iso);
+    if (parsed == null) {
+      return iso;
+    }
+    final local = parsed.toLocal();
+    final day = '${local.day}'.padLeft(2, '0');
+    final month = '${local.month}'.padLeft(2, '0');
+    return '$day/$month/${local.year}';
+  }
+}
+
+class _SubscriptionHeroCard extends StatelessWidget {
+  const _SubscriptionHeroCard({
+    required this.planCode,
+    required this.status,
+    required this.memberCount,
+    required this.amountVnd,
+    required this.showAds,
+    required this.adFree,
+    required this.expiresAtIso,
+    required this.nextPaymentDueAtIso,
+  });
+
+  final String planCode;
+  final String status;
+  final int memberCount;
+  final int amountVnd;
+  final bool showAds;
+  final bool adFree;
+  final String? expiresAtIso;
+  final String? nextPaymentDueAtIso;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final statusLabel = switch (status) {
+      'active' => l10n.pick(vi: 'Đang hoạt động', en: 'Active'),
+      'grace_period' => l10n.pick(vi: 'Ân hạn', en: 'Grace period'),
+      'pending_payment' => l10n.pick(vi: 'Chờ thanh toán', en: 'Pending payment'),
+      'expired' => l10n.pick(vi: 'Hết hạn', en: 'Expired'),
+      _ => status,
+    };
+
+    return Container(
+      padding: const EdgeInsets.all(22),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [colorScheme.primary, colorScheme.primaryContainer],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                planCode,
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  color: colorScheme.onPrimary,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                decoration: BoxDecoration(
+                  color: colorScheme.onPrimary.withValues(alpha: 0.16),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+                child: Text(
+                  statusLabel,
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    color: colorScheme.onPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            l10n.pick(
+              vi: 'Số thành viên hiện tại: $memberCount',
+              en: 'Current members: $memberCount',
+            ),
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: colorScheme.onPrimary.withValues(alpha: 0.95),
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            l10n.pick(
+              vi: 'Phí năm: ${_formatVnd(amountVnd)} (đã gồm VAT)',
+              en: 'Annual fee: ${_formatVnd(amountVnd)} (VAT included)',
+            ),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onPrimary.withValues(alpha: 0.92),
+            ),
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _HeroPill(
+                icon: adFree ? Icons.block_flipped : Icons.ads_click_outlined,
+                text: adFree
+                    ? l10n.pick(vi: 'Không quảng cáo', en: 'Ad-free')
+                    : l10n.pick(vi: 'Có quảng cáo', en: 'Ads enabled'),
+              ),
+              _HeroPill(
+                icon: Icons.event_available_outlined,
+                text: l10n.pick(
+                  vi: 'Hết hạn: ${_dateOnly(expiresAtIso)}',
+                  en: 'Expires: ${_dateOnly(expiresAtIso)}',
+                ),
+              ),
+              _HeroPill(
+                icon: Icons.schedule,
+                text: l10n.pick(
+                  vi: 'Kỳ tiếp theo: ${_dateOnly(nextPaymentDueAtIso)}',
+                  en: 'Next due: ${_dateOnly(nextPaymentDueAtIso)}',
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CheckoutResultCard extends StatelessWidget {
+  const _CheckoutResultCard({
+    required this.checkout,
+    this.onCopyUrl,
+    this.onConfirmCard,
+    this.onConfirmVnpay,
+  });
+
+  final BillingCheckoutResult checkout;
+  final VoidCallback? onCopyUrl;
+  final VoidCallback? onConfirmCard;
+  final VoidCallback? onConfirmVnpay;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.pick(vi: 'Phiên thanh toán mới nhất', en: 'Latest checkout'),
+              style: const TextStyle(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              l10n.pick(
+                vi: 'Mã giao dịch: ${checkout.transactionId}',
+                en: 'Transaction: ${checkout.transactionId}',
+              ),
+            ),
+            Text(
+              l10n.pick(
+                vi: 'Phương thức: ${checkout.paymentMethod.toUpperCase()}',
+                en: 'Method: ${checkout.paymentMethod.toUpperCase()}',
+              ),
+            ),
+            if (checkout.checkoutUrl.trim().isNotEmpty) ...[
+              const SizedBox(height: 8),
+              SelectableText(checkout.checkoutUrl),
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                onPressed: onCopyUrl,
+                icon: const Icon(Icons.copy_outlined),
+                label: Text(
+                  l10n.pick(
+                    vi: 'Sao chép liên kết thanh toán',
+                    en: 'Copy checkout link',
+                  ),
+                ),
+              ),
+            ],
+            if (onConfirmCard != null) ...[
+              const SizedBox(height: 8),
+              FilledButton(
+                onPressed: onConfirmCard,
+                child: Text(
+                  l10n.pick(
+                    vi: 'Xác nhận thanh toán thẻ',
+                    en: 'Confirm card payment',
+                  ),
+                ),
+              ),
+            ],
+            if (onConfirmVnpay != null) ...[
+              const SizedBox(height: 8),
+              FilledButton.tonal(
+                onPressed: onConfirmVnpay,
+                child: Text(
+                  l10n.pick(
+                    vi: 'Đánh dấu VNPay đã thanh toán',
+                    en: 'Mark VNPay paid',
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HeroPill extends StatelessWidget {
+  const _HeroPill({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: colorScheme.onPrimary.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: colorScheme.onPrimary),
+          const SizedBox(width: 6),
+          Text(
+            text,
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: colorScheme.onPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoCard extends StatelessWidget {
+  const _InfoCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.tone,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final Color tone;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: tone,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(description),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  const _SectionCard({
+    this.sectionKey,
+    required this.title,
+    required this.child,
+  });
+
+  final Key? sectionKey;
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: sectionKey,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 10),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 42),
+            const SizedBox(height: 12),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              description,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _dateOnly(String? iso) {
+  if (iso == null || iso.trim().isEmpty) {
+    return 'N/A';
+  }
+  final parsed = DateTime.tryParse(iso);
+  if (parsed == null) {
+    return iso;
+  }
+  final local = parsed.toLocal();
+  final day = '${local.day}'.padLeft(2, '0');
+  final month = '${local.month}'.padLeft(2, '0');
+  return '$day/$month/${local.year}';
+}
+
+String _formatVnd(int amount) {
+  return '${amount.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (m) => '${m[1]},')} VND';
+}
+
+extension on Iterable<BillingPlanPricing> {
+  BillingPlanPricing? get firstOrNull {
+    for (final item in this) {
+      return item;
+    }
+    return null;
+  }
+}

--- a/mobile/befam/lib/features/billing/services/billing_repository.dart
+++ b/mobile/befam/lib/features/billing/services/billing_repository.dart
@@ -1,0 +1,63 @@
+import '../../../core/services/runtime_mode.dart';
+import '../../auth/models/auth_session.dart';
+import '../models/billing_workspace_snapshot.dart';
+import 'debug_billing_repository.dart';
+import 'firebase_billing_repository.dart';
+
+enum BillingRepositoryErrorCode {
+  permissionDenied,
+  invalidArgument,
+  failedPrecondition,
+  notFound,
+  unavailable,
+  unknown,
+}
+
+class BillingRepositoryException implements Exception {
+  const BillingRepositoryException(this.code, [this.message]);
+
+  final BillingRepositoryErrorCode code;
+  final String? message;
+
+  @override
+  String toString() => message ?? code.name;
+}
+
+abstract interface class BillingRepository {
+  bool get isSandbox;
+
+  Future<BillingWorkspaceSnapshot> loadWorkspace({required AuthSession session});
+
+  Future<BillingEntitlement> resolveEntitlement({required AuthSession session});
+
+  Future<BillingSettings> updatePreferences({
+    required AuthSession session,
+    required String paymentMode,
+    required bool autoRenew,
+    List<int>? reminderDaysBefore,
+  });
+
+  Future<BillingCheckoutResult> createCheckout({
+    required AuthSession session,
+    required String paymentMethod,
+    String? returnUrl,
+  });
+
+  Future<void> completeCardCheckout({
+    required AuthSession session,
+    required String transactionId,
+  });
+
+  Future<void> settleVnpayCheckout({
+    required AuthSession session,
+    required String transactionId,
+  });
+}
+
+BillingRepository createDefaultBillingRepository() {
+  if (RuntimeMode.shouldUseMockBackend) {
+    return DebugBillingRepository.shared();
+  }
+
+  return FirebaseBillingRepository();
+}

--- a/mobile/befam/lib/features/billing/services/debug_billing_repository.dart
+++ b/mobile/befam/lib/features/billing/services/debug_billing_repository.dart
@@ -1,0 +1,652 @@
+import 'dart:async';
+
+import '../../../core/services/debug_genealogy_store.dart';
+import '../../auth/models/auth_session.dart';
+import '../models/billing_workspace_snapshot.dart';
+import 'billing_repository.dart';
+
+class DebugBillingRepository implements BillingRepository {
+  DebugBillingRepository._({required DebugGenealogyStore genealogyStore})
+    : _genealogyStore = genealogyStore;
+
+  factory DebugBillingRepository.shared() {
+    return DebugBillingRepository._(
+      genealogyStore: DebugGenealogyStore.sharedSeeded(),
+    );
+  }
+
+  final DebugGenealogyStore _genealogyStore;
+
+  static final Map<String, _DebugBillingState> _statesByClanId = {};
+  static int _transactionSequence = 1;
+  static int _invoiceSequence = 1;
+  static int _auditSequence = 1;
+
+  @override
+  bool get isSandbox => true;
+
+  @override
+  Future<BillingWorkspaceSnapshot> loadWorkspace({
+    required AuthSession session,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    final clanId = _clanIdOf(session);
+    final state = _ensureState(clanId);
+    _syncStateWithMemberCount(state, clanId);
+    return state.toSnapshot();
+  }
+
+  @override
+  Future<BillingEntitlement> resolveEntitlement({
+    required AuthSession session,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    final clanId = _clanIdOf(session);
+    final state = _ensureState(clanId);
+    _syncStateWithMemberCount(state, clanId);
+    return state.entitlement;
+  }
+
+  @override
+  Future<BillingSettings> updatePreferences({
+    required AuthSession session,
+    required String paymentMode,
+    required bool autoRenew,
+    List<int>? reminderDaysBefore,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 90));
+    final clanId = _clanIdOf(session);
+    final state = _ensureState(clanId);
+
+    final normalizedMode = paymentMode.trim().toLowerCase();
+    if (normalizedMode != 'manual' && normalizedMode != 'auto_renew') {
+      throw const BillingRepositoryException(
+        BillingRepositoryErrorCode.invalidArgument,
+        'paymentMode must be manual or auto_renew.',
+      );
+    }
+
+    state.settings = BillingSettings(
+      id: clanId,
+      clanId: clanId,
+      paymentMode: normalizedMode,
+      autoRenew: autoRenew,
+      reminderDaysBefore:
+          (reminderDaysBefore ?? state.settings.reminderDaysBefore)
+              .where((value) => value > 0 && value <= 60)
+              .toSet()
+              .toList(growable: false)
+            ..sort((left, right) => right.compareTo(left)),
+      updatedAtIso: DateTime.now().toUtc().toIso8601String(),
+    );
+
+    state.subscription = BillingSubscription(
+      id: state.subscription.id,
+      clanId: state.subscription.clanId,
+      planCode: state.subscription.planCode,
+      status: state.subscription.status,
+      memberCount: state.subscription.memberCount,
+      amountVndYear: state.subscription.amountVndYear,
+      vatIncluded: state.subscription.vatIncluded,
+      paymentMode: state.settings.paymentMode,
+      autoRenew: state.settings.autoRenew,
+      startsAtIso: state.subscription.startsAtIso,
+      expiresAtIso: state.subscription.expiresAtIso,
+      nextPaymentDueAtIso: state.subscription.nextPaymentDueAtIso,
+      graceEndsAtIso: state.subscription.graceEndsAtIso,
+      lastPaymentMethod: state.subscription.lastPaymentMethod,
+      lastTransactionId: state.subscription.lastTransactionId,
+      updatedAtIso: DateTime.now().toUtc().toIso8601String(),
+    );
+
+    _writeAudit(
+      state,
+      clanId: clanId,
+      action: 'billing_preferences_updated',
+      entityType: 'billingSettings',
+      entityId: clanId,
+      actorUid: session.uid,
+    );
+
+    return state.settings;
+  }
+
+  @override
+  Future<BillingCheckoutResult> createCheckout({
+    required AuthSession session,
+    required String paymentMethod,
+    String? returnUrl,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 140));
+    final clanId = _clanIdOf(session);
+    final state = _ensureState(clanId);
+    _syncStateWithMemberCount(state, clanId);
+
+    final method = paymentMethod.trim().toLowerCase();
+    if (method != 'card' && method != 'vnpay') {
+      throw const BillingRepositoryException(
+        BillingRepositoryErrorCode.invalidArgument,
+        'paymentMethod must be card or vnpay.',
+      );
+    }
+
+    final tier = _resolveTier(state.memberCount);
+    final now = DateTime.now().toUtc();
+    final transactionId = 'txn_debug_${_transactionSequence++}';
+    final invoiceId = 'inv_debug_${_invoiceSequence++}';
+
+    final transaction = BillingPaymentTransaction(
+      id: transactionId,
+      clanId: clanId,
+      subscriptionId: clanId,
+      invoiceId: invoiceId,
+      paymentMethod: method,
+      paymentStatus: tier.planCode == 'FREE' ? 'succeeded' : 'pending',
+      planCode: tier.planCode,
+      memberCount: state.memberCount,
+      amountVnd: tier.priceVndYear,
+      vatIncluded: true,
+      currency: 'VND',
+      gatewayReference:
+          '${method.toUpperCase()}-${DateTime.now().millisecondsSinceEpoch}',
+      createdAtIso: now.toIso8601String(),
+      paidAtIso: tier.planCode == 'FREE' ? now.toIso8601String() : null,
+      failedAtIso: null,
+    );
+    state.transactions.insert(0, transaction);
+
+    final invoice = BillingInvoice(
+      id: invoiceId,
+      clanId: clanId,
+      subscriptionId: clanId,
+      transactionId: transactionId,
+      planCode: tier.planCode,
+      amountVnd: tier.priceVndYear,
+      vatIncluded: true,
+      currency: 'VND',
+      status: tier.planCode == 'FREE' ? 'paid' : 'issued',
+      periodStartIso: state.subscription.startsAtIso,
+      periodEndIso: state.subscription.expiresAtIso,
+      issuedAtIso: now.toIso8601String(),
+      paidAtIso: tier.planCode == 'FREE' ? now.toIso8601String() : null,
+    );
+    state.invoices.insert(0, invoice);
+
+    state.subscription = BillingSubscription(
+      id: state.subscription.id,
+      clanId: clanId,
+      planCode: tier.planCode,
+      status: tier.planCode == 'FREE' ? 'active' : 'pending_payment',
+      memberCount: state.memberCount,
+      amountVndYear: tier.priceVndYear,
+      vatIncluded: true,
+      paymentMode: state.settings.paymentMode,
+      autoRenew: state.settings.autoRenew,
+      startsAtIso: state.subscription.startsAtIso,
+      expiresAtIso: state.subscription.expiresAtIso,
+      nextPaymentDueAtIso: state.subscription.nextPaymentDueAtIso,
+      graceEndsAtIso: state.subscription.graceEndsAtIso,
+      lastPaymentMethod: method,
+      lastTransactionId: transactionId,
+      updatedAtIso: now.toIso8601String(),
+    );
+    state.entitlement = _buildEntitlement(
+      planCode: tier.planCode,
+      status: state.subscription.status,
+      expiresAtIso: state.subscription.expiresAtIso,
+      nextPaymentDueAtIso: state.subscription.nextPaymentDueAtIso,
+    );
+
+    _writeAudit(
+      state,
+      clanId: clanId,
+      action: 'checkout_created',
+      entityType: 'paymentTransaction',
+      entityId: transactionId,
+      actorUid: session.uid,
+    );
+
+    if (tier.planCode == 'FREE') {
+      _applySuccessfulPayment(state, transactionId: transactionId, actorUid: session.uid);
+    }
+
+    final checkoutUrl = method == 'vnpay'
+        ? 'https://sandbox.vnpayment.vn/paymentv2/vpcpay.html?txn=$transactionId'
+        : 'https://example.com/billing/card?txn=$transactionId';
+
+    return BillingCheckoutResult(
+      clanId: clanId,
+      paymentMethod: method,
+      planCode: tier.planCode,
+      amountVnd: tier.priceVndYear,
+      vatIncluded: true,
+      transactionId: transactionId,
+      invoiceId: invoiceId,
+      checkoutUrl: checkoutUrl,
+      requiresManualConfirmation: method == 'card' && tier.planCode != 'FREE',
+      subscription: state.subscription,
+      entitlement: state.entitlement,
+    );
+  }
+
+  @override
+  Future<void> completeCardCheckout({
+    required AuthSession session,
+    required String transactionId,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 130));
+    final clanId = _clanIdOf(session);
+    final state = _ensureState(clanId);
+    final transaction = _findTransaction(state, transactionId);
+    if (transaction.paymentMethod != 'card') {
+      throw const BillingRepositoryException(
+        BillingRepositoryErrorCode.invalidArgument,
+        'Transaction is not a card checkout.',
+      );
+    }
+    _applySuccessfulPayment(
+      state,
+      transactionId: transactionId.trim(),
+      actorUid: session.uid,
+    );
+  }
+
+  @override
+  Future<void> settleVnpayCheckout({
+    required AuthSession session,
+    required String transactionId,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 130));
+    final clanId = _clanIdOf(session);
+    final state = _ensureState(clanId);
+    final transaction = _findTransaction(state, transactionId);
+    if (transaction.paymentMethod != 'vnpay') {
+      throw const BillingRepositoryException(
+        BillingRepositoryErrorCode.invalidArgument,
+        'Transaction is not a VNPay checkout.',
+      );
+    }
+    _applySuccessfulPayment(
+      state,
+      transactionId: transactionId.trim(),
+      actorUid: session.uid,
+    );
+  }
+
+  _DebugBillingState _ensureState(String clanId) {
+    return _statesByClanId.putIfAbsent(clanId, () {
+      final memberCount = _memberCountForClan(clanId);
+      final tier = _resolveTier(memberCount);
+      final now = DateTime.now().toUtc();
+      final subscription = BillingSubscription(
+        id: clanId,
+        clanId: clanId,
+        planCode: tier.planCode,
+        status: tier.planCode == 'FREE' ? 'active' : 'expired',
+        memberCount: memberCount,
+        amountVndYear: tier.priceVndYear,
+        vatIncluded: true,
+        paymentMode: 'manual',
+        autoRenew: false,
+        startsAtIso: tier.planCode == 'FREE' ? now.toIso8601String() : null,
+        expiresAtIso: tier.planCode == 'FREE' ? null : now.toIso8601String(),
+        nextPaymentDueAtIso: tier.planCode == 'FREE' ? null : now.toIso8601String(),
+        graceEndsAtIso: null,
+        lastPaymentMethod: null,
+        lastTransactionId: null,
+        updatedAtIso: now.toIso8601String(),
+      );
+      final settings = BillingSettings(
+        id: clanId,
+        clanId: clanId,
+        paymentMode: 'manual',
+        autoRenew: false,
+        reminderDaysBefore: const [30, 14, 7, 3, 1],
+        updatedAtIso: now.toIso8601String(),
+      );
+      return _DebugBillingState(
+        clanId: clanId,
+        memberCount: memberCount,
+        subscription: subscription,
+        entitlement: _buildEntitlement(
+          planCode: subscription.planCode,
+          status: subscription.status,
+          expiresAtIso: subscription.expiresAtIso,
+          nextPaymentDueAtIso: subscription.nextPaymentDueAtIso,
+        ),
+        settings: settings,
+        transactions: [],
+        invoices: [],
+        auditLogs: [],
+      );
+    });
+  }
+
+  void _syncStateWithMemberCount(_DebugBillingState state, String clanId) {
+    final memberCount = _memberCountForClan(clanId);
+    if (memberCount == state.memberCount) {
+      return;
+    }
+    final tier = _resolveTier(memberCount);
+    state.memberCount = memberCount;
+    state.subscription = BillingSubscription(
+      id: state.subscription.id,
+      clanId: state.subscription.clanId,
+      planCode: tier.planCode,
+      status: tier.planCode == 'FREE' ? 'active' : state.subscription.status,
+      memberCount: memberCount,
+      amountVndYear: tier.priceVndYear,
+      vatIncluded: true,
+      paymentMode: state.settings.paymentMode,
+      autoRenew: state.settings.autoRenew,
+      startsAtIso: state.subscription.startsAtIso,
+      expiresAtIso: state.subscription.expiresAtIso,
+      nextPaymentDueAtIso: state.subscription.nextPaymentDueAtIso,
+      graceEndsAtIso: state.subscription.graceEndsAtIso,
+      lastPaymentMethod: state.subscription.lastPaymentMethod,
+      lastTransactionId: state.subscription.lastTransactionId,
+      updatedAtIso: DateTime.now().toUtc().toIso8601String(),
+    );
+    state.entitlement = _buildEntitlement(
+      planCode: state.subscription.planCode,
+      status: state.subscription.status,
+      expiresAtIso: state.subscription.expiresAtIso,
+      nextPaymentDueAtIso: state.subscription.nextPaymentDueAtIso,
+    );
+  }
+
+  BillingPaymentTransaction _findTransaction(
+    _DebugBillingState state,
+    String transactionId,
+  ) {
+    final normalized = transactionId.trim();
+    BillingPaymentTransaction? transaction;
+    for (final item in state.transactions) {
+      if (item.id == normalized) {
+        transaction = item;
+        break;
+      }
+    }
+    if (transaction == null) {
+      throw const BillingRepositoryException(
+        BillingRepositoryErrorCode.notFound,
+        'Transaction not found.',
+      );
+    }
+    return transaction;
+  }
+
+  void _applySuccessfulPayment(
+    _DebugBillingState state, {
+    required String transactionId,
+    required String actorUid,
+  }) {
+    final now = DateTime.now().toUtc();
+    final transaction = _findTransaction(state, transactionId);
+    final txIndex = state.transactions.indexWhere((item) => item.id == transactionId);
+    final paidTransaction = BillingPaymentTransaction(
+      id: transaction.id,
+      clanId: transaction.clanId,
+      subscriptionId: transaction.subscriptionId,
+      invoiceId: transaction.invoiceId,
+      paymentMethod: transaction.paymentMethod,
+      paymentStatus: 'succeeded',
+      planCode: transaction.planCode,
+      memberCount: transaction.memberCount,
+      amountVnd: transaction.amountVnd,
+      vatIncluded: transaction.vatIncluded,
+      currency: transaction.currency,
+      gatewayReference: transaction.gatewayReference,
+      createdAtIso: transaction.createdAtIso,
+      paidAtIso: now.toIso8601String(),
+      failedAtIso: null,
+    );
+    state.transactions[txIndex] = paidTransaction;
+
+    final invoiceIndex = state.invoices.indexWhere((item) => item.id == transaction.invoiceId);
+    if (invoiceIndex >= 0) {
+      final invoice = state.invoices[invoiceIndex];
+      state.invoices[invoiceIndex] = BillingInvoice(
+        id: invoice.id,
+        clanId: invoice.clanId,
+        subscriptionId: invoice.subscriptionId,
+        transactionId: invoice.transactionId,
+        planCode: invoice.planCode,
+        amountVnd: invoice.amountVnd,
+        vatIncluded: invoice.vatIncluded,
+        currency: invoice.currency,
+        status: 'paid',
+        periodStartIso: invoice.periodStartIso,
+        periodEndIso: invoice.periodEndIso,
+        issuedAtIso: invoice.issuedAtIso,
+        paidAtIso: now.toIso8601String(),
+      );
+    }
+
+    final startsAt = now;
+    final expiresAt = DateTime.utc(now.year + 1, now.month, now.day, now.hour, now.minute, now.second);
+    state.subscription = BillingSubscription(
+      id: state.subscription.id,
+      clanId: state.subscription.clanId,
+      planCode: paidTransaction.planCode,
+      status: 'active',
+      memberCount: state.memberCount,
+      amountVndYear: paidTransaction.amountVnd,
+      vatIncluded: true,
+      paymentMode: state.settings.paymentMode,
+      autoRenew: state.settings.autoRenew,
+      startsAtIso: startsAt.toIso8601String(),
+      expiresAtIso: expiresAt.toIso8601String(),
+      nextPaymentDueAtIso: expiresAt.toIso8601String(),
+      graceEndsAtIso: null,
+      lastPaymentMethod: paidTransaction.paymentMethod,
+      lastTransactionId: paidTransaction.id,
+      updatedAtIso: now.toIso8601String(),
+    );
+    state.entitlement = _buildEntitlement(
+      planCode: state.subscription.planCode,
+      status: state.subscription.status,
+      expiresAtIso: state.subscription.expiresAtIso,
+      nextPaymentDueAtIso: state.subscription.nextPaymentDueAtIso,
+    );
+
+    _writeAudit(
+      state,
+      clanId: state.clanId,
+      action: 'payment_succeeded',
+      entityType: 'paymentTransaction',
+      entityId: transactionId,
+      actorUid: actorUid,
+    );
+  }
+
+  void _writeAudit(
+    _DebugBillingState state, {
+    required String clanId,
+    required String action,
+    required String entityType,
+    required String entityId,
+    required String actorUid,
+  }) {
+    state.auditLogs.insert(
+      0,
+      BillingAuditLog(
+        id: 'audit_debug_${_auditSequence++}',
+        clanId: clanId,
+        actorUid: actorUid,
+        action: action,
+        entityType: entityType,
+        entityId: entityId,
+        createdAtIso: DateTime.now().toUtc().toIso8601String(),
+      ),
+    );
+  }
+
+  int _memberCountForClan(String clanId) {
+    return _genealogyStore.members.values.where((member) => member.clanId == clanId).length;
+  }
+
+  _PricingTier _resolveTier(int memberCount) {
+    if (memberCount <= 10) {
+      return const _PricingTier(
+        planCode: 'FREE',
+        minMembers: 0,
+        maxMembers: 10,
+        priceVndYear: 0,
+        showAds: true,
+      );
+    }
+    if (memberCount <= 200) {
+      return const _PricingTier(
+        planCode: 'BASE',
+        minMembers: 11,
+        maxMembers: 200,
+        priceVndYear: 49000,
+        showAds: true,
+      );
+    }
+    if (memberCount <= 700) {
+      return const _PricingTier(
+        planCode: 'PLUS',
+        minMembers: 201,
+        maxMembers: 700,
+        priceVndYear: 89000,
+        showAds: false,
+      );
+    }
+    return const _PricingTier(
+      planCode: 'PRO',
+      minMembers: 701,
+      maxMembers: null,
+      priceVndYear: 119000,
+      showAds: false,
+    );
+  }
+
+  BillingEntitlement _buildEntitlement({
+    required String planCode,
+    required String status,
+    required String? expiresAtIso,
+    required String? nextPaymentDueAtIso,
+  }) {
+    final isActive = status == 'active' || status == 'grace_period';
+    final showAds = !isActive
+        ? true
+        : (planCode == 'FREE' || planCode == 'BASE');
+    return BillingEntitlement(
+      planCode: planCode,
+      status: status,
+      showAds: showAds,
+      adFree: !showAds,
+      hasPremiumAccess: isActive && planCode != 'FREE',
+      expiresAtIso: expiresAtIso,
+      nextPaymentDueAtIso: nextPaymentDueAtIso,
+    );
+  }
+
+  String _clanIdOf(AuthSession session) {
+    final clanId = (session.clanId ?? '').trim();
+    if (clanId.isEmpty) {
+      throw const BillingRepositoryException(
+        BillingRepositoryErrorCode.failedPrecondition,
+        'No clan context available for billing.',
+      );
+    }
+    return clanId;
+  }
+}
+
+class _DebugBillingState {
+  _DebugBillingState({
+    required this.clanId,
+    required this.memberCount,
+    required this.subscription,
+    required this.entitlement,
+    required this.settings,
+    required this.transactions,
+    required this.invoices,
+    required this.auditLogs,
+  });
+
+  final String clanId;
+  int memberCount;
+  BillingSubscription subscription;
+  BillingEntitlement entitlement;
+  BillingSettings settings;
+  final List<BillingPaymentTransaction> transactions;
+  final List<BillingInvoice> invoices;
+  final List<BillingAuditLog> auditLogs;
+
+  BillingWorkspaceSnapshot toSnapshot() {
+    final pricing = [
+      const _PricingTier(
+        planCode: 'FREE',
+        minMembers: 0,
+        maxMembers: 10,
+        priceVndYear: 0,
+        showAds: true,
+      ),
+      const _PricingTier(
+        planCode: 'BASE',
+        minMembers: 11,
+        maxMembers: 200,
+        priceVndYear: 49000,
+        showAds: true,
+      ),
+      const _PricingTier(
+        planCode: 'PLUS',
+        minMembers: 201,
+        maxMembers: 700,
+        priceVndYear: 89000,
+        showAds: false,
+      ),
+      const _PricingTier(
+        planCode: 'PRO',
+        minMembers: 701,
+        maxMembers: null,
+        priceVndYear: 119000,
+        showAds: false,
+      ),
+    ].map((tier) => tier.toPricing()).toList(growable: false);
+
+    return BillingWorkspaceSnapshot(
+      clanId: clanId,
+      subscription: subscription,
+      entitlement: entitlement,
+      settings: settings,
+      pricingTiers: pricing,
+      memberCount: memberCount,
+      transactions: List.unmodifiable(transactions),
+      invoices: List.unmodifiable(invoices),
+      auditLogs: List.unmodifiable(auditLogs),
+    );
+  }
+}
+
+class _PricingTier {
+  const _PricingTier({
+    required this.planCode,
+    required this.minMembers,
+    required this.maxMembers,
+    required this.priceVndYear,
+    required this.showAds,
+  });
+
+  final String planCode;
+  final int minMembers;
+  final int? maxMembers;
+  final int priceVndYear;
+  final bool showAds;
+
+  BillingPlanPricing toPricing() {
+    return BillingPlanPricing(
+      planCode: planCode,
+      minMembers: minMembers,
+      maxMembers: maxMembers,
+      priceVndYear: priceVndYear,
+      vatIncluded: true,
+      showAds: showAds,
+      adFree: !showAds,
+    );
+  }
+}

--- a/mobile/befam/lib/features/billing/services/firebase_billing_repository.dart
+++ b/mobile/befam/lib/features/billing/services/firebase_billing_repository.dart
@@ -1,0 +1,441 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+
+import '../../../core/services/firebase_services.dart';
+import '../../../core/services/firebase_session_access_sync.dart';
+import '../../auth/models/auth_session.dart';
+import '../models/billing_workspace_snapshot.dart';
+import 'billing_repository.dart';
+
+class FirebaseBillingRepository implements BillingRepository {
+  FirebaseBillingRepository({
+    FirebaseFunctions? functions,
+    FirebaseFirestore? firestore,
+  }) : _functions = functions ?? FirebaseServices.functions,
+       _firestore = firestore ?? FirebaseServices.firestore;
+
+  final FirebaseFunctions _functions;
+  final FirebaseFirestore _firestore;
+
+  @override
+  bool get isSandbox => false;
+
+  @override
+  Future<BillingWorkspaceSnapshot> loadWorkspace({
+    required AuthSession session,
+  }) async {
+    final clanId = _sessionClanId(session);
+    await FirebaseSessionAccessSync.ensureUserSessionDocument(
+      firestore: _firestore,
+      session: session,
+    );
+    final result = await _call('loadBillingWorkspace').call({
+      'clanId': clanId,
+    });
+    return _parseWorkspace(result.data);
+  }
+
+  @override
+  Future<BillingEntitlement> resolveEntitlement({
+    required AuthSession session,
+  }) async {
+    final clanId = _sessionClanId(session);
+    await FirebaseSessionAccessSync.ensureUserSessionDocument(
+      firestore: _firestore,
+      session: session,
+    );
+    final result = await _call('resolveBillingEntitlement').call({
+      'clanId': clanId,
+    });
+    final map = _asMap(result.data);
+    return _parseEntitlement(_asMap(map['entitlement']));
+  }
+
+  @override
+  Future<BillingSettings> updatePreferences({
+    required AuthSession session,
+    required String paymentMode,
+    required bool autoRenew,
+    List<int>? reminderDaysBefore,
+  }) async {
+    final clanId = _sessionClanId(session);
+    await FirebaseSessionAccessSync.ensureUserSessionDocument(
+      firestore: _firestore,
+      session: session,
+    );
+    final payload = <String, dynamic>{
+      'clanId': clanId,
+      'paymentMode': paymentMode,
+      'autoRenew': autoRenew,
+      ...?reminderDaysBefore == null
+          ? null
+          : {'reminderDaysBefore': reminderDaysBefore},
+    };
+    final result = await _call('updateBillingPreferences').call(payload);
+    return _parseSettings(_asMap(result.data));
+  }
+
+  @override
+  Future<BillingCheckoutResult> createCheckout({
+    required AuthSession session,
+    required String paymentMethod,
+    String? returnUrl,
+  }) async {
+    final clanId = _sessionClanId(session);
+    await FirebaseSessionAccessSync.ensureUserSessionDocument(
+      firestore: _firestore,
+      session: session,
+    );
+    final result = await _call('createSubscriptionCheckout').call({
+      'clanId': clanId,
+      'paymentMethod': paymentMethod,
+      if (returnUrl != null && returnUrl.trim().isNotEmpty)
+        'returnUrl': returnUrl.trim(),
+    });
+    final map = _asMap(result.data);
+    return BillingCheckoutResult(
+      clanId: _readString(map, 'clanId', fallback: clanId),
+      paymentMethod: _readString(map, 'paymentMethod', fallback: paymentMethod),
+      planCode: _readString(map, 'planCode', fallback: 'FREE'),
+      amountVnd: _readInt(map, 'amountVnd'),
+      vatIncluded: _readBool(map, 'vatIncluded', fallback: true),
+      transactionId: _readString(map, 'transactionId'),
+      invoiceId: _readString(map, 'invoiceId'),
+      checkoutUrl: _readString(map, 'checkoutUrl', fallback: ''),
+      requiresManualConfirmation: _readBool(
+        map,
+        'requiresManualConfirmation',
+        fallback: false,
+      ),
+      subscription: _parseSubscription(_asMap(map['subscription'])),
+      entitlement: _parseEntitlement(_asMap(map['entitlement'])),
+    );
+  }
+
+  @override
+  Future<void> completeCardCheckout({
+    required AuthSession session,
+    required String transactionId,
+  }) async {
+    final clanId = _sessionClanId(session);
+    await FirebaseSessionAccessSync.ensureUserSessionDocument(
+      firestore: _firestore,
+      session: session,
+    );
+    await _call('completeCardCheckout').call({
+      'clanId': clanId,
+      'transactionId': transactionId.trim(),
+    });
+  }
+
+  @override
+  Future<void> settleVnpayCheckout({
+    required AuthSession session,
+    required String transactionId,
+  }) async {
+    final clanId = _sessionClanId(session);
+    await FirebaseSessionAccessSync.ensureUserSessionDocument(
+      firestore: _firestore,
+      session: session,
+    );
+    await _call('simulateVnpaySettlement').call({
+      'clanId': clanId,
+      'transactionId': transactionId.trim(),
+    });
+  }
+
+  HttpsCallable _call(String name) {
+    return _functions.httpsCallable(name);
+  }
+
+  BillingWorkspaceSnapshot _parseWorkspace(Object? raw) {
+    final map = _asMap(raw);
+    final pricing = _asList(map['pricingTiers'])
+        .map((item) => _parsePricing(_asMap(item)))
+        .toList(growable: false);
+    final transactions = _asList(map['transactions'])
+        .map((item) => _parseTransaction(_asMap(item)))
+        .toList(growable: false);
+    final invoices = _asList(map['invoices'])
+        .map((item) => _parseInvoice(_asMap(item)))
+        .toList(growable: false);
+    final auditLogs = _asList(map['auditLogs'])
+        .map((item) => _parseAuditLog(_asMap(item)))
+        .toList(growable: false);
+
+    return BillingWorkspaceSnapshot(
+      clanId: _readString(map, 'clanId'),
+      subscription: _parseSubscription(_asMap(map['subscription'])),
+      entitlement: _parseEntitlement(_asMap(map['entitlement'])),
+      settings: _parseSettings(_asMap(map['settings'])),
+      pricingTiers: pricing,
+      memberCount: _readInt(map, 'memberCount'),
+      transactions: transactions,
+      invoices: invoices,
+      auditLogs: auditLogs,
+    );
+  }
+
+  BillingSubscription _parseSubscription(Map<String, dynamic> map) {
+    return BillingSubscription(
+      id: _readString(map, 'id'),
+      clanId: _readString(map, 'clanId'),
+      planCode: _readString(map, 'planCode', fallback: 'FREE'),
+      status: _readString(map, 'status', fallback: 'expired'),
+      memberCount: _readInt(map, 'memberCount'),
+      amountVndYear: _readInt(map, 'amountVndYear'),
+      vatIncluded: _readBool(map, 'vatIncluded', fallback: true),
+      paymentMode: _readString(map, 'paymentMode', fallback: 'manual'),
+      autoRenew: _readBool(map, 'autoRenew', fallback: false),
+      startsAtIso: _readIso(map, 'startsAt'),
+      expiresAtIso: _readIso(map, 'expiresAt'),
+      nextPaymentDueAtIso: _readIso(map, 'nextPaymentDueAt'),
+      graceEndsAtIso: _readIso(map, 'graceEndsAt'),
+      lastPaymentMethod: _readNullableString(map, 'lastPaymentMethod'),
+      lastTransactionId: _readNullableString(map, 'lastTransactionId'),
+      updatedAtIso: _readIso(map, 'updatedAt'),
+    );
+  }
+
+  BillingEntitlement _parseEntitlement(Map<String, dynamic> map) {
+    return BillingEntitlement(
+      planCode: _readString(map, 'planCode', fallback: 'FREE'),
+      status: _readString(map, 'status', fallback: 'expired'),
+      showAds: _readBool(map, 'showAds', fallback: true),
+      adFree: _readBool(map, 'adFree', fallback: false),
+      hasPremiumAccess: _readBool(map, 'hasPremiumAccess', fallback: false),
+      expiresAtIso: _readIso(map, 'expiresAtIso'),
+      nextPaymentDueAtIso: _readIso(map, 'nextPaymentDueAtIso'),
+    );
+  }
+
+  BillingSettings _parseSettings(Map<String, dynamic> map) {
+    return BillingSettings(
+      id: _readString(map, 'id'),
+      clanId: _readString(map, 'clanId'),
+      paymentMode: _readString(map, 'paymentMode', fallback: 'manual'),
+      autoRenew: _readBool(map, 'autoRenew', fallback: false),
+      reminderDaysBefore: _readIntList(map, 'reminderDaysBefore'),
+      updatedAtIso: _readIso(map, 'updatedAt'),
+    );
+  }
+
+  BillingPlanPricing _parsePricing(Map<String, dynamic> map) {
+    return BillingPlanPricing(
+      planCode: _readString(map, 'planCode', fallback: 'FREE'),
+      minMembers: _readInt(map, 'minMembers'),
+      maxMembers: _readNullableInt(map, 'maxMembers'),
+      priceVndYear: _readInt(map, 'priceVndYear'),
+      vatIncluded: _readBool(map, 'vatIncluded', fallback: true),
+      showAds: _readBool(map, 'showAds', fallback: true),
+      adFree: _readBool(map, 'adFree', fallback: false),
+    );
+  }
+
+  BillingPaymentTransaction _parseTransaction(Map<String, dynamic> map) {
+    return BillingPaymentTransaction(
+      id: _readString(map, 'id'),
+      clanId: _readString(map, 'clanId'),
+      subscriptionId: _readString(map, 'subscriptionId'),
+      invoiceId: _readString(map, 'invoiceId'),
+      paymentMethod: _readString(map, 'paymentMethod', fallback: 'card'),
+      paymentStatus: _readString(map, 'paymentStatus', fallback: 'created'),
+      planCode: _readString(map, 'planCode', fallback: 'FREE'),
+      memberCount: _readInt(map, 'memberCount'),
+      amountVnd: _readInt(map, 'amountVnd'),
+      vatIncluded: _readBool(map, 'vatIncluded', fallback: true),
+      currency: _readString(map, 'currency', fallback: 'VND'),
+      gatewayReference: _readNullableString(map, 'gatewayReference'),
+      createdAtIso: _readIso(map, 'createdAt'),
+      paidAtIso: _readIso(map, 'paidAt'),
+      failedAtIso: _readIso(map, 'failedAt'),
+    );
+  }
+
+  BillingInvoice _parseInvoice(Map<String, dynamic> map) {
+    return BillingInvoice(
+      id: _readString(map, 'id'),
+      clanId: _readString(map, 'clanId'),
+      subscriptionId: _readString(map, 'subscriptionId'),
+      transactionId: _readString(map, 'transactionId'),
+      planCode: _readString(map, 'planCode', fallback: 'FREE'),
+      amountVnd: _readInt(map, 'amountVnd'),
+      vatIncluded: _readBool(map, 'vatIncluded', fallback: true),
+      currency: _readString(map, 'currency', fallback: 'VND'),
+      status: _readString(map, 'status', fallback: 'issued'),
+      periodStartIso: _readIso(map, 'periodStart'),
+      periodEndIso: _readIso(map, 'periodEnd'),
+      issuedAtIso: _readIso(map, 'issuedAt'),
+      paidAtIso: _readIso(map, 'paidAt'),
+    );
+  }
+
+  BillingAuditLog _parseAuditLog(Map<String, dynamic> map) {
+    return BillingAuditLog(
+      id: _readString(map, 'id'),
+      clanId: _readString(map, 'clanId'),
+      actorUid: _readNullableString(map, 'actorUid'),
+      action: _readString(map, 'action'),
+      entityType: _readString(map, 'entityType'),
+      entityId: _readString(map, 'entityId'),
+      createdAtIso: _readIso(map, 'createdAt'),
+    );
+  }
+
+  String _sessionClanId(AuthSession session) {
+    final clanId = (session.clanId ?? '').trim();
+    if (clanId.isEmpty) {
+      throw const BillingRepositoryException(
+        BillingRepositoryErrorCode.failedPrecondition,
+        'No clan context available for billing.',
+      );
+    }
+    return clanId;
+  }
+
+  Map<String, dynamic> _asMap(Object? raw) {
+    if (raw is Map<String, dynamic>) {
+      return raw;
+    }
+    if (raw is Map) {
+      return raw.map(
+        (key, value) => MapEntry(key.toString(), value),
+      );
+    }
+    return const {};
+  }
+
+  List<dynamic> _asList(Object? raw) {
+    if (raw is List) {
+      return raw;
+    }
+    return const [];
+  }
+
+  String _readString(
+    Map<String, dynamic> map,
+    String key, {
+    String fallback = '',
+  }) {
+    final value = map[key];
+    if (value is String && value.trim().isNotEmpty) {
+      return value.trim();
+    }
+    return fallback;
+  }
+
+  String? _readNullableString(Map<String, dynamic> map, String key) {
+    final value = map[key];
+    if (value is String && value.trim().isNotEmpty) {
+      return value.trim();
+    }
+    return null;
+  }
+
+  int _readInt(Map<String, dynamic> map, String key, {int fallback = 0}) {
+    final value = map[key];
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.toInt();
+    }
+    if (value is String) {
+      final parsed = int.tryParse(value);
+      if (parsed != null) {
+        return parsed;
+      }
+    }
+    return fallback;
+  }
+
+  int? _readNullableInt(Map<String, dynamic> map, String key) {
+    final value = map[key];
+    if (value == null) {
+      return null;
+    }
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.toInt();
+    }
+    if (value is String) {
+      return int.tryParse(value);
+    }
+    return null;
+  }
+
+  bool _readBool(Map<String, dynamic> map, String key, {bool fallback = false}) {
+    final value = map[key];
+    if (value is bool) {
+      return value;
+    }
+    if (value is String) {
+      final normalized = value.trim().toLowerCase();
+      if (normalized == 'true') {
+        return true;
+      }
+      if (normalized == 'false') {
+        return false;
+      }
+    }
+    return fallback;
+  }
+
+  List<int> _readIntList(Map<String, dynamic> map, String key) {
+    final raw = map[key];
+    if (raw is! List) {
+      return const [30, 14, 7, 3, 1];
+    }
+    final values = raw
+        .map((item) {
+          if (item is int) {
+            return item;
+          }
+          if (item is num) {
+            return item.toInt();
+          }
+          if (item is String) {
+            return int.tryParse(item);
+          }
+          return null;
+        })
+        .whereType<int>()
+        .where((value) => value > 0 && value <= 60)
+        .toSet()
+        .toList(growable: false)
+      ..sort((left, right) => right.compareTo(left));
+    return values.isEmpty ? const [30, 14, 7, 3, 1] : values;
+  }
+
+  String? _readIso(Map<String, dynamic> map, String key) {
+    final value = map[key];
+    if (value == null) {
+      return null;
+    }
+    if (value is String) {
+      final trimmed = value.trim();
+      return trimmed.isEmpty ? null : trimmed;
+    }
+    if (value is DateTime) {
+      return value.toUtc().toIso8601String();
+    }
+    if (value is Timestamp) {
+      return value.toDate().toUtc().toIso8601String();
+    }
+    if (value is Map) {
+      final seconds = value['_seconds'];
+      final nanoseconds = value['_nanoseconds'];
+      if (seconds is int) {
+        final dt = DateTime.fromMillisecondsSinceEpoch(
+          (seconds * 1000) +
+              (nanoseconds is int ? (nanoseconds ~/ 1000000) : 0),
+          isUtc: true,
+        );
+        return dt.toIso8601String();
+      }
+    }
+    return null;
+  }
+}

--- a/mobile/befam/lib/features/profile/presentation/profile_workspace_page.dart
+++ b/mobile/befam/lib/features/profile/presentation/profile_workspace_page.dart
@@ -7,6 +7,8 @@ import '../../../core/widgets/app_feedback_states.dart';
 import '../../../l10n/generated/app_localizations.dart';
 import '../../../l10n/l10n.dart';
 import '../../auth/models/auth_session.dart';
+import '../../billing/presentation/billing_workspace_page.dart';
+import '../../billing/services/billing_repository.dart';
 import '../../member/models/member_profile.dart';
 import '../../member/services/member_avatar_picker.dart';
 import '../../member/services/member_repository.dart';
@@ -22,6 +24,8 @@ class ProfileWorkspacePage extends StatefulWidget {
     this.avatarPicker,
     this.notificationPreferencesRepository,
     this.localeController,
+    this.billingRepository,
+    this.onBillingStateChanged,
     this.onLogoutRequested,
     this.showAppBar = false,
   });
@@ -32,6 +36,8 @@ class ProfileWorkspacePage extends StatefulWidget {
   final ProfileNotificationPreferencesRepository?
   notificationPreferencesRepository;
   final AppLocaleController? localeController;
+  final BillingRepository? billingRepository;
+  final VoidCallback? onBillingStateChanged;
   final Future<void> Function()? onLogoutRequested;
   final bool showAppBar;
 
@@ -200,7 +206,10 @@ class _ProfileWorkspacePageState extends State<ProfileWorkspacePage> {
         builder: (context) {
           return _SettingsScreenShell(
             controller: _controller,
+            session: widget.session,
             localeController: _localeController,
+            billingRepository: widget.billingRepository,
+            onBillingStateChanged: widget.onBillingStateChanged,
             onLogoutRequested: widget.onLogoutRequested,
           );
         },
@@ -428,12 +437,18 @@ class _ProfileWorkspacePageState extends State<ProfileWorkspacePage> {
 class _SettingsScreenShell extends StatelessWidget {
   const _SettingsScreenShell({
     required this.controller,
+    required this.session,
     required this.localeController,
+    this.billingRepository,
+    this.onBillingStateChanged,
     required this.onLogoutRequested,
   });
 
   final ProfileController controller;
+  final AuthSession session;
   final AppLocaleController localeController;
+  final BillingRepository? billingRepository;
+  final VoidCallback? onBillingStateChanged;
   final Future<void> Function()? onLogoutRequested;
 
   Future<void> _confirmLogout(BuildContext context) async {
@@ -536,6 +551,46 @@ class _SettingsScreenShell extends StatelessWidget {
                 _ProfileSectionCard(
                   title: l10n.notificationSettingsTitle,
                   child: _NotificationSettingsPanel(controller: controller),
+                ),
+                const SizedBox(height: 20),
+                _ProfileSectionCard(
+                  title: l10n.pick(
+                    vi: 'Gói dịch vụ & thanh toán',
+                    en: 'Subscription & billing',
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        l10n.pick(
+                          vi: 'Xem trạng thái gói, ngày hết hạn, chế độ thanh toán tự động/thủ công và lịch sử giao dịch.',
+                          en: 'View your current plan, expiry date, payment mode, and transaction history.',
+                        ),
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                      const SizedBox(height: 10),
+                      FilledButton.tonalIcon(
+                        onPressed: () async {
+                          await Navigator.of(context).push(
+                            MaterialPageRoute<void>(
+                              builder: (context) => BillingWorkspacePage(
+                                session: session,
+                                repository: billingRepository,
+                              ),
+                            ),
+                          );
+                          onBillingStateChanged?.call();
+                        },
+                        icon: const Icon(Icons.workspace_premium_outlined),
+                        label: Text(
+                          l10n.pick(
+                            vi: 'Mở quản lý gói',
+                            en: 'Open billing workspace',
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
                 if (onLogoutRequested != null) ...[
                   const SizedBox(height: 20),

--- a/mobile/befam/test/features/billing/billing_repository_test.dart
+++ b/mobile/befam/test/features/billing/billing_repository_test.dart
@@ -1,0 +1,81 @@
+import 'package:befam/core/services/debug_genealogy_store.dart';
+import 'package:befam/features/auth/models/auth_entry_method.dart';
+import 'package:befam/features/auth/models/auth_member_access_mode.dart';
+import 'package:befam/features/auth/models/auth_session.dart';
+import 'package:befam/features/billing/services/debug_billing_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  AuthSession buildSession() {
+    return AuthSession(
+      uid: 'debug:+84901234567',
+      loginMethod: AuthEntryMethod.phone,
+      phoneE164: '+84901234567',
+      displayName: 'Nguyen Minh',
+      memberId: 'member_demo_parent_001',
+      clanId: 'clan_demo_001',
+      branchId: 'branch_demo_001',
+      primaryRole: 'CLAN_ADMIN',
+      accessMode: AuthMemberAccessMode.claimed,
+      linkedAuthUid: true,
+      isSandbox: true,
+      signedInAtIso: DateTime(2026, 3, 15).toIso8601String(),
+    );
+  }
+
+  test('debug billing repository loads workspace and free-plan entitlement', () async {
+    final repository = DebugBillingRepository.shared();
+    final snapshot = await repository.loadWorkspace(session: buildSession());
+
+    expect(snapshot.clanId, 'clan_demo_001');
+    expect(snapshot.subscription.planCode, 'FREE');
+    expect(snapshot.entitlement.showAds, isTrue);
+    expect(snapshot.pricingTiers, isNotEmpty);
+  });
+
+  test('debug billing repository updates billing preferences', () async {
+    final repository = DebugBillingRepository.shared();
+    final settings = await repository.updatePreferences(
+      session: buildSession(),
+      paymentMode: 'auto_renew',
+      autoRenew: true,
+      reminderDaysBefore: const [21, 7, 1],
+    );
+
+    expect(settings.paymentMode, 'auto_renew');
+    expect(settings.autoRenew, isTrue);
+    expect(settings.reminderDaysBefore, containsAll(<int>[21, 7, 1]));
+  });
+
+  test('debug billing repository creates checkout for paid tier and settles payment', () async {
+    final store = DebugGenealogyStore.sharedSeeded();
+    for (var index = 0; index < 20; index += 1) {
+      store.members['member_billing_test_$index'] =
+          store.members['member_demo_parent_001']!.copyWith(
+            id: 'member_billing_test_$index',
+            fullName: 'Billing Test Member $index',
+            normalizedFullName: 'billing test member $index',
+            authUid: null,
+            primaryRole: 'MEMBER',
+          );
+    }
+
+    final repository = DebugBillingRepository.shared();
+    final checkout = await repository.createCheckout(
+      session: buildSession(),
+      paymentMethod: 'card',
+    );
+    expect(checkout.planCode, isNot('FREE'));
+    expect(checkout.amountVnd, greaterThan(0));
+    expect(checkout.requiresManualConfirmation, isTrue);
+
+    await repository.completeCardCheckout(
+      session: buildSession(),
+      transactionId: checkout.transactionId,
+    );
+
+    final snapshot = await repository.loadWorkspace(session: buildSession());
+    expect(snapshot.subscription.status, 'active');
+    expect(snapshot.entitlement.hasPremiumAccess, isTrue);
+  });
+}

--- a/mobile/befam/test/features/billing/billing_workspace_page_test.dart
+++ b/mobile/befam/test/features/billing/billing_workspace_page_test.dart
@@ -1,0 +1,112 @@
+import 'package:befam/core/services/debug_genealogy_store.dart';
+import 'package:befam/features/auth/models/auth_entry_method.dart';
+import 'package:befam/features/auth/models/auth_member_access_mode.dart';
+import 'package:befam/features/auth/models/auth_session.dart';
+import 'package:befam/features/billing/presentation/billing_workspace_page.dart';
+import 'package:befam/features/billing/services/debug_billing_repository.dart';
+import 'package:befam/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  AuthSession buildSession() {
+    return AuthSession(
+      uid: 'debug:+84901234567',
+      loginMethod: AuthEntryMethod.phone,
+      phoneE164: '+84901234567',
+      displayName: 'Nguyen Minh',
+      memberId: 'member_demo_parent_001',
+      clanId: 'clan_demo_001',
+      branchId: 'branch_demo_001',
+      primaryRole: 'CLAN_ADMIN',
+      accessMode: AuthMemberAccessMode.claimed,
+      linkedAuthUid: true,
+      isSandbox: true,
+      signedInAtIso: DateTime(2026, 3, 15).toIso8601String(),
+    );
+  }
+
+  Future<void> pumpBillingPage(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('vi'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: BillingWorkspacePage(
+          session: buildSession(),
+          repository: DebugBillingRepository.shared(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+  }
+
+  void seedPaidTier() {
+    final store = DebugGenealogyStore.sharedSeeded();
+    for (var index = 0; index < 20; index += 1) {
+      store.members['member_billing_widget_$index'] =
+          store.members['member_demo_parent_001']!.copyWith(
+            id: 'member_billing_widget_$index',
+            fullName: 'Billing Widget Member $index',
+            normalizedFullName: 'billing widget member $index',
+            authUid: null,
+            primaryRole: 'MEMBER',
+          );
+    }
+  }
+
+  testWidgets('renders billing workspace summary', (tester) async {
+    await pumpBillingPage(tester);
+
+    expect(find.text('Gói dịch vụ'), findsOneWidget);
+    expect(find.textContaining('Số thành viên hiện tại'), findsOneWidget);
+    await tester.scrollUntilVisible(
+      find.text('Lịch sử thanh toán'),
+      280,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.text('Lịch sử thanh toán'), findsOneWidget);
+  });
+
+  testWidgets('creates card checkout and displays latest checkout card', (tester) async {
+    seedPaidTier();
+    await pumpBillingPage(tester);
+
+    final cardButton = find.byKey(const Key('billing-checkout-card-button'));
+    expect(cardButton, findsOneWidget);
+
+    await tester.tap(cardButton);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+
+    expect(find.text('Phiên thanh toán mới nhất'), findsOneWidget);
+    expect(find.textContaining('Mã giao dịch'), findsOneWidget);
+  });
+
+  testWidgets('saves billing preference changes', (tester) async {
+    seedPaidTier();
+    await pumpBillingPage(tester);
+
+    final saveButton = find.byKey(const Key('billing-save-preferences-button'));
+    await tester.scrollUntilVisible(
+      saveButton,
+      280,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(find.text('Tự động').first, warnIfMissed: false);
+    await tester.pump();
+
+    await tester.tap(saveButton);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('Đã lưu cài đặt thanh toán.'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- implement backend billing domain for Free/Base/Plus/Pro plans with non-overlap member tiers
- add Cloud Functions callables/webhooks/jobs for checkout, settlement, reminders, entitlement resolution, and billing workspace data
- add Firestore rules + indexes for billing collections and callback idempotency support
- add Flutter billing module (repository/controller/screen), payment mode management, history/invoice/audit UI, and entitlement-driven ad banner behavior
- add BILL-012 tests (functions contract tests + Flutter unit/widget tests)
- update product/architecture/security/privacy/monitoring docs to reflect implemented billing feature set

## Validation
- `cd firebase/functions && npm test`
- `cd mobile/befam && flutter analyze lib/features/billing lib/app/home/app_shell_page.dart lib/features/profile/presentation/profile_workspace_page.dart`
- `cd mobile/befam && flutter test test/features/billing/billing_repository_test.dart test/features/billing/billing_workspace_page_test.dart`
- `python3 scripts/validate_rules_documentation.py`

## Notes
- `mkdocs` CLI is not installed in this environment, so docs site build was not executed locally.
