### PR TITLE
feat(billing): scope subscriptions per user across clans

### DIFF
--- a/firebase/functions/src/auth/callables.ts
+++ b/firebase/functions/src/auth/callables.ts
@@ -442,6 +442,8 @@ export const bootstrapClanWorkspace = onCall(
         status: 'active',
         memberCount: 1,
         branchCount: 1,
+        ownerUid: auth.uid,
+        billingOwnerUid: auth.uid,
         createdAt: now,
         createdBy: auth.uid,
         updatedAt: now,

--- a/firebase/functions/src/billing/callables.ts
+++ b/firebase/functions/src/billing/callables.ts
@@ -9,7 +9,6 @@ import {
   buildEntitlementFromSubscription,
   createPendingCheckout,
   ensureSubscriptionForClan,
-  loadBillingSettings,
   resolveBillingAudienceMemberIds,
   upsertBillingSettings,
   writeBillingAuditLog,
@@ -37,6 +36,10 @@ const subscriptionsCollection = db.collection('subscriptions');
 const transactionsCollection = db.collection('paymentTransactions');
 const invoicesCollection = db.collection('subscriptionInvoices');
 const billingAuditLogsCollection = db.collection('billingAuditLogs');
+
+function scopedBillingDocId(clanId: string, ownerUid: string): string {
+  return `${clanId}__${ownerUid}`;
+}
 
 export const resolveBillingEntitlement = onCall(
   { region: APP_REGION },
@@ -76,7 +79,6 @@ export const loadBillingWorkspace = onCall(
       throw new HttpsError('failed-precondition', 'No clan context is available.');
     }
     ensureClanAccess(auth.token, clanId);
-    assertBillingAdmin(auth.token);
 
     const ensured = await ensureSubscriptionForClan({
       clanId,
@@ -133,7 +135,6 @@ export const updateBillingPreferences = onCall(
       throw new HttpsError('failed-precondition', 'No clan context is available.');
     }
     ensureClanAccess(auth.token, clanId);
-    assertBillingAdmin(auth.token);
 
     const paymentMode = normalizePaymentModeFromInput(request.data);
     const autoRenew = readBoolean(request.data, 'autoRenew', paymentMode === 'auto_renew');
@@ -141,13 +142,14 @@ export const updateBillingPreferences = onCall(
 
     const settings = await upsertBillingSettings({
       clanId,
+      ownerUid: auth.uid,
       paymentMode,
       autoRenew,
       reminderDaysBefore,
       actorUid: auth.uid,
     });
 
-    await subscriptionsCollection.doc(clanId).set(
+    await subscriptionsCollection.doc(scopedBillingDocId(clanId, auth.uid)).set(
       {
         paymentMode: settings.paymentMode,
         autoRenew: settings.autoRenew,
@@ -184,7 +186,6 @@ export const createSubscriptionCheckout = onCall(
       throw new HttpsError('failed-precondition', 'No clan context is available.');
     }
     ensureClanAccess(auth.token, clanId);
-    assertBillingAdmin(auth.token);
 
     const paymentMethod = normalizePaymentMethod(request.data);
     const requestedPlanCode = normalizeRequestedPlanCode(request.data);
@@ -262,7 +263,6 @@ export const completeCardCheckout = onCall(
       throw new HttpsError('failed-precondition', 'No clan context is available.');
     }
     ensureClanAccess(auth.token, clanId);
-    assertBillingAdmin(auth.token);
 
     const transactionId = readString(request.data, 'transactionId');
     if (transactionId == null || transactionId.length === 0) {
@@ -276,6 +276,10 @@ export const completeCardCheckout = onCall(
     const txClanId = normalizeString(txSnapshot.data()?.clanId);
     if (txClanId !== clanId) {
       throw new HttpsError('permission-denied', 'transaction clan mismatch.');
+    }
+    const txOwnerUid = normalizeString(txSnapshot.data()?.subscriptionOwnerUid);
+    if (txOwnerUid.length > 0 && txOwnerUid !== auth.uid) {
+      throw new HttpsError('permission-denied', 'transaction owner mismatch.');
     }
 
     const payment = await applyPaymentResult({
@@ -317,11 +321,23 @@ export const simulateVnpaySettlement = onCall(
       throw new HttpsError('failed-precondition', 'No clan context is available.');
     }
     ensureClanAccess(auth.token, clanId);
-    assertBillingAdmin(auth.token);
 
     const transactionId = readString(request.data, 'transactionId');
     if (transactionId == null || transactionId.length === 0) {
       throw new HttpsError('invalid-argument', 'transactionId is required.');
+    }
+
+    const txSnapshot = await transactionsCollection.doc(transactionId).get();
+    if (!txSnapshot.exists) {
+      throw new HttpsError('not-found', 'transaction not found.');
+    }
+    const txClanId = normalizeString(txSnapshot.data()?.clanId);
+    if (txClanId !== clanId) {
+      throw new HttpsError('permission-denied', 'transaction clan mismatch.');
+    }
+    const txOwnerUid = normalizeString(txSnapshot.data()?.subscriptionOwnerUid);
+    if (txOwnerUid.length > 0 && txOwnerUid !== auth.uid) {
+      throw new HttpsError('permission-denied', 'transaction owner mismatch.');
     }
 
     const payment = await applyPaymentResult({
@@ -402,25 +418,6 @@ function resolveClanId(token: AuthToken, data: unknown): string {
     return dataClanId;
   }
   return clanIds[0] ?? '';
-}
-
-function assertBillingAdmin(token: AuthToken): void {
-  const role = normalizeString(token.primaryRole).toUpperCase();
-  const allowed = new Set([
-    'SUPER_ADMIN',
-    'CLAN_ADMIN',
-    'BRANCH_ADMIN',
-    'CLAN_OWNER',
-    'CLAN_LEADER',
-    'VICE_LEADER',
-    'SUPPORTER_OF_LEADER',
-  ]);
-  if (!allowed.has(role)) {
-    throw new HttpsError(
-      'permission-denied',
-      'Billing actions require clan owner/admin privileges.',
-    );
-  }
 }
 
 function normalizePaymentMethod(data: unknown): PaymentMethod {

--- a/firebase/functions/src/billing/store.ts
+++ b/firebase/functions/src/billing/store.ts
@@ -27,6 +27,7 @@ type NullableDate = Date | null;
 export type BillingSettingsRecord = {
   id: string;
   clanId: string;
+  ownerUid: string;
   paymentMode: PaymentMode;
   autoRenew: boolean;
   reminderDaysBefore: Array<number>;
@@ -36,6 +37,7 @@ export type BillingSettingsRecord = {
 export type BillingTransactionRecord = {
   id: string;
   clanId: string;
+  subscriptionOwnerUid: string;
   subscriptionId: string;
   invoiceId: string;
   paymentMethod: PaymentMethod;
@@ -55,6 +57,7 @@ export type BillingTransactionRecord = {
 export type BillingInvoiceRecord = {
   id: string;
   clanId: string;
+  subscriptionOwnerUid: string;
   subscriptionId: string;
   transactionId: string;
   planCode: BillingPlanCode;
@@ -85,17 +88,36 @@ const invoicesCollection = db.collection('subscriptionInvoices');
 const webhookEventsCollection = db.collection('paymentWebhookEvents');
 const billingAuditLogsCollection = db.collection('billingAuditLogs');
 
+function scopedBillingDocId({
+  clanId,
+  ownerUid,
+}: {
+  clanId: string;
+  ownerUid: string;
+}): string {
+  return `${clanId}__${ownerUid}`;
+}
+
 export async function countClanMembers(clanId: string): Promise<number> {
   const snapshot = await membersCollection.where('clanId', '==', clanId).count().get();
   return Number(snapshot.data().count ?? 0);
 }
 
-export async function loadBillingSettings(clanId: string): Promise<BillingSettingsRecord> {
-  const snapshot = await billingSettingsCollection.doc(clanId).get();
+export async function loadBillingSettings(
+  clanId: string,
+  ownerUid: string,
+): Promise<BillingSettingsRecord> {
+  const scopedId = scopedBillingDocId({ clanId, ownerUid });
+  const [scopedSnapshot, legacySnapshot] = await Promise.all([
+    billingSettingsCollection.doc(scopedId).get(),
+    billingSettingsCollection.doc(clanId).get(),
+  ]);
+  const snapshot = scopedSnapshot.exists ? scopedSnapshot : legacySnapshot;
   if (!snapshot.exists) {
     return {
-      id: clanId,
+      id: scopedId,
       clanId,
+      ownerUid,
       paymentMode: 'manual',
       autoRenew: false,
       reminderDaysBefore: [30, 14, 7, 3, 1],
@@ -104,8 +126,9 @@ export async function loadBillingSettings(clanId: string): Promise<BillingSettin
   }
   const data = snapshot.data() ?? {};
   return {
-    id: snapshot.id,
+    id: scopedId,
     clanId: readString(data.clanId, clanId),
+    ownerUid: readString(data.ownerUid, ownerUid),
     paymentMode: normalizePaymentMode(data.paymentMode),
     autoRenew: readBool(data.autoRenew, false),
     reminderDaysBefore: normalizeReminderDays(data.reminderDaysBefore),
@@ -115,22 +138,26 @@ export async function loadBillingSettings(clanId: string): Promise<BillingSettin
 
 export async function upsertBillingSettings({
   clanId,
+  ownerUid,
   paymentMode,
   autoRenew,
   reminderDaysBefore,
   actorUid,
 }: {
   clanId: string;
+  ownerUid: string;
   paymentMode: PaymentMode;
   autoRenew: boolean;
   reminderDaysBefore?: Array<number>;
   actorUid: string;
 }): Promise<BillingSettingsRecord> {
+  const scopedId = scopedBillingDocId({ clanId, ownerUid });
   const normalizedReminderDays = normalizeReminderDays(reminderDaysBefore);
-  await billingSettingsCollection.doc(clanId).set(
+  await billingSettingsCollection.doc(scopedId).set(
     {
-      id: clanId,
+      id: scopedId,
       clanId,
+      ownerUid,
       paymentMode,
       autoRenew,
       reminderDaysBefore: normalizedReminderDays,
@@ -141,15 +168,29 @@ export async function upsertBillingSettings({
     },
     { merge: true },
   );
-  return loadBillingSettings(clanId);
+  return loadBillingSettings(clanId, ownerUid);
 }
 
-export async function loadSubscription(clanId: string): Promise<BillingSubscriptionRecord | null> {
-  const snapshot = await subscriptionsCollection.doc(clanId).get();
+export async function loadSubscription({
+  clanId,
+  ownerUid,
+}: {
+  clanId: string;
+  ownerUid: string;
+}): Promise<BillingSubscriptionRecord | null> {
+  const scopedId = scopedBillingDocId({ clanId, ownerUid });
+  const [scopedSnapshot, legacySnapshot] = await Promise.all([
+    subscriptionsCollection.doc(scopedId).get(),
+    subscriptionsCollection.doc(clanId).get(),
+  ]);
+  const snapshot = scopedSnapshot.exists ? scopedSnapshot : legacySnapshot;
   if (!snapshot.exists) {
     return null;
   }
-  return mapSubscription(snapshot.id, snapshot.data() ?? {});
+  return mapSubscription(scopedId, snapshot.data() ?? {}, {
+    fallbackClanId: clanId,
+    fallbackOwnerUid: ownerUid,
+  });
 }
 
 export async function ensureSubscriptionForClan({
@@ -161,22 +202,27 @@ export async function ensureSubscriptionForClan({
   actorUid: string;
   now?: Date;
 }): Promise<EnsureSubscriptionResult> {
+  const scopedSubscriptionId = scopedBillingDocId({
+    clanId,
+    ownerUid: actorUid,
+  });
   const [memberCount, settings, existing] = await Promise.all([
     countClanMembers(clanId),
-    loadBillingSettings(clanId),
-    loadSubscription(clanId),
+    loadBillingSettings(clanId, actorUid),
+    loadSubscription({ clanId, ownerUid: actorUid }),
   ]);
   const minimumTier = resolvePlanByMemberCount(memberCount);
 
   if (existing == null) {
     const seeded = seedSubscription({
       clanId,
+      ownerUid: actorUid,
       tier: minimumTier,
       memberCount,
       settings,
       now,
     });
-    await subscriptionsCollection.doc(clanId).set(
+    await subscriptionsCollection.doc(scopedSubscriptionId).set(
       {
         ...toSubscriptionWriteMap(seeded),
         createdAt: FieldValue.serverTimestamp(),
@@ -191,7 +237,7 @@ export async function ensureSubscriptionForClan({
       actorUid,
       action: 'subscription_bootstrapped',
       entityType: 'subscription',
-      entityId: clanId,
+      entityId: scopedSubscriptionId,
       after: {
         planCode: seeded.planCode,
         status: seeded.status,
@@ -235,7 +281,7 @@ export async function ensureSubscriptionForClan({
     updatedAt: now,
   };
 
-  await subscriptionsCollection.doc(clanId).set(
+  await subscriptionsCollection.doc(scopedSubscriptionId).set(
     {
       ...toSubscriptionWriteMap(updated),
       updatedAt: FieldValue.serverTimestamp(),
@@ -289,6 +335,7 @@ export async function createPendingCheckout({
   const transaction: BillingTransactionRecord = {
     id: transactionRef.id,
     clanId,
+    subscriptionOwnerUid: actorUid,
     subscriptionId: subscription.id,
     invoiceId: invoiceRef.id,
     paymentMethod,
@@ -308,6 +355,7 @@ export async function createPendingCheckout({
   const invoice: BillingInvoiceRecord = {
     id: invoiceRef.id,
     clanId,
+    subscriptionOwnerUid: actorUid,
     subscriptionId: subscription.id,
     transactionId: transaction.id,
     planCode: tier.planCode,
@@ -338,8 +386,11 @@ export async function createPendingCheckout({
     updatedBy: actorUid,
   });
   batch.set(
-    subscriptionsCollection.doc(clanId),
+    subscriptionsCollection.doc(subscription.id),
     {
+      id: subscription.id,
+      clanId,
+      ownerUid: actorUid,
       planCode: tier.planCode,
       memberCount,
       amountVndYear: tier.priceVndYear,
@@ -451,7 +502,10 @@ export async function applyPaymentResult({
 
   const transactionData = mapTransaction(transactionId, txnSnapshot.data() ?? {});
   if (transactionData.paymentStatus === 'succeeded' && paymentStatus === 'succeeded') {
-    const subscription = await loadSubscription(transactionData.clanId);
+    const subscription = await loadSubscription({
+      clanId: transactionData.clanId,
+      ownerUid: transactionData.subscriptionOwnerUid,
+    });
     const invoice = await loadInvoice(transactionData.invoiceId);
     return {
       clanId: transactionData.clanId,
@@ -462,7 +516,7 @@ export async function applyPaymentResult({
   }
 
   const invoiceRef = invoicesCollection.doc(transactionData.invoiceId);
-  const subscriptionRef = subscriptionsCollection.doc(transactionData.clanId);
+  const subscriptionRef = subscriptionsCollection.doc(transactionData.subscriptionId);
 
   await db.runTransaction(async (tx) => {
     const [invoiceSnapshot, subscriptionSnapshot] = await Promise.all([
@@ -471,7 +525,10 @@ export async function applyPaymentResult({
     ]);
 
     const existingSubscription = subscriptionSnapshot.exists
-      ? mapSubscription(subscriptionSnapshot.id, subscriptionSnapshot.data() ?? {})
+      ? mapSubscription(subscriptionSnapshot.id, subscriptionSnapshot.data() ?? {}, {
+        fallbackClanId: transactionData.clanId,
+        fallbackOwnerUid: transactionData.subscriptionOwnerUid,
+      })
       : null;
 
     const transactionWrite: Record<string, unknown> = {
@@ -519,8 +576,9 @@ export async function applyPaymentResult({
       tx.set(
         subscriptionRef,
         {
-          id: transactionData.clanId,
+          id: transactionData.subscriptionId,
           clanId: transactionData.clanId,
+          ownerUid: transactionData.subscriptionOwnerUid,
           planCode: tier.planCode,
           status: 'active',
           memberCount: transactionData.memberCount,
@@ -578,7 +636,7 @@ export async function applyPaymentResult({
 
   const [refreshedTransaction, refreshedSubscription, refreshedInvoice] = await Promise.all([
     transactionsCollection.doc(transactionId).get(),
-    subscriptionsCollection.doc(transactionData.clanId).get(),
+    subscriptionsCollection.doc(transactionData.subscriptionId).get(),
     invoicesCollection.doc(transactionData.invoiceId).get(),
   ]);
 
@@ -589,7 +647,10 @@ export async function applyPaymentResult({
       ? mapInvoice(refreshedInvoice.id, refreshedInvoice.data() ?? {})
       : null,
     subscription: refreshedSubscription.exists
-      ? mapSubscription(refreshedSubscription.id, refreshedSubscription.data() ?? {})
+      ? mapSubscription(refreshedSubscription.id, refreshedSubscription.data() ?? {}, {
+        fallbackClanId: transactionData.clanId,
+        fallbackOwnerUid: transactionData.subscriptionOwnerUid,
+      })
       : null,
   };
 }
@@ -686,12 +747,14 @@ function normalizeStatusForPlan({
 
 function seedSubscription({
   clanId,
+  ownerUid,
   tier,
   memberCount,
   settings,
   now,
 }: {
   clanId: string;
+  ownerUid: string;
   tier: BillingTierPricing;
   memberCount: number;
   settings: BillingSettingsRecord;
@@ -700,6 +763,7 @@ function seedSubscription({
   if (tier.planCode === 'FREE') {
     return createSubscriptionDraft({
       clanId,
+      ownerUid,
       tier,
       memberCount,
       paymentMode: settings.paymentMode,
@@ -713,6 +777,7 @@ function seedSubscription({
 
   return createSubscriptionDraft({
     clanId,
+    ownerUid,
     tier,
     memberCount,
     paymentMode: settings.paymentMode,
@@ -728,6 +793,7 @@ function toSubscriptionWriteMap(record: BillingSubscriptionRecord): Record<strin
   return {
     id: record.id,
     clanId: record.clanId,
+    ownerUid: record.ownerUid,
     planCode: record.planCode,
     status: record.status,
     memberCount: record.memberCount,
@@ -750,6 +816,7 @@ function toTransactionWriteMap(record: BillingTransactionRecord): Record<string,
   return {
     id: record.id,
     clanId: record.clanId,
+    subscriptionOwnerUid: record.subscriptionOwnerUid,
     subscriptionId: record.subscriptionId,
     invoiceId: record.invoiceId,
     paymentMethod: record.paymentMethod,
@@ -770,6 +837,7 @@ function toInvoiceWriteMap(record: BillingInvoiceRecord): Record<string, unknown
   return {
     id: record.id,
     clanId: record.clanId,
+    subscriptionOwnerUid: record.subscriptionOwnerUid,
     subscriptionId: record.subscriptionId,
     transactionId: record.transactionId,
     planCode: record.planCode,
@@ -783,10 +851,18 @@ function toInvoiceWriteMap(record: BillingInvoiceRecord): Record<string, unknown
   };
 }
 
-function mapSubscription(id: string, data: Record<string, unknown>): BillingSubscriptionRecord {
+function mapSubscription(
+  id: string,
+  data: Record<string, unknown>,
+  fallback: {
+    fallbackClanId: string;
+    fallbackOwnerUid: string;
+  },
+): BillingSubscriptionRecord {
   return {
     id,
-    clanId: readString(data.clanId, ''),
+    clanId: readString(data.clanId, fallback.fallbackClanId),
+    ownerUid: readString(data.ownerUid, fallback.fallbackOwnerUid),
     planCode: normalizePlanCode(data.planCode),
     status: normalizeSubscriptionStatusCode(data.status),
     memberCount: readNumber(data.memberCount, 0),
@@ -808,6 +884,7 @@ function mapTransaction(id: string, data: Record<string, unknown>): BillingTrans
   return {
     id,
     clanId: readString(data.clanId, ''),
+    subscriptionOwnerUid: readString(data.subscriptionOwnerUid, ''),
     subscriptionId: readString(data.subscriptionId, ''),
     invoiceId: readString(data.invoiceId, ''),
     paymentMethod: normalizePaymentMethod(data.paymentMethod),
@@ -829,6 +906,7 @@ function mapInvoice(id: string, data: Record<string, unknown>): BillingInvoiceRe
   return {
     id,
     clanId: readString(data.clanId, ''),
+    subscriptionOwnerUid: readString(data.subscriptionOwnerUid, ''),
     subscriptionId: readString(data.subscriptionId, ''),
     transactionId: readString(data.transactionId, ''),
     planCode: normalizePlanCode(data.planCode),

--- a/firebase/functions/src/billing/subscription-lifecycle.ts
+++ b/firebase/functions/src/billing/subscription-lifecycle.ts
@@ -12,6 +12,7 @@ type NullableDate = Date | null;
 export type BillingSubscriptionRecord = {
   id: string;
   clanId: string;
+  ownerUid: string;
   planCode: BillingPlanCode;
   status: SubscriptionStatus;
   memberCount: number;
@@ -93,6 +94,7 @@ export function buildEntitlement({
 
 export function createSubscriptionDraft({
   clanId,
+  ownerUid,
   tier,
   memberCount,
   paymentMode,
@@ -103,6 +105,7 @@ export function createSubscriptionDraft({
   now = new Date(),
 }: {
   clanId: string;
+  ownerUid: string;
   tier: BillingTierPricing;
   memberCount: number;
   paymentMode: PaymentMode;
@@ -113,8 +116,9 @@ export function createSubscriptionDraft({
   now?: Date;
 }): BillingSubscriptionRecord {
   return {
-    id: clanId,
+    id: `${clanId}__${ownerUid}`,
     clanId,
+    ownerUid,
     planCode: tier.planCode,
     status,
     memberCount,

--- a/firebase/functions/src/billing/subscription-reminders.ts
+++ b/firebase/functions/src/billing/subscription-reminders.ts
@@ -47,6 +47,7 @@ export async function sendSubscriptionRemindersRun(
     if (clanId.length === 0) {
       continue;
     }
+    const ownerUid = normalizeString(data.ownerUid);
 
     const expiresAt = toDate(data.expiresAt);
     if (expiresAt == null) {
@@ -59,7 +60,7 @@ export async function sendSubscriptionRemindersRun(
     }
 
     const [settings, memberIds] = await Promise.all([
-      loadBillingSettings(clanId),
+      loadBillingSettings(clanId, ownerUid),
       resolveBillingAudienceMemberIds(clanId),
     ]);
 

--- a/mobile/befam/lib/features/billing/services/debug_billing_repository.dart
+++ b/mobile/befam/lib/features/billing/services/debug_billing_repository.dart
@@ -17,7 +17,7 @@ class DebugBillingRepository implements BillingRepository {
 
   final DebugGenealogyStore _genealogyStore;
 
-  static final Map<String, _DebugBillingState> _statesByClanId = {};
+  static final Map<String, _DebugBillingState> _statesByScopeId = {};
   static int _transactionSequence = 1;
   static int _invoiceSequence = 1;
   static int _auditSequence = 1;
@@ -31,7 +31,7 @@ class DebugBillingRepository implements BillingRepository {
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 120));
     final clanId = _clanIdOf(session);
-    final state = _ensureState(clanId);
+    final state = _ensureState(clanId: clanId, ownerUid: session.uid);
     _syncStateWithMemberCount(state, clanId);
     return state.toSnapshot();
   }
@@ -42,7 +42,7 @@ class DebugBillingRepository implements BillingRepository {
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 90));
     final clanId = _clanIdOf(session);
-    final state = _ensureState(clanId);
+    final state = _ensureState(clanId: clanId, ownerUid: session.uid);
     _syncStateWithMemberCount(state, clanId);
     return state.toViewerSummary();
   }
@@ -53,7 +53,7 @@ class DebugBillingRepository implements BillingRepository {
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 60));
     final clanId = _clanIdOf(session);
-    final state = _ensureState(clanId);
+    final state = _ensureState(clanId: clanId, ownerUid: session.uid);
     _syncStateWithMemberCount(state, clanId);
     return state.entitlement;
   }
@@ -67,7 +67,7 @@ class DebugBillingRepository implements BillingRepository {
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 90));
     final clanId = _clanIdOf(session);
-    final state = _ensureState(clanId);
+    final state = _ensureState(clanId: clanId, ownerUid: session.uid);
 
     final normalizedMode = paymentMode.trim().toLowerCase();
     if (normalizedMode != 'manual' && normalizedMode != 'auto_renew') {
@@ -78,7 +78,7 @@ class DebugBillingRepository implements BillingRepository {
     }
 
     state.settings = BillingSettings(
-      id: clanId,
+      id: '${clanId}__${session.uid}',
       clanId: clanId,
       paymentMode: normalizedMode,
       autoRenew: autoRenew,
@@ -115,7 +115,7 @@ class DebugBillingRepository implements BillingRepository {
       clanId: clanId,
       action: 'billing_preferences_updated',
       entityType: 'billingSettings',
-      entityId: clanId,
+      entityId: state.settings.id,
       actorUid: session.uid,
     );
 
@@ -131,7 +131,7 @@ class DebugBillingRepository implements BillingRepository {
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 140));
     final clanId = _clanIdOf(session);
-    final state = _ensureState(clanId);
+    final state = _ensureState(clanId: clanId, ownerUid: session.uid);
     _syncStateWithMemberCount(state, clanId);
 
     final method = paymentMethod.trim().toLowerCase();
@@ -144,7 +144,8 @@ class DebugBillingRepository implements BillingRepository {
 
     final minimumTier = _resolveTier(state.memberCount);
     final currentTier = _resolveTierByPlanCode(state.subscription.planCode);
-    final defaultTier = _rankPlanCode(currentTier.planCode) >=
+    final defaultTier =
+        _rankPlanCode(currentTier.planCode) >=
             _rankPlanCode(minimumTier.planCode)
         ? currentTier
         : minimumTier;
@@ -168,7 +169,7 @@ class DebugBillingRepository implements BillingRepository {
     final transaction = BillingPaymentTransaction(
       id: transactionId,
       clanId: clanId,
-      subscriptionId: clanId,
+      subscriptionId: state.subscription.id,
       invoiceId: invoiceId,
       paymentMethod: method,
       paymentStatus: tier.planCode == 'FREE' ? 'succeeded' : 'pending',
@@ -188,7 +189,7 @@ class DebugBillingRepository implements BillingRepository {
     final invoice = BillingInvoice(
       id: invoiceId,
       clanId: clanId,
-      subscriptionId: clanId,
+      subscriptionId: state.subscription.id,
       transactionId: transactionId,
       planCode: tier.planCode,
       amountVnd: tier.priceVndYear,
@@ -237,7 +238,11 @@ class DebugBillingRepository implements BillingRepository {
     );
 
     if (tier.planCode == 'FREE') {
-      _applySuccessfulPayment(state, transactionId: transactionId, actorUid: session.uid);
+      _applySuccessfulPayment(
+        state,
+        transactionId: transactionId,
+        actorUid: session.uid,
+      );
     }
 
     final checkoutUrl = method == 'vnpay'
@@ -266,7 +271,7 @@ class DebugBillingRepository implements BillingRepository {
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 130));
     final clanId = _clanIdOf(session);
-    final state = _ensureState(clanId);
+    final state = _ensureState(clanId: clanId, ownerUid: session.uid);
     final transaction = _findTransaction(state, transactionId);
     if (transaction.paymentMethod != 'card') {
       throw const BillingRepositoryException(
@@ -288,7 +293,7 @@ class DebugBillingRepository implements BillingRepository {
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 130));
     final clanId = _clanIdOf(session);
-    final state = _ensureState(clanId);
+    final state = _ensureState(clanId: clanId, ownerUid: session.uid);
     final transaction = _findTransaction(state, transactionId);
     if (transaction.paymentMethod != 'vnpay') {
       throw const BillingRepositoryException(
@@ -303,13 +308,17 @@ class DebugBillingRepository implements BillingRepository {
     );
   }
 
-  _DebugBillingState _ensureState(String clanId) {
-    return _statesByClanId.putIfAbsent(clanId, () {
+  _DebugBillingState _ensureState({
+    required String clanId,
+    required String ownerUid,
+  }) {
+    final scopeId = '${clanId}__$ownerUid';
+    return _statesByScopeId.putIfAbsent(scopeId, () {
       final memberCount = _memberCountForClan(clanId);
       final tier = _resolveTier(memberCount);
       final now = DateTime.now().toUtc();
       final subscription = BillingSubscription(
-        id: clanId,
+        id: scopeId,
         clanId: clanId,
         planCode: tier.planCode,
         status: tier.planCode == 'FREE' ? 'active' : 'expired',
@@ -320,14 +329,16 @@ class DebugBillingRepository implements BillingRepository {
         autoRenew: false,
         startsAtIso: tier.planCode == 'FREE' ? now.toIso8601String() : null,
         expiresAtIso: tier.planCode == 'FREE' ? null : now.toIso8601String(),
-        nextPaymentDueAtIso: tier.planCode == 'FREE' ? null : now.toIso8601String(),
+        nextPaymentDueAtIso: tier.planCode == 'FREE'
+            ? null
+            : now.toIso8601String(),
         graceEndsAtIso: null,
         lastPaymentMethod: null,
         lastTransactionId: null,
         updatedAtIso: now.toIso8601String(),
       );
       final settings = BillingSettings(
-        id: clanId,
+        id: scopeId,
         clanId: clanId,
         paymentMode: 'manual',
         autoRenew: false,
@@ -335,6 +346,7 @@ class DebugBillingRepository implements BillingRepository {
         updatedAtIso: now.toIso8601String(),
       );
       return _DebugBillingState(
+        ownerUid: ownerUid,
         clanId: clanId,
         memberCount: memberCount,
         subscription: subscription,
@@ -359,7 +371,8 @@ class DebugBillingRepository implements BillingRepository {
     }
     final minimumTier = _resolveTier(memberCount);
     final currentTier = _resolveTierByPlanCode(state.subscription.planCode);
-    final tier = _rankPlanCode(currentTier.planCode) >=
+    final tier =
+        _rankPlanCode(currentTier.planCode) >=
             _rankPlanCode(minimumTier.planCode)
         ? currentTier
         : minimumTier;
@@ -418,7 +431,9 @@ class DebugBillingRepository implements BillingRepository {
   }) {
     final now = DateTime.now().toUtc();
     final transaction = _findTransaction(state, transactionId);
-    final txIndex = state.transactions.indexWhere((item) => item.id == transactionId);
+    final txIndex = state.transactions.indexWhere(
+      (item) => item.id == transactionId,
+    );
     final paidTransaction = BillingPaymentTransaction(
       id: transaction.id,
       clanId: transaction.clanId,
@@ -438,7 +453,9 @@ class DebugBillingRepository implements BillingRepository {
     );
     state.transactions[txIndex] = paidTransaction;
 
-    final invoiceIndex = state.invoices.indexWhere((item) => item.id == transaction.invoiceId);
+    final invoiceIndex = state.invoices.indexWhere(
+      (item) => item.id == transaction.invoiceId,
+    );
     if (invoiceIndex >= 0) {
       final invoice = state.invoices[invoiceIndex];
       state.invoices[invoiceIndex] = BillingInvoice(
@@ -459,7 +476,14 @@ class DebugBillingRepository implements BillingRepository {
     }
 
     final startsAt = now;
-    final expiresAt = DateTime.utc(now.year + 1, now.month, now.day, now.hour, now.minute, now.second);
+    final expiresAt = DateTime.utc(
+      now.year + 1,
+      now.month,
+      now.day,
+      now.hour,
+      now.minute,
+      now.second,
+    );
     state.subscription = BillingSubscription(
       id: state.subscription.id,
       clanId: state.subscription.clanId,
@@ -518,7 +542,9 @@ class DebugBillingRepository implements BillingRepository {
   }
 
   int _memberCountForClan(String clanId) {
-    return _genealogyStore.members.values.where((member) => member.clanId == clanId).length;
+    return _genealogyStore.members.values
+        .where((member) => member.clanId == clanId)
+        .length;
   }
 
   _PricingTier _resolveTier(int memberCount) {
@@ -644,6 +670,7 @@ class DebugBillingRepository implements BillingRepository {
 
 class _DebugBillingState {
   _DebugBillingState({
+    required this.ownerUid,
     required this.clanId,
     required this.memberCount,
     required this.subscription,
@@ -654,6 +681,7 @@ class _DebugBillingState {
     required this.auditLogs,
   });
 
+  final String ownerUid;
   final String clanId;
   int memberCount;
   BillingSubscription subscription;


### PR DESCRIPTION
## Summary
- scope subscription and billing records by user using clanId__ownerUid instead of clan-only IDs
- ensure checkout/payment callbacks enforce ownership (subscriptionOwnerUid) and clan match
- update reminder/settings loading and debug billing repository to align with per-user subscription scope

## Validation
- npm test (firebase/functions)
- flutter test test/features/billing test/app/home/app_shell_billing_tab_test.dart