### PR TITLE
feat(billing): VNPay checkout hardening and timeout-safe subscription flow

### DIFF
--- a/firebase/functions/src/billing/callables.ts
+++ b/firebase/functions/src/billing/callables.ts
@@ -8,6 +8,7 @@ import {
   countClanMembers,
   buildEntitlementFromSubscription,
   createPendingCheckout,
+  expireStalePendingTransactions,
   ensureSubscriptionForClan,
   resolveBillingAudienceMemberIds,
   upsertBillingSettings,
@@ -16,6 +17,7 @@ import {
 import {
   BILLING_PRICING_TIERS,
   rankPlanCode,
+  resolveEffectivePlanCode,
   resolvePlanByMemberCount,
   type BillingPlanCode,
   type PaymentMethod,
@@ -31,6 +33,14 @@ import {
   tokenClanIds,
   type AuthToken,
 } from '../shared/permissions';
+import {
+  buildVnpayQueryString,
+  createVnpaySignature,
+  formatVnpayTimestampGmt7,
+  normalizeVnpayIpAddress,
+  normalizeVnpayLocale,
+  normalizeVnpayOrderInfo,
+} from './vnpay';
 
 const subscriptionsCollection = db.collection('subscriptions');
 const transactionsCollection = db.collection('paymentTransactions');
@@ -52,10 +62,22 @@ export const resolveBillingEntitlement = onCall(
     }
     ensureClanAccess(auth.token, clanId);
 
-    const ensured = await ensureSubscriptionForClan({
+    let ensured = await ensureSubscriptionForClan({
       clanId,
       actorUid: auth.uid,
     });
+    const staleSweep = await expireStalePendingTransactions({ clanId });
+    if (staleSweep.expiredCount > 0) {
+      ensured = await ensureSubscriptionForClan({
+        clanId,
+        actorUid: auth.uid,
+      });
+      logInfo('resolveBillingEntitlement refreshed after timeout sweep', {
+        uid: auth.uid,
+        clanId,
+        timedOutTransactions: staleSweep.transactionIds,
+      });
+    }
     const entitlement = buildEntitlementFromSubscription(ensured.subscription);
 
     return {
@@ -80,10 +102,22 @@ export const loadBillingWorkspace = onCall(
     }
     ensureClanAccess(auth.token, clanId);
 
-    const ensured = await ensureSubscriptionForClan({
+    const staleSweep = await expireStalePendingTransactions({ clanId });
+    let ensured = await ensureSubscriptionForClan({
       clanId,
       actorUid: auth.uid,
     });
+    if (staleSweep.expiredCount > 0) {
+      ensured = await ensureSubscriptionForClan({
+        clanId,
+        actorUid: auth.uid,
+      });
+      logInfo('loadBillingWorkspace refreshed after timeout sweep', {
+        uid: auth.uid,
+        clanId,
+        timedOutTransactions: staleSweep.transactionIds,
+      });
+    }
     const [transactionsSnapshot, invoicesSnapshot, auditSnapshot] = await Promise.all([
       transactionsCollection
         .where('clanId', '==', clanId)
@@ -187,6 +221,11 @@ export const createSubscriptionCheckout = onCall(
     }
     ensureClanAccess(auth.token, clanId);
 
+    await expireStalePendingTransactions({ clanId });
+    const ensured = await ensureSubscriptionForClan({
+      clanId,
+      actorUid: auth.uid,
+    });
     const paymentMethod = normalizePaymentMethod(request.data);
     const requestedPlanCode = normalizeRequestedPlanCode(request.data);
     if (requestedPlanCode != null) {
@@ -199,6 +238,23 @@ export const createSubscriptionCheckout = onCall(
         );
       }
     }
+    const effectivePlanCode = resolveEffectivePlanCode({
+      memberCount: ensured.memberCount,
+      currentPlanCode: ensured.subscription.planCode,
+      requestedPlanCode,
+    });
+    const currentPlanRank = rankPlanCode(ensured.subscription.planCode);
+    const nextPlanRank = rankPlanCode(effectivePlanCode);
+    const isActiveOrGrace =
+      ensured.entitlement.status === 'active' ||
+      ensured.entitlement.status === 'grace_period';
+    if (isActiveOrGrace && currentPlanRank > 0 && nextPlanRank <= currentPlanRank) {
+      throw new HttpsError(
+        'failed-precondition',
+        'Current subscription is still valid. Only higher-tier upgrades are allowed.',
+      );
+    }
+
     const checkout = await createPendingCheckout({
       clanId,
       actorUid: auth.uid,
@@ -212,14 +268,22 @@ export const createSubscriptionCheckout = onCall(
       checkoutUrl = '';
       requiresManualConfirmation = false;
     } else if (paymentMethod === 'vnpay') {
+      const locale = normalizeVnpayLocale(
+        readString(request.data, 'locale') ?? process.env.VNPAY_LOCALE ?? 'vn',
+      );
+      const orderInfo = buildVnpayOrderInfo({
+        planCode: checkout.tier.planCode,
+        memberCount: checkout.memberCount,
+        note: readString(request.data, 'orderNote'),
+      });
       checkoutUrl = buildVnpayCheckoutUrl({
         transactionId: checkout.transaction.id,
         amountVnd: checkout.transaction.amountVnd,
-        orderInfo: `BeFam ${checkout.tier.planCode} annual subscription`,
-        returnUrl:
-          readString(request.data, 'returnUrl') ??
-          process.env.VNPAY_RETURN_URL ??
-          'https://example.com/billing/vnpay-return',
+        orderInfo,
+        returnUrl: resolveVnpayReturnUrl(readString(request.data, 'returnUrl')),
+        clientIp: resolveVnpayClientIpAddress(request.rawRequest),
+        locale,
+        bankCode: normalizeVnpayBankCode(readString(request.data, 'bankCode')),
       });
     } else {
       checkoutUrl = buildCardCheckoutHintUrl({
@@ -459,6 +523,41 @@ function normalizeRequestedPlanCode(data: unknown): BillingPlanCode | null {
   );
 }
 
+function normalizeVnpayBankCode(rawValue: string | null): string | null {
+  if (rawValue == null) {
+    return null;
+  }
+  const normalized = rawValue.trim().toUpperCase();
+  if (normalized.length === 0) {
+    return null;
+  }
+  if (!/^[A-Z0-9_]{2,32}$/.test(normalized)) {
+    throw new HttpsError(
+      'invalid-argument',
+      'bankCode must match VNPay bank code format.',
+    );
+  }
+  return normalized;
+}
+
+function buildVnpayOrderInfo({
+  planCode,
+  memberCount,
+  note,
+}: {
+  planCode: BillingPlanCode;
+  memberCount: number;
+  note: string | null;
+}): string {
+  const base = `BeFam ${planCode} ${memberCount} members annual`;
+  if (note == null || note.trim().length === 0) {
+    return base;
+  }
+  const trimmedNote = note.trim().replaceAll(/\s+/g, ' ');
+  const limited = trimmedNote.slice(0, 120);
+  return `${base} - ${limited}`;
+}
+
 function readReminderDays(data: unknown): Array<number> | undefined {
   if (data == null || typeof data !== 'object') {
     return undefined;
@@ -551,25 +650,41 @@ function buildVnpayCheckoutUrl({
   amountVnd,
   orderInfo,
   returnUrl,
+  clientIp,
+  locale,
+  bankCode,
 }: {
   transactionId: string;
   amountVnd: number;
   orderInfo: string;
   returnUrl: string;
+  clientIp: string;
+  locale: 'vn' | 'en';
+  bankCode: string | null;
 }): string {
   const tmnCode = process.env.VNPAY_TMNCODE?.trim() ?? '';
   const hashSecret = process.env.VNPAY_HASH_SECRET?.trim() ?? '';
   if (tmnCode.length === 0 || hashSecret.length === 0) {
-    const fallback = new URL(
-      process.env.BILLING_VNPAY_FALLBACK_URL ?? 'https://example.com/billing/vnpay',
+    const fallbackBase = process.env.BILLING_VNPAY_FALLBACK_URL?.trim();
+    if (fallbackBase != null && fallbackBase.length > 0) {
+      const fallback = new URL(fallbackBase);
+      fallback.searchParams.set('transactionId', transactionId);
+      fallback.searchParams.set('amountVnd', `${amountVnd}`);
+      return fallback.toString();
+    }
+    throw new HttpsError(
+      'failed-precondition',
+      'VNPay sandbox is not configured. Set VNPAY_TMNCODE and VNPAY_HASH_SECRET.',
     );
-    fallback.searchParams.set('transactionId', transactionId);
-    fallback.searchParams.set('amountVnd', `${amountVnd}`);
-    return fallback.toString();
   }
 
   const now = new Date();
-  const createDate = formatVnpTimestamp(now);
+  const createDate = formatVnpayTimestampGmt7(now);
+  const expireDate = formatVnpayTimestampGmt7(
+    new Date(now.getTime() + parsePositiveInteger(process.env.VNPAY_EXPIRE_MINUTES, 15) * 60_000),
+  );
+  const gatewayBase =
+    process.env.VNPAY_PAYMENT_URL?.trim() ?? 'https://sandbox.vnpayment.vn/paymentv2/vpcpay.html';
   const params: Record<string, string> = {
     vnp_Version: '2.1.0',
     vnp_Command: 'pay',
@@ -577,30 +692,96 @@ function buildVnpayCheckoutUrl({
     vnp_Amount: `${Math.max(0, Math.trunc(amountVnd)) * 100}`,
     vnp_CurrCode: 'VND',
     vnp_TxnRef: transactionId,
-    vnp_OrderInfo: orderInfo,
-    vnp_OrderType: 'billpayment',
-    vnp_Locale: 'vn',
+    vnp_OrderInfo: normalizeVnpayOrderInfo(orderInfo),
+    vnp_OrderType: process.env.VNPAY_ORDER_TYPE?.trim() || 'other',
+    vnp_Locale: locale,
     vnp_ReturnUrl: returnUrl,
-    vnp_IpAddr: '127.0.0.1',
+    vnp_IpAddr: clientIp,
     vnp_CreateDate: createDate,
+    vnp_ExpireDate: expireDate,
+    ...(bankCode == null ? {} : { vnp_BankCode: bankCode }),
   };
 
-  const queryString = Object.keys(params)
-    .sort()
-    .map((key) => `${key}=${encodeURIComponent(params[key])}`)
-    .join('&');
-  const secureHash = createHmac('sha512', hashSecret).update(queryString).digest('hex');
-  return `https://sandbox.vnpayment.vn/paymentv2/vpcpay.html?${queryString}&vnp_SecureHash=${secureHash}`;
+  const queryString = buildVnpayQueryString(params);
+  const secureHash = createVnpaySignature(params, hashSecret);
+  const separator = gatewayBase.includes('?') ? '&' : '?';
+  return `${gatewayBase}${separator}${queryString}&vnp_SecureHash=${secureHash}`;
 }
 
-function formatVnpTimestamp(value: Date): string {
-  const year = value.getUTCFullYear();
-  const month = `${value.getUTCMonth() + 1}`.padStart(2, '0');
-  const day = `${value.getUTCDate()}`.padStart(2, '0');
-  const hour = `${value.getUTCHours()}`.padStart(2, '0');
-  const minute = `${value.getUTCMinutes()}`.padStart(2, '0');
-  const second = `${value.getUTCSeconds()}`.padStart(2, '0');
-  return `${year}${month}${day}${hour}${minute}${second}`;
+function resolveVnpayReturnUrl(explicitUrl: string | null): string {
+  const candidate =
+    explicitUrl?.trim() ||
+    process.env.VNPAY_RETURN_URL?.trim() ||
+    resolveDefaultVnpayReturnUrl();
+  if (candidate.length === 0) {
+    throw new HttpsError(
+      'failed-precondition',
+      'VNPAY_RETURN_URL is not configured and no default callback URL can be derived.',
+    );
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    throw new HttpsError('invalid-argument', 'returnUrl must be a valid absolute URL.');
+  }
+
+  const isLocalhost =
+    parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1';
+  if (!isLocalhost && parsed.protocol !== 'https:') {
+    throw new HttpsError('invalid-argument', 'returnUrl must use HTTPS for VNPay.');
+  }
+
+  parsed.search = '';
+  parsed.hash = '';
+  return parsed.toString();
+}
+
+function resolveDefaultVnpayReturnUrl(): string {
+  const projectId = (process.env.GCLOUD_PROJECT ?? process.env.GCP_PROJECT ?? '').trim();
+  if (projectId.length === 0) {
+    return '';
+  }
+  return `https://${APP_REGION}-${projectId}.cloudfunctions.net/vnpayPaymentCallback`;
+}
+
+function resolveVnpayClientIpAddress(rawRequest: unknown): string {
+  if (rawRequest == null || typeof rawRequest !== 'object') {
+    return '127.0.0.1';
+  }
+
+  const request = rawRequest as {
+    ip?: unknown;
+    headers?: Record<string, unknown>;
+    socket?: { remoteAddress?: unknown };
+  };
+  const forwarded = readHeaderValue(request.headers?.['x-forwarded-for']);
+  const directIp = normalizeUnknownString(request.ip);
+  const remoteAddress = normalizeUnknownString(request.socket?.remoteAddress);
+  return normalizeVnpayIpAddress(forwarded || directIp || remoteAddress || '127.0.0.1');
+}
+
+function readHeaderValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
+    return value[0].trim();
+  }
+  return '';
+}
+
+function normalizeUnknownString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function parsePositiveInteger(rawValue: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(rawValue ?? '', 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
 }
 
 function formatVnd(amount: number): string {

--- a/firebase/functions/src/billing/store.ts
+++ b/firebase/functions/src/billing/store.ts
@@ -391,11 +391,12 @@ export async function createPendingCheckout({
       id: subscription.id,
       clanId,
       ownerUid: actorUid,
-      planCode: tier.planCode,
+      planCode: tier.planCode === 'FREE' ? tier.planCode : subscription.planCode,
       memberCount,
-      amountVndYear: tier.priceVndYear,
-      vatIncluded: tier.vatIncluded,
-      status: tier.planCode === 'FREE' ? 'active' : 'pending_payment',
+      amountVndYear:
+        tier.planCode === 'FREE' ? tier.priceVndYear : subscription.amountVndYear,
+      vatIncluded: tier.planCode === 'FREE' ? tier.vatIncluded : subscription.vatIncluded,
+      status: tier.planCode === 'FREE' ? 'active' : subscription.status,
       lastTransactionId: transaction.id,
       lastInvoiceId: invoice.id,
       lastPaymentMethod: paymentMethod,
@@ -422,17 +423,123 @@ export async function createPendingCheckout({
 
   const checkoutSubscription: BillingSubscriptionRecord = {
     ...subscription,
-    planCode: tier.planCode,
+    planCode: tier.planCode === 'FREE' ? tier.planCode : subscription.planCode,
     memberCount,
-    amountVndYear: tier.priceVndYear,
-    vatIncluded: tier.vatIncluded,
-    status: tier.planCode === 'FREE' ? 'active' : 'pending_payment',
+    amountVndYear:
+      tier.planCode === 'FREE' ? tier.priceVndYear : subscription.amountVndYear,
+    vatIncluded: tier.planCode === 'FREE' ? tier.vatIncluded : subscription.vatIncluded,
+    status: tier.planCode === 'FREE' ? 'active' : subscription.status,
     lastPaymentMethod: paymentMethod,
     lastTransactionId: transaction.id,
     updatedAt: now,
   };
 
   return { tier, memberCount, subscription: checkoutSubscription, transaction, invoice };
+}
+
+export async function expireStalePendingTransactions({
+  clanId,
+  actorUid = 'system:billing_timeout',
+  now = new Date(),
+  timeoutMinutes,
+  scanLimit,
+}: {
+  clanId: string;
+  actorUid?: string;
+  now?: Date;
+  timeoutMinutes?: number;
+  scanLimit?: number;
+}): Promise<{
+  timeoutMinutes: number;
+  expiredCount: number;
+  transactionIds: Array<string>;
+}> {
+  const resolvedTimeoutMinutes = Math.max(
+    5,
+    Math.trunc(timeoutMinutes ?? readNumber(process.env.BILLING_PENDING_TIMEOUT_MINUTES, 45)),
+  );
+  const resolvedScanLimit = Math.max(
+    20,
+    Math.min(200, Math.trunc(scanLimit ?? readNumber(process.env.BILLING_PENDING_SCAN_LIMIT, 100))),
+  );
+  const cutoffTimeMs = now.getTime() - resolvedTimeoutMinutes * 60_000;
+
+  const snapshot = await transactionsCollection
+    .where('clanId', '==', clanId)
+    .orderBy('createdAt', 'desc')
+    .limit(resolvedScanLimit)
+    .get();
+  const staleTransactions = snapshot.docs
+    .map((doc) => mapTransaction(doc.id, doc.data() ?? {}))
+    .filter((transaction) => {
+      const status = transaction.paymentStatus.trim().toLowerCase();
+      if (status !== 'pending' && status !== 'created') {
+        return false;
+      }
+      if (transaction.createdAt == null) {
+        return false;
+      }
+      return transaction.createdAt.getTime() <= cutoffTimeMs;
+    });
+
+  if (staleTransactions.length === 0) {
+    return {
+      timeoutMinutes: resolvedTimeoutMinutes,
+      expiredCount: 0,
+      transactionIds: [],
+    };
+  }
+
+  const transactionIds: Array<string> = [];
+  for (const transaction of staleTransactions) {
+    try {
+      await applyPaymentResult({
+        transactionId: transaction.id,
+        provider: 'system_timeout',
+        gatewayReference: transaction.gatewayReference ?? `TIMEOUT-${transaction.id.slice(0, 10)}`,
+        paymentStatus: 'canceled',
+        payloadHash: `timeout:${clanId}:${transaction.id}:${Math.trunc(now.getTime() / 60_000)}`,
+        actorUid,
+        now,
+      });
+      transactionIds.push(transaction.id);
+      await writeBillingAuditLog({
+        clanId,
+        actorUid,
+        action: 'payment_timeout_marked',
+        entityType: 'paymentTransaction',
+        entityId: transaction.id,
+        before: {
+          status: transaction.paymentStatus,
+          createdAt: transaction.createdAt?.toISOString() ?? null,
+        },
+        after: {
+          status: 'canceled',
+          timeoutMinutes: resolvedTimeoutMinutes,
+        },
+      });
+    } catch (error) {
+      logWarn('failed to expire stale billing transaction', {
+        clanId,
+        transactionId: transaction.id,
+        error: `${error}`,
+      });
+    }
+  }
+
+  if (transactionIds.length > 0) {
+    logInfo('expired stale pending billing transactions', {
+      clanId,
+      timeoutMinutes: resolvedTimeoutMinutes,
+      transactionIds,
+    });
+  }
+
+  return {
+    timeoutMinutes: resolvedTimeoutMinutes,
+    expiredCount: transactionIds.length,
+    transactionIds,
+  };
 }
 
 export async function recordPaymentWebhookEvent({
@@ -551,7 +658,12 @@ export async function applyPaymentResult({
       tx.set(
         invoiceRef,
         {
-          status: paymentStatus === 'succeeded' ? 'paid' : 'failed',
+          status:
+            paymentStatus === 'succeeded'
+              ? 'paid'
+              : paymentStatus === 'canceled'
+              ? 'void'
+              : 'failed',
           paidAt: paymentStatus === 'succeeded' ? FieldValue.serverTimestamp() : null,
           updatedAt: FieldValue.serverTimestamp(),
           updatedBy: actorUid,
@@ -561,7 +673,7 @@ export async function applyPaymentResult({
     }
 
     if (paymentStatus === 'succeeded') {
-      const tier = resolvePlanByMemberCount(transactionData.memberCount);
+      const tier = resolveTierByPlanCode(transactionData.planCode);
       const anchorStart = existingSubscription?.expiresAt != null &&
           existingSubscription.expiresAt.getTime() > now.getTime()
         ? existingSubscription.expiresAt
@@ -603,10 +715,14 @@ export async function applyPaymentResult({
         { merge: true },
       );
     } else {
+      const nextStatus = resolveStatusAfterUnsuccessfulPayment({
+        subscription: existingSubscription,
+        now,
+      });
       tx.set(
         subscriptionRef,
         {
-          status: 'expired',
+          status: nextStatus,
           updatedAt: FieldValue.serverTimestamp(),
           updatedBy: actorUid,
         },
@@ -619,7 +735,12 @@ export async function applyPaymentResult({
       id: auditRef.id,
       clanId: transactionData.clanId,
       actorUid,
-      action: paymentStatus === 'succeeded' ? 'payment_succeeded' : 'payment_failed',
+      action:
+        paymentStatus === 'succeeded'
+          ? 'payment_succeeded'
+          : paymentStatus === 'canceled'
+          ? 'payment_canceled'
+          : 'payment_failed',
       entityType: 'paymentTransaction',
       entityId: transactionData.id,
       before: {
@@ -741,6 +862,28 @@ function normalizeStatusForPlan({
   }
   if (currentStatus === 'pending_payment') {
     return currentStatus;
+  }
+  return 'expired';
+}
+
+function resolveStatusAfterUnsuccessfulPayment({
+  subscription,
+  now,
+}: {
+  subscription: BillingSubscriptionRecord | null;
+  now: Date;
+}): SubscriptionStatus {
+  if (subscription == null) {
+    return 'expired';
+  }
+  const normalizedStatus = normalizeSubscriptionStatus({
+    status: subscription.status,
+    expiresAt: subscription.expiresAt,
+    graceEndsAt: subscription.graceEndsAt,
+    now,
+  });
+  if (normalizedStatus === 'active' || normalizedStatus === 'grace_period') {
+    return normalizedStatus;
   }
   return 'expired';
 }

--- a/firebase/functions/src/billing/vnpay.ts
+++ b/firebase/functions/src/billing/vnpay.ts
@@ -1,0 +1,138 @@
+import { createHmac } from 'node:crypto';
+
+type VnpayHashMode = 'encoded' | 'raw';
+
+const HASH_EXCLUDED_KEYS = new Set(['vnp_securehash', 'vnp_securehashtype']);
+const GMT_PLUS_7_OFFSET_MILLIS = 7 * 60 * 60 * 1000;
+
+export function buildVnpayQueryString(params: Record<string, string>): string {
+  return buildVnpayHashData(params, { mode: 'encoded' });
+}
+
+export function buildVnpayHashData(
+  params: Record<string, string>,
+  options?: {
+    mode?: VnpayHashMode;
+  },
+): string {
+  const mode = options?.mode ?? 'encoded';
+  return canonicalEntries(params)
+    .map(([key, value]) => {
+      if (mode === 'raw') {
+        return `${key}=${value}`;
+      }
+      return `${encodeVnpayComponent(key)}=${encodeVnpayComponent(value)}`;
+    })
+    .join('&');
+}
+
+export function createVnpaySignature(
+  params: Record<string, string>,
+  hashSecret: string,
+  mode: VnpayHashMode = 'encoded',
+): string {
+  const hashData = buildVnpayHashData(params, { mode });
+  return createHmac('sha512', hashSecret).update(hashData).digest('hex');
+}
+
+export function validateVnpaySignature(
+  params: Record<string, string>,
+  hashSecret: string,
+): boolean {
+  const secureHash = normalizeHash(params.vnp_SecureHash);
+  if (secureHash.length === 0 || hashSecret.trim().length === 0) {
+    return false;
+  }
+
+  const encodedExpected = normalizeHash(createVnpaySignature(params, hashSecret, 'encoded'));
+  if (safeEqual(encodedExpected, secureHash)) {
+    return true;
+  }
+
+  // Keep backward compatibility with older integrations that hash raw values.
+  const rawExpected = normalizeHash(createVnpaySignature(params, hashSecret, 'raw'));
+  return safeEqual(rawExpected, secureHash);
+}
+
+export function formatVnpayTimestampGmt7(value: Date): string {
+  const shifted = new Date(value.getTime() + GMT_PLUS_7_OFFSET_MILLIS);
+  const year = shifted.getUTCFullYear();
+  const month = `${shifted.getUTCMonth() + 1}`.padStart(2, '0');
+  const day = `${shifted.getUTCDate()}`.padStart(2, '0');
+  const hour = `${shifted.getUTCHours()}`.padStart(2, '0');
+  const minute = `${shifted.getUTCMinutes()}`.padStart(2, '0');
+  const second = `${shifted.getUTCSeconds()}`.padStart(2, '0');
+  return `${year}${month}${day}${hour}${minute}${second}`;
+}
+
+export function normalizeVnpayLocale(rawValue: string | null | undefined): 'vn' | 'en' {
+  return rawValue?.trim().toLowerCase() === 'en' ? 'en' : 'vn';
+}
+
+export function normalizeVnpayOrderInfo(rawValue: string): string {
+  const normalized = rawValue
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^A-Za-z0-9 .,:_/-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (normalized.length === 0) {
+    return 'BeFam subscription payment';
+  }
+  return normalized.slice(0, 255);
+}
+
+export function normalizeVnpayIpAddress(rawValue: string | null | undefined): string {
+  let value = (rawValue ?? '').trim();
+  if (value.length === 0) {
+    return '127.0.0.1';
+  }
+
+  if (value.includes(',')) {
+    value = value.split(',')[0]?.trim() ?? '';
+  }
+  if (value.startsWith('::ffff:')) {
+    value = value.slice(7);
+  }
+  if (value === '::1') {
+    return '127.0.0.1';
+  }
+
+  const ipv4WithPortMatch = value.match(/^(\d{1,3}(?:\.\d{1,3}){3}):\d{1,5}$/);
+  if (ipv4WithPortMatch != null) {
+    value = ipv4WithPortMatch[1];
+  }
+
+  if (value.length === 0) {
+    return '127.0.0.1';
+  }
+  return value;
+}
+
+function canonicalEntries(params: Record<string, string>): Array<[string, string]> {
+  return Object.entries(params)
+    .filter(([key]) => !HASH_EXCLUDED_KEYS.has(key.trim().toLowerCase()))
+    .map(([key, value]) => [key.trim(), value.trim()] as [string, string])
+    .filter(([key]) => key.length > 0)
+    .sort(([left], [right]) => left.localeCompare(right));
+}
+
+function encodeVnpayComponent(value: string): string {
+  return encodeURIComponent(value).replace(/%20/g, '+');
+}
+
+function normalizeHash(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+function safeEqual(left: string, right: string): boolean {
+  if (left.length === 0 || right.length === 0 || left.length !== right.length) {
+    return false;
+  }
+
+  let mismatch = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    mismatch |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return mismatch === 0;
+}

--- a/firebase/functions/src/billing/webhooks.ts
+++ b/firebase/functions/src/billing/webhooks.ts
@@ -1,5 +1,6 @@
 import { createHash, createHmac } from 'node:crypto';
 
+import type { Response } from 'express';
 import { onRequest } from 'firebase-functions/v2/https';
 
 import { APP_REGION } from '../config/runtime';
@@ -9,7 +10,11 @@ import {
   resolveBillingAudienceMemberIds,
 } from './store';
 import { notifyMembers } from '../notifications/push-delivery';
+import { db } from '../shared/firestore';
 import { logError, logInfo, logWarn } from '../shared/logger';
+import { validateVnpaySignature } from './vnpay';
+
+const transactionsCollection = db.collection('paymentTransactions');
 
 export const vnpayPaymentCallback = onRequest(
   { region: APP_REGION },
@@ -22,7 +27,10 @@ export const vnpayPaymentCallback = onRequest(
     const params = normalizeQueryParams(request.query);
     const transactionId = params.vnp_TxnRef ?? '';
     if (transactionId.length === 0) {
-      response.status(400).json({ ok: false, message: 'vnp_TxnRef is required' });
+      respondVnpay(response, {
+        rspCode: '01',
+        message: 'Order not found',
+      });
       return;
     }
 
@@ -37,11 +45,12 @@ export const vnpayPaymentCallback = onRequest(
       transactionId,
       payloadHash,
       validSignature: signatureValid,
-      rawPayload: params,
+      rawPayload: sanitizeVnpayPayload(params),
     });
     if (webhookEvent.alreadyProcessed) {
-      response.status(200).json({
-        ok: true,
+      respondVnpay(response, {
+        rspCode: '02',
+        message: 'Order already confirmed',
         idempotent: true,
         transactionId,
       });
@@ -53,16 +62,52 @@ export const vnpayPaymentCallback = onRequest(
         transactionId,
         externalEventId,
       });
-      response.status(401).json({
-        ok: false,
-        message: 'Invalid VNPay signature',
+      respondVnpay(response, {
+        rspCode: '97',
+        message: 'Invalid Checksum',
+      });
+      return;
+    }
+
+    const transactionSnapshot = await transactionsCollection.doc(transactionId).get();
+    if (!transactionSnapshot.exists) {
+      respondVnpay(response, {
+        rspCode: '01',
+        message: 'Order not found',
+      });
+      return;
+    }
+    const transactionData = transactionSnapshot.data() ?? {};
+    const currentPaymentStatus = normalizeString(transactionData.paymentStatus);
+    if (currentPaymentStatus === 'succeeded') {
+      respondVnpay(response, {
+        rspCode: '02',
+        message: 'Order already confirmed',
+      });
+      return;
+    }
+
+    const callbackAmount = parseInteger(params.vnp_Amount);
+    const expectedAmount = Math.max(0, Math.trunc(readNumber(transactionData.amountVnd) * 100));
+    if (callbackAmount == null || expectedAmount !== callbackAmount) {
+      logWarn('vnpay callback amount mismatch', {
+        transactionId,
+        callbackAmount,
+        expectedAmount,
+      });
+      respondVnpay(response, {
+        rspCode: '04',
+        message: 'Invalid amount',
       });
       return;
     }
 
     const responseCode = params.vnp_ResponseCode ?? '';
-    const paymentStatus =
-      responseCode === '00' ? 'succeeded' : responseCode === '24' ? 'canceled' : 'failed';
+    const transactionStatus = params.vnp_TransactionStatus ?? '';
+    const paymentStatus = normalizeVnpayPaymentStatus({
+      responseCode,
+      transactionStatus,
+    });
 
     try {
       const result = await applyPaymentResult({
@@ -85,9 +130,11 @@ export const vnpayPaymentCallback = onRequest(
         transactionId,
         paymentStatus,
         responseCode,
+        transactionStatus,
       });
-      response.status(200).json({
-        ok: true,
+      respondVnpay(response, {
+        rspCode: '00',
+        message: 'Confirm Success',
         transactionId,
         paymentStatus,
       });
@@ -96,9 +143,9 @@ export const vnpayPaymentCallback = onRequest(
         transactionId,
         error: `${error}`,
       });
-      response.status(500).json({
-        ok: false,
-        message: 'Could not process VNPay callback',
+      respondVnpay(response, {
+        rspCode: '99',
+        message: 'Unknown error',
       });
     }
   },
@@ -130,7 +177,7 @@ export const cardPaymentCallback = onRequest(
       transactionId,
       payloadHash,
       validSignature: signatureValid,
-      rawPayload: payload,
+      rawPayload: sanitizeCardPayload(payload),
     });
     if (webhookEvent.alreadyProcessed) {
       response.status(200).json({
@@ -204,6 +251,39 @@ function mergeCardPayload(query: unknown, body: unknown): CardPayload {
   };
 }
 
+function sanitizeVnpayPayload(params: Record<string, string>): Record<string, unknown> {
+  const keepKeys = [
+    'vnp_TmnCode',
+    'vnp_TxnRef',
+    'vnp_TransactionNo',
+    'vnp_Amount',
+    'vnp_BankCode',
+    'vnp_BankTranNo',
+    'vnp_CardType',
+    'vnp_PayDate',
+    'vnp_ResponseCode',
+    'vnp_TransactionStatus',
+    'vnp_TransactionType',
+    'vnp_PayType',
+  ];
+  const output: Record<string, unknown> = {};
+  for (const key of keepKeys) {
+    const value = params[key];
+    if (value != null && value.trim().length > 0) {
+      output[key] = value.trim();
+    }
+  }
+  return output;
+}
+
+function sanitizeCardPayload(payload: CardPayload): Record<string, unknown> {
+  return {
+    transactionId: payload.transactionId,
+    status: payload.status,
+    gatewayReference: payload.gatewayReference,
+  };
+}
+
 function normalizeCardStatus(status: string): 'succeeded' | 'failed' | 'canceled' {
   const normalized = status.trim().toLowerCase();
   if (normalized === 'success' || normalized === 'succeeded' || normalized === 'paid') {
@@ -243,19 +323,44 @@ function normalizeQueryParams(query: unknown): Record<string, string> {
 }
 
 export function isValidVnpaySignature(params: Record<string, string>): boolean {
-  const secureHash = params.vnp_SecureHash;
   const hashSecret = process.env.VNPAY_HASH_SECRET?.trim() ?? '';
-  if (secureHash == null || secureHash.length === 0 || hashSecret.length === 0) {
+  if (hashSecret.length === 0) {
     return false;
   }
+  return validateVnpaySignature(params, hashSecret);
+}
 
-  const canonical = Object.entries(params)
-    .filter(([key]) => key !== 'vnp_SecureHash' && key !== 'vnp_SecureHashType')
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
-    .join('&');
-  const expected = createHmac('sha512', hashSecret).update(canonical).digest('hex');
-  return safeEqual(expected, secureHash);
+function normalizeVnpayPaymentStatus({
+  responseCode,
+  transactionStatus,
+}: {
+  responseCode: string;
+  transactionStatus: string;
+}): 'succeeded' | 'failed' | 'canceled' {
+  if (responseCode === '00' && (transactionStatus.length === 0 || transactionStatus === '00')) {
+    return 'succeeded';
+  }
+  if (responseCode === '24') {
+    return 'canceled';
+  }
+  return 'failed';
+}
+
+function respondVnpay(
+  response: Response,
+  payload: {
+    rspCode: string;
+    message: string;
+    httpStatus?: number;
+    [key: string]: unknown;
+  },
+): void {
+  const { rspCode, message, httpStatus = 200, ...extra } = payload;
+  response.status(httpStatus).json({
+    RspCode: rspCode,
+    Message: message,
+    ...extra,
+  });
 }
 
 async function notifyBillingWebhookResult({
@@ -311,6 +416,27 @@ function safeEqual(left: string, right: string): boolean {
 
 function normalizeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function parseInteger(value: string | undefined): number | null {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return parsed;
+}
+
+function readNumber(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
 }
 
 function sha256(value: string): string {

--- a/firebase/functions/src/contract-tests/billing.contract.test.ts
+++ b/firebase/functions/src/contract-tests/billing.contract.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { createHmac } from 'node:crypto';
 import test from 'node:test';
 
 import { isValidVnpaySignature } from '../billing/webhooks';
+import { createVnpaySignature } from '../billing/vnpay';
 import {
   canAccessPremiumFeatures,
   resolveEffectivePlanCode,
@@ -110,17 +110,39 @@ test('billing contract: VNPay callback signature is validated', () => {
     vnp_Version: '2.1.0',
   };
 
-  const canonical = Object.entries(params)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
-    .join('&');
-
-  params.vnp_SecureHash = createHmac('sha512', process.env.VNPAY_HASH_SECRET)
-    .update(canonical)
-    .digest('hex');
+  params.vnp_SecureHash = createVnpaySignature(
+    params,
+    process.env.VNPAY_HASH_SECRET as string,
+    'encoded',
+  );
 
   assert.equal(isValidVnpaySignature(params), true);
 
   params.vnp_SecureHash = `${params.vnp_SecureHash.substring(0, 30)}broken`;
   assert.equal(isValidVnpaySignature(params), false);
+});
+
+test('billing contract: VNPay callback supports raw signature mode', () => {
+  process.env.VNPAY_HASH_SECRET = 'contract-test-secret';
+
+  const params: Record<string, string> = {
+    vnp_Amount: '4900000',
+    vnp_Command: 'pay',
+    vnp_CreateDate: '20260315120000',
+    vnp_CurrCode: 'VND',
+    vnp_OrderInfo: 'Thanh toan don hang 5',
+    vnp_ResponseCode: '00',
+    vnp_TmnCode: 'DEMO1234',
+    vnp_TransactionNo: '15190022',
+    vnp_TxnRef: 'txn_contract_002',
+    vnp_Version: '2.1.0',
+  };
+
+  params.vnp_SecureHash = createVnpaySignature(
+    params,
+    process.env.VNPAY_HASH_SECRET as string,
+    'raw',
+  );
+
+  assert.equal(isValidVnpaySignature(params), true);
 });

--- a/mobile/befam/ios/Podfile.lock
+++ b/mobile/befam/ios/Podfile.lock
@@ -1520,6 +1520,8 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -1534,6 +1536,7 @@ DEPENDENCIES:
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - printing (from `.symlinks/plugins/printing/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -1596,6 +1599,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/printing/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
@@ -1643,6 +1648,7 @@ SPEC CHECKSUMS:
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
 PODFILE CHECKSUM: 4eff67d0a836cec7916701393d553813e6ca7743
 

--- a/mobile/befam/lib/features/billing/presentation/billing_controller.dart
+++ b/mobile/befam/lib/features/billing/presentation/billing_controller.dart
@@ -63,10 +63,15 @@ class BillingController extends ChangeNotifier {
     await refresh();
   }
 
-  Future<void> refresh() async {
-    _isLoading = true;
-    _errorMessage = null;
-    notifyListeners();
+  Future<void> refresh({bool silent = false}) async {
+    final shouldShowLoading = !silent || _workspace == null;
+    if (shouldShowLoading) {
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+    } else {
+      _errorMessage = null;
+    }
     try {
       if (canManageBilling) {
         _workspace = await _repository.loadWorkspace(session: _session);
@@ -121,6 +126,9 @@ class BillingController extends ChangeNotifier {
     required String paymentMethod,
     String? requestedPlanCode,
     String? returnUrl,
+    String? locale,
+    String? orderNote,
+    String? bankCode,
   }) async {
     _isCreatingCheckout = true;
     _errorMessage = null;
@@ -132,6 +140,9 @@ class BillingController extends ChangeNotifier {
         paymentMethod: paymentMethod,
         requestedPlanCode: requestedPlanCode,
         returnUrl: returnUrl,
+        locale: locale,
+        orderNote: orderNote,
+        bankCode: bankCode,
       );
       _workspace = await _repository.loadWorkspace(session: _session);
       _viewerSummary = null;

--- a/mobile/befam/lib/features/billing/presentation/billing_workspace_page.dart
+++ b/mobile/befam/lib/features/billing/presentation/billing_workspace_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../../core/widgets/app_feedback_states.dart';
 import '../../../l10n/generated/app_localizations.dart';
@@ -34,6 +35,8 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
   bool _autoRenewDraft = false;
   Set<int> _reminderDaysDraft = {30, 14, 7, 3, 1};
   String? _draftSeedKey;
+  Timer? _pendingPollingTimer;
+  bool _isPollingRefreshInFlight = false;
 
   @override
   void initState() {
@@ -49,14 +52,42 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
 
   @override
   void dispose() {
+    _pendingPollingTimer?.cancel();
     _controller.dispose();
     super.dispose();
   }
 
-  Future<void> _createCheckout(String paymentMethod) async {
+  Future<void> _startVnpayCheckoutFlow({
+    required BillingWorkspaceSnapshot workspace,
+    required BillingPlanPricing selectedTier,
+  }) async {
+    final draft = await Navigator.of(context).push<_VnpayCheckoutDraft>(
+      MaterialPageRoute(
+        builder: (context) => _VnpayCheckoutFormPage(
+          selectedTier: selectedTier,
+          memberCount: workspace.memberCount,
+          currentPlanCode: workspace.subscription.planCode,
+          currentStatus: workspace.entitlement.status,
+          expiresAtIso:
+              workspace.entitlement.expiresAtIso ??
+              workspace.subscription.expiresAtIso,
+          defaultLocale: _preferredVnpayLocale(context),
+        ),
+      ),
+    );
+    if (!mounted || draft == null) {
+      return;
+    }
+    await _createVnpayCheckout(draft);
+  }
+
+  Future<void> _createVnpayCheckout(_VnpayCheckoutDraft draft) async {
     final result = await _controller.createCheckout(
-      paymentMethod: paymentMethod,
+      paymentMethod: 'vnpay',
       requestedPlanCode: _selectedPlanCodeDraft,
+      locale: draft.locale,
+      orderNote: draft.orderNote,
+      bankCode: draft.bankCode,
     );
     if (!mounted || result == null) {
       return;
@@ -65,12 +96,22 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
       SnackBar(
         content: Text(
           context.l10n.pick(
-            vi: 'Đã tạo phiên thanh toán ${paymentMethod.toUpperCase()}.',
-            en: '${paymentMethod.toUpperCase()} checkout created.',
+            vi: 'Đã tạo phiên thanh toán VNPay. Hệ thống sẽ cập nhật khi VNPay xác nhận.',
+            en: 'VNPay checkout created. We will update once VNPay confirms payment.',
           ),
         ),
       ),
     );
+    if (result.checkoutUrl.trim().isNotEmpty) {
+      await _openCheckoutUrl(result.checkoutUrl);
+    }
+  }
+
+  String _preferredVnpayLocale(BuildContext context) {
+    final languageCode = Localizations.localeOf(
+      context,
+    ).languageCode.toLowerCase();
+    return languageCode == 'en' ? 'en' : 'vn';
   }
 
   Future<void> _savePreferences() async {
@@ -111,6 +152,73 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
         ),
       ),
     );
+  }
+
+  Future<void> _openCheckoutUrl(String checkoutUrl) async {
+    final uri = Uri.tryParse(checkoutUrl.trim());
+    if (uri == null) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            context.l10n.pick(
+              vi: 'Liên kết thanh toán không hợp lệ.',
+              en: 'Invalid checkout URL.',
+            ),
+          ),
+        ),
+      );
+      return;
+    }
+
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (launched || !mounted) {
+      return;
+    }
+
+    await Clipboard.setData(ClipboardData(text: checkoutUrl));
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          context.l10n.pick(
+            vi: 'Không thể mở VNPay. Đã sao chép liên kết để bạn mở thủ công.',
+            en: 'Could not open VNPay. The checkout link has been copied.',
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _syncPendingPolling({required bool shouldPoll}) {
+    if (shouldPoll) {
+      _pendingPollingTimer ??= Timer.periodic(const Duration(seconds: 8), (_) {
+        if (!mounted ||
+            _controller.isLoading ||
+            _controller.isCreatingCheckout ||
+            _controller.isProcessingPayment ||
+            _isPollingRefreshInFlight) {
+          return;
+        }
+        _isPollingRefreshInFlight = true;
+        unawaited(() async {
+          try {
+            await _controller.refresh(silent: true);
+          } finally {
+            _isPollingRefreshInFlight = false;
+          }
+        }());
+      });
+      return;
+    }
+
+    _pendingPollingTimer?.cancel();
+    _pendingPollingTimer = null;
+    _isPollingRefreshInFlight = false;
   }
 
   void _syncDraftFromWorkspace(BillingWorkspaceSnapshot workspace) {
@@ -156,6 +264,9 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
         final viewerSummary = _controller.viewerSummary;
         if (workspace != null) {
           _syncDraftFromWorkspace(workspace);
+        }
+        if (!_controller.canManageBilling || workspace == null) {
+          _syncPendingPolling(shouldPoll: false);
         }
 
         return Scaffold(
@@ -251,9 +362,27 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
       (tier) => tier.planCode.trim().toUpperCase() == selectedPlanCode,
       orElse: () => minimumTier,
     );
+    final currentPlanRank = _planRank(workspace.subscription.planCode);
+    final selectedPlanRank = _planRank(selectedTier.planCode);
+    final activeStatus = _isActiveSubscriptionStatus(
+      workspace.entitlement.status,
+    );
+    final isUpgrade = selectedPlanRank > currentPlanRank;
+    final upgradeOnlyMode = activeStatus && currentPlanRank > 0;
+    final checkoutBlockedByUpgradeRule = upgradeOnlyMode && !isUpgrade;
+    final canStartVnpayCheckout =
+        canManage &&
+        !_controller.isCreatingCheckout &&
+        selectedTier.priceVndYear > 0 &&
+        !checkoutBlockedByUpgradeRule;
     final pendingTransactions = workspace.transactions
         .where((tx) => _isPendingPaymentStatus(tx.paymentStatus))
         .toList(growable: false);
+    _syncPendingPolling(
+      shouldPoll: pendingTransactions.any(
+        (tx) => tx.paymentMethod.trim().toLowerCase() == 'vnpay',
+      ),
+    );
 
     return RefreshIndicator(
       onRefresh: _controller.refresh,
@@ -367,6 +496,20 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
                   style: theme.textTheme.bodySmall,
                 ),
                 const SizedBox(height: 12),
+                if (upgradeOnlyMode)
+                  _InfoCard(
+                    icon: Icons.upgrade_outlined,
+                    title: l10n.pick(
+                      vi: 'Gói hiện tại vẫn còn hiệu lực',
+                      en: 'Current plan is still active',
+                    ),
+                    description: l10n.pick(
+                      vi: 'Trong thời gian còn hạn, hệ thống chỉ cho thanh toán nâng cấp lên gói cao hơn.',
+                      en: 'While your plan is valid, checkout is available for higher-tier upgrades only.',
+                    ),
+                    tone: colorScheme.secondaryContainer,
+                  ),
+                if (upgradeOnlyMode) const SizedBox(height: 10),
                 if (selectedTier.priceVndYear == 0)
                   _InfoCard(
                     icon: Icons.info_outline,
@@ -381,28 +524,40 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
                     tone: colorScheme.tertiaryContainer,
                   )
                 else
-                  Wrap(
-                    spacing: 10,
-                    runSpacing: 10,
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      FilledButton.icon(
-                        key: const Key('billing-checkout-card-button'),
-                        onPressed: canManage && !_controller.isCreatingCheckout
-                            ? () => _createCheckout('card')
-                            : null,
-                        icon: const Icon(Icons.credit_card),
-                        label: Text(
-                          l10n.pick(vi: 'Thanh toán thẻ', en: 'Pay by card'),
+                      SizedBox(
+                        width: double.infinity,
+                        child: FilledButton.icon(
+                          key: const Key('billing-checkout-vnpay-button'),
+                          onPressed: canStartVnpayCheckout
+                              ? () => _startVnpayCheckoutFlow(
+                                  workspace: workspace,
+                                  selectedTier: selectedTier,
+                                )
+                              : null,
+                          icon: const Icon(Icons.qr_code_2_outlined),
+                          label: Text(
+                            l10n.pick(
+                              vi: 'Thanh toán bằng VNPay',
+                              en: 'Pay with VNPay',
+                            ),
+                          ),
                         ),
                       ),
-                      OutlinedButton.icon(
-                        key: const Key('billing-checkout-vnpay-button'),
-                        onPressed: canManage && !_controller.isCreatingCheckout
-                            ? () => _createCheckout('vnpay')
-                            : null,
-                        icon: const Icon(Icons.qr_code_2_outlined),
-                        label: const Text('VNPay'),
-                      ),
+                      if (checkoutBlockedByUpgradeRule) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          l10n.pick(
+                            vi: 'Vui lòng chọn gói cao hơn để nâng cấp trong thời gian còn hạn.',
+                            en: 'Please choose a higher plan to upgrade while current plan is valid.',
+                          ),
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.error,
+                          ),
+                        ),
+                      ],
                     ],
                   ),
                 if (_controller.lastCheckout case final checkout?) ...[
@@ -412,22 +567,9 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
                     onCopyUrl: checkout.checkoutUrl.trim().isEmpty
                         ? null
                         : () => _copyCheckoutUrl(checkout.checkoutUrl),
-                    onConfirmCard:
-                        canManage &&
-                            checkout.paymentMethod == 'card' &&
-                            checkout.requiresManualConfirmation
-                        ? () => _controller.confirmCardPayment(
-                            checkout.transactionId,
-                          )
-                        : null,
-                    onConfirmVnpay:
-                        canManage &&
-                            checkout.paymentMethod == 'vnpay' &&
-                            checkout.planCode != 'FREE'
-                        ? () => _controller.confirmVnpayPayment(
-                            checkout.transactionId,
-                          )
-                        : null,
+                    onOpenUrl: checkout.checkoutUrl.trim().isEmpty
+                        ? null
+                        : () => _openCheckoutUrl(checkout.checkoutUrl),
                   ),
                 ],
                 if (pendingTransactions.isNotEmpty) ...[
@@ -448,33 +590,21 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
                       child: ListTile(
                         dense: true,
                         title: Text(
-                          '${tx.paymentMethod.toUpperCase()} • ${_formatVnd(tx.amountVnd)}',
+                          '${_localizedPlanName(tx.planCode, l10n)} • ${_formatVnd(tx.amountVnd)}',
                         ),
                         subtitle: Text(
-                          l10n.pick(vi: 'Mã: ${tx.id}', en: 'Ref: ${tx.id}'),
+                          l10n.pick(
+                            vi: 'VNPay • Mã: ${tx.id}',
+                            en: 'VNPay • Ref: ${tx.id}',
+                          ),
                         ),
-                        trailing: tx.paymentMethod == 'card'
-                            ? TextButton(
-                                onPressed: canManage
-                                    ? () =>
-                                          _controller.confirmCardPayment(tx.id)
-                                    : null,
-                                child: Text(
-                                  l10n.pick(vi: 'Xác nhận', en: 'Confirm'),
-                                ),
-                              )
-                            : TextButton(
-                                onPressed: canManage
-                                    ? () =>
-                                          _controller.confirmVnpayPayment(tx.id)
-                                    : null,
-                                child: Text(
-                                  l10n.pick(
-                                    vi: 'Đã thanh toán',
-                                    en: 'Mark paid',
-                                  ),
-                                ),
-                              ),
+                        trailing: Tooltip(
+                          message: l10n.pick(
+                            vi: 'Đợi VNPay gửi callback xác nhận. Gói hiện tại vẫn được giữ nguyên cho đến khi thanh toán thành công.',
+                            en: 'Waiting for VNPay callback confirmation. Your current plan remains active until payment succeeds.',
+                          ),
+                          child: const Icon(Icons.hourglass_top_rounded),
+                        ),
                       ),
                     ),
                 ],
@@ -909,6 +1039,14 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
         return l10n.pick(vi: 'Thanh toán thành công', en: 'Payment succeeded');
       case 'payment_failed':
         return l10n.pick(vi: 'Thanh toán thất bại', en: 'Payment failed');
+      case 'payment_canceled':
+      case 'payment_cancelled':
+        return l10n.pick(vi: 'Thanh toán đã hủy', en: 'Payment canceled');
+      case 'payment_timeout_marked':
+        return l10n.pick(
+          vi: 'Phiên thanh toán đã hết hạn',
+          en: 'Payment session timed out',
+        );
       case 'billing_preferences_updated':
         return l10n.pick(
           vi: 'Đã cập nhật cài đặt thanh toán',
@@ -940,6 +1078,11 @@ class _BillingWorkspacePageState extends State<BillingWorkspacePage> {
   bool _isPendingPaymentStatus(String status) {
     final normalized = status.trim().toLowerCase();
     return normalized == 'pending' || normalized == 'created';
+  }
+
+  bool _isActiveSubscriptionStatus(String status) {
+    final normalized = status.trim().toLowerCase();
+    return normalized == 'active' || normalized == 'grace_period';
   }
 
   String _humanizeCode(String raw) {
@@ -1107,18 +1250,275 @@ class _SubscriptionHeroCard extends StatelessWidget {
   }
 }
 
+class _VnpayCheckoutDraft {
+  const _VnpayCheckoutDraft({
+    required this.locale,
+    this.orderNote,
+    this.bankCode,
+  });
+
+  final String locale;
+  final String? orderNote;
+  final String? bankCode;
+}
+
+class _VnpayCheckoutFormPage extends StatefulWidget {
+  const _VnpayCheckoutFormPage({
+    required this.selectedTier,
+    required this.memberCount,
+    required this.currentPlanCode,
+    required this.currentStatus,
+    required this.expiresAtIso,
+    required this.defaultLocale,
+  });
+
+  final BillingPlanPricing selectedTier;
+  final int memberCount;
+  final String currentPlanCode;
+  final String currentStatus;
+  final String? expiresAtIso;
+  final String defaultLocale;
+
+  @override
+  State<_VnpayCheckoutFormPage> createState() => _VnpayCheckoutFormPageState();
+}
+
+class _VnpayCheckoutFormPageState extends State<_VnpayCheckoutFormPage> {
+  late final TextEditingController _orderNoteController;
+  String? _selectedBankCode;
+
+  @override
+  void initState() {
+    super.initState();
+    _orderNoteController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _orderNoteController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.pick(vi: 'Thanh toán VNPay', en: 'VNPay checkout')),
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+          children: [
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.pick(vi: 'Tóm tắt đơn hàng', en: 'Order summary'),
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    _SummaryRow(
+                      label: l10n.pick(vi: 'Gói thanh toán', en: 'Plan'),
+                      value: _localizedPlanName(
+                        widget.selectedTier.planCode,
+                        l10n,
+                      ),
+                    ),
+                    _SummaryRow(
+                      label: l10n.pick(vi: 'Số thành viên', en: 'Members'),
+                      value: '${widget.memberCount}',
+                    ),
+                    _SummaryRow(
+                      label: l10n.pick(vi: 'Tổng tiền', en: 'Total amount'),
+                      value: _formatVnd(widget.selectedTier.priceVndYear),
+                    ),
+                    _SummaryRow(
+                      label: l10n.pick(vi: 'Gói đang dùng', en: 'Current plan'),
+                      value:
+                          '${_localizedPlanName(widget.currentPlanCode, l10n)} • '
+                          '${_humanizeStatusCode(widget.currentStatus, l10n)}',
+                    ),
+                    _SummaryRow(
+                      label: l10n.pick(
+                        vi: 'Hiệu lực hiện tại',
+                        en: 'Current validity',
+                      ),
+                      value: _dateOnly(widget.expiresAtIso),
+                    ),
+                    _SummaryRow(
+                      label: l10n.pick(
+                        vi: 'Ngôn ngữ VNPay',
+                        en: 'VNPay language',
+                      ),
+                      value: widget.defaultLocale == 'en'
+                          ? l10n.pick(vi: 'Tiếng Anh', en: 'English')
+                          : l10n.pick(vi: 'Tiếng Việt', en: 'Vietnamese'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _orderNoteController,
+              maxLength: 120,
+              textInputAction: TextInputAction.done,
+              decoration: InputDecoration(
+                labelText: l10n.pick(
+                  vi: 'Ghi chú đơn hàng (tùy chọn)',
+                  en: 'Order note (optional)',
+                ),
+                hintText: l10n.pick(
+                  vi: 'Ví dụ: Gia hạn cho năm 2026',
+                  en: 'Example: Renewal for 2026',
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            DropdownButtonFormField<String?>(
+              isExpanded: true,
+              initialValue: _selectedBankCode,
+              decoration: InputDecoration(
+                labelText: l10n.pick(
+                  vi: 'Kênh thanh toán (tùy chọn)',
+                  en: 'Payment channel (optional)',
+                ),
+              ),
+              items: [
+                DropdownMenuItem<String?>(
+                  value: null,
+                  child: Text(
+                    l10n.pick(vi: 'Tự chọn tại VNPay', en: 'Choose on VNPay'),
+                  ),
+                ),
+                for (final option in _vnpayBankOptions)
+                  DropdownMenuItem<String?>(
+                    value: option.code,
+                    child: Text(
+                      l10n.pick(vi: option.labelVi, en: option.labelEn),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+              ],
+              onChanged: (value) {
+                setState(() {
+                  _selectedBankCode = value;
+                });
+              },
+            ),
+            const SizedBox(height: 12),
+            Text(
+              l10n.pick(
+                vi: 'Nhấn "Tiếp tục với VNPay" để chuyển sang trang thanh toán sandbox. Gói hiện tại chỉ đổi khi VNPay xác nhận thành công.',
+                en: 'Tap "Continue to VNPay" to open the sandbox checkout. Current plan changes only after successful VNPay confirmation.',
+              ),
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        minimum: const EdgeInsets.fromLTRB(20, 8, 20, 16),
+        child: FilledButton.icon(
+          onPressed: () {
+            Navigator.of(context).pop(
+              _VnpayCheckoutDraft(
+                locale: widget.defaultLocale,
+                orderNote: _orderNoteController.text.trim().isEmpty
+                    ? null
+                    : _orderNoteController.text.trim(),
+                bankCode: _selectedBankCode,
+              ),
+            );
+          },
+          icon: const Icon(Icons.arrow_forward),
+          label: Text(
+            l10n.pick(vi: 'Tiếp tục với VNPay', en: 'Continue to VNPay'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryRow extends StatelessWidget {
+  const _SummaryRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 126,
+            child: Text(label, style: theme.textTheme.bodySmall),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              value,
+              textAlign: TextAlign.right,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _VnpayBankOption {
+  const _VnpayBankOption({
+    required this.code,
+    required this.labelVi,
+    required this.labelEn,
+  });
+
+  final String code;
+  final String labelVi;
+  final String labelEn;
+}
+
+const List<_VnpayBankOption> _vnpayBankOptions = [
+  _VnpayBankOption(code: 'VNPAYQR', labelVi: 'QR VNPay', labelEn: 'VNPay QR'),
+  _VnpayBankOption(
+    code: 'VNBANK',
+    labelVi: 'ATM/Tài khoản nội địa',
+    labelEn: 'Domestic ATM/account',
+  ),
+  _VnpayBankOption(
+    code: 'INTCARD',
+    labelVi: 'Thẻ quốc tế',
+    labelEn: 'International card',
+  ),
+];
+
 class _CheckoutResultCard extends StatelessWidget {
   const _CheckoutResultCard({
     required this.checkout,
     this.onCopyUrl,
-    this.onConfirmCard,
-    this.onConfirmVnpay,
+    this.onOpenUrl,
   });
 
   final BillingCheckoutResult checkout;
   final VoidCallback? onCopyUrl;
-  final VoidCallback? onConfirmCard;
-  final VoidCallback? onConfirmVnpay;
+  final VoidCallback? onOpenUrl;
 
   @override
   Widget build(BuildContext context) {
@@ -1140,49 +1540,47 @@ class _CheckoutResultCard extends StatelessWidget {
                 en: 'Transaction: ${checkout.transactionId}',
               ),
             ),
+            const SizedBox(height: 4),
             Text(
               l10n.pick(
                 vi: 'Phương thức: ${checkout.paymentMethod.toUpperCase()}',
                 en: 'Method: ${checkout.paymentMethod.toUpperCase()}',
               ),
             ),
+            const SizedBox(height: 4),
+            Text(
+              l10n.pick(
+                vi: 'Số tiền: ${_formatVnd(checkout.amountVnd)}',
+                en: 'Amount: ${_formatVnd(checkout.amountVnd)}',
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.pick(
+                vi: 'Sau khi thanh toán, VNPay sẽ gọi callback để hệ thống tự cập nhật trạng thái gói.',
+                en: 'After payment, VNPay callback will update your subscription status automatically.',
+              ),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
             if (checkout.checkoutUrl.trim().isNotEmpty) ...[
               const SizedBox(height: 8),
-              SelectableText(checkout.checkoutUrl),
-              const SizedBox(height: 8),
-              OutlinedButton.icon(
-                onPressed: onCopyUrl,
-                icon: const Icon(Icons.copy_outlined),
-                label: Text(
-                  l10n.pick(
-                    vi: 'Sao chép liên kết thanh toán',
-                    en: 'Copy checkout link',
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  FilledButton.tonalIcon(
+                    onPressed: onOpenUrl,
+                    icon: const Icon(Icons.open_in_new),
+                    label: Text(l10n.pick(vi: 'Mở VNPay', en: 'Open VNPay')),
                   ),
-                ),
-              ),
-            ],
-            if (onConfirmCard != null) ...[
-              const SizedBox(height: 8),
-              FilledButton(
-                onPressed: onConfirmCard,
-                child: Text(
-                  l10n.pick(
-                    vi: 'Xác nhận thanh toán thẻ',
-                    en: 'Confirm card payment',
+                  OutlinedButton.icon(
+                    onPressed: onCopyUrl,
+                    icon: const Icon(Icons.copy_outlined),
+                    label: Text(
+                      l10n.pick(vi: 'Sao chép link', en: 'Copy link'),
+                    ),
                   ),
-                ),
-              ),
-            ],
-            if (onConfirmVnpay != null) ...[
-              const SizedBox(height: 8),
-              FilledButton.tonal(
-                onPressed: onConfirmVnpay,
-                child: Text(
-                  l10n.pick(
-                    vi: 'Đánh dấu VNPay đã thanh toán',
-                    en: 'Mark VNPay paid',
-                  ),
-                ),
+                ],
               ),
             ],
           ],
@@ -1397,6 +1795,20 @@ String _localizedPlanName(String planCode, AppLocalizations l10n) {
   }
 }
 
+String _humanizeStatusCode(String status, AppLocalizations l10n) {
+  switch (status.trim().toLowerCase()) {
+    case 'active':
+      return l10n.pick(vi: 'Đang hoạt động', en: 'Active');
+    case 'grace_period':
+      return l10n.pick(vi: 'Ân hạn', en: 'Grace period');
+    case 'pending_payment':
+      return l10n.pick(vi: 'Chờ thanh toán', en: 'Pending payment');
+    case 'expired':
+      return l10n.pick(vi: 'Hết hạn', en: 'Expired');
+    default:
+      return status;
+  }
+}
 String _friendlyErrorMessage(String? raw, AppLocalizations l10n) {
   final fallback = l10n.pick(
     vi: 'Hãy thử tải lại sau.',
@@ -1436,6 +1848,24 @@ String _friendlyErrorMessage(String? raw, AppLocalizations l10n) {
     return l10n.pick(
       vi: 'Không thể kết nối dịch vụ thanh toán. Vui lòng kiểm tra mạng và thử lại.',
       en: 'Billing service is unavailable. Please check your network and retry.',
+    );
+  }
+  if (lower.contains('timeout') || lower.contains('timed out')) {
+    return l10n.pick(
+      vi: 'Phiên thanh toán đã hết thời gian chờ. Vui lòng tạo phiên mới để thanh toán lại.',
+      en: 'Payment session timed out. Please create a new checkout and try again.',
+    );
+  }
+  if (lower.contains('canceled') || lower.contains('cancelled')) {
+    return l10n.pick(
+      vi: 'Thanh toán đã bị hủy. Bạn có thể tạo phiên mới bất kỳ lúc nào.',
+      en: 'Payment was canceled. You can create a new checkout anytime.',
+    );
+  }
+  if (lower.contains('payment failed') || lower.contains(' failed')) {
+    return l10n.pick(
+      vi: 'Thanh toán chưa thành công. Vui lòng kiểm tra lại và thử lại.',
+      en: 'Payment did not complete successfully. Please review and try again.',
     );
   }
 

--- a/mobile/befam/lib/features/billing/services/billing_repository.dart
+++ b/mobile/befam/lib/features/billing/services/billing_repository.dart
@@ -48,6 +48,9 @@ abstract interface class BillingRepository {
     required String paymentMethod,
     String? requestedPlanCode,
     String? returnUrl,
+    String? locale,
+    String? orderNote,
+    String? bankCode,
   });
 
   Future<void> completeCardCheckout({

--- a/mobile/befam/lib/features/billing/services/debug_billing_repository.dart
+++ b/mobile/befam/lib/features/billing/services/debug_billing_repository.dart
@@ -128,6 +128,9 @@ class DebugBillingRepository implements BillingRepository {
     required String paymentMethod,
     String? requestedPlanCode,
     String? returnUrl,
+    String? locale,
+    String? orderNote,
+    String? bankCode,
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 140));
     final clanId = _clanIdOf(session);
@@ -203,14 +206,17 @@ class DebugBillingRepository implements BillingRepository {
     );
     state.invoices.insert(0, invoice);
 
+    final shouldApplyImmediately = tier.planCode == 'FREE';
     state.subscription = BillingSubscription(
       id: state.subscription.id,
       clanId: clanId,
-      planCode: tier.planCode,
-      status: tier.planCode == 'FREE' ? 'active' : 'pending_payment',
+      planCode: shouldApplyImmediately ? tier.planCode : state.subscription.planCode,
+      status: shouldApplyImmediately ? 'active' : state.subscription.status,
       memberCount: state.memberCount,
-      amountVndYear: tier.priceVndYear,
-      vatIncluded: true,
+      amountVndYear: shouldApplyImmediately
+          ? tier.priceVndYear
+          : state.subscription.amountVndYear,
+      vatIncluded: shouldApplyImmediately ? true : state.subscription.vatIncluded,
       paymentMode: state.settings.paymentMode,
       autoRenew: state.settings.autoRenew,
       startsAtIso: state.subscription.startsAtIso,
@@ -237,7 +243,7 @@ class DebugBillingRepository implements BillingRepository {
       actorUid: session.uid,
     );
 
-    if (tier.planCode == 'FREE') {
+    if (shouldApplyImmediately) {
       _applySuccessfulPayment(
         state,
         transactionId: transactionId,
@@ -246,7 +252,13 @@ class DebugBillingRepository implements BillingRepository {
     }
 
     final checkoutUrl = method == 'vnpay'
-        ? 'https://sandbox.vnpayment.vn/paymentv2/vpcpay.html?txn=$transactionId'
+        ? _buildDebugVnpayUrl(
+            transactionId: transactionId,
+            amountVnd: tier.priceVndYear,
+            locale: locale,
+            orderNote: orderNote,
+            bankCode: bankCode,
+          )
         : 'https://example.com/billing/card?txn=$transactionId';
 
     return BillingCheckoutResult(
@@ -262,6 +274,29 @@ class DebugBillingRepository implements BillingRepository {
       subscription: state.subscription,
       entitlement: state.entitlement,
     );
+  }
+
+  String _buildDebugVnpayUrl({
+    required String transactionId,
+    required int amountVnd,
+    String? locale,
+    String? orderNote,
+    String? bankCode,
+  }) {
+    final url = Uri.parse('https://sandbox.vnpayment.vn/paymentv2/vpcpay.html')
+        .replace(
+          queryParameters: {
+            'txn': transactionId,
+            'amount': '$amountVnd',
+            if (locale != null && locale.trim().isNotEmpty)
+              'locale': locale.trim().toLowerCase(),
+            if (orderNote != null && orderNote.trim().isNotEmpty)
+              'note': orderNote.trim(),
+            if (bankCode != null && bankCode.trim().isNotEmpty)
+              'bankCode': bankCode.trim().toUpperCase(),
+          },
+        );
+    return url.toString();
   }
 
   @override

--- a/mobile/befam/lib/features/billing/services/firebase_billing_repository.dart
+++ b/mobile/befam/lib/features/billing/services/firebase_billing_repository.dart
@@ -29,9 +29,7 @@ class FirebaseBillingRepository implements BillingRepository {
       firestore: _firestore,
       session: session,
     );
-    final result = await _call('loadBillingWorkspace').call({
-      'clanId': clanId,
-    });
+    final result = await _call('loadBillingWorkspace').call({'clanId': clanId});
     return _parseWorkspace(result.data);
   }
 
@@ -44,13 +42,13 @@ class FirebaseBillingRepository implements BillingRepository {
       firestore: _firestore,
       session: session,
     );
-    final result = await _call('resolveBillingEntitlement').call({
-      'clanId': clanId,
-    });
+    final result = await _call(
+      'resolveBillingEntitlement',
+    ).call({'clanId': clanId});
     final map = _asMap(result.data);
-    final pricing = _asList(map['pricingTiers'])
-        .map((item) => _parsePricing(_asMap(item)))
-        .toList(growable: false);
+    final pricing = _asList(
+      map['pricingTiers'],
+    ).map((item) => _parsePricing(_asMap(item))).toList(growable: false);
     return BillingViewerSummary(
       clanId: _readString(map, 'clanId', fallback: clanId),
       subscription: _parseSubscription(_asMap(map['subscription'])),
@@ -69,9 +67,9 @@ class FirebaseBillingRepository implements BillingRepository {
       firestore: _firestore,
       session: session,
     );
-    final result = await _call('resolveBillingEntitlement').call({
-      'clanId': clanId,
-    });
+    final result = await _call(
+      'resolveBillingEntitlement',
+    ).call({'clanId': clanId});
     final map = _asMap(result.data);
     return _parseEntitlement(_asMap(map['entitlement']));
   }
@@ -106,6 +104,9 @@ class FirebaseBillingRepository implements BillingRepository {
     required String paymentMethod,
     String? requestedPlanCode,
     String? returnUrl,
+    String? locale,
+    String? orderNote,
+    String? bankCode,
   }) async {
     final clanId = _sessionClanId(session);
     await FirebaseSessionAccessSync.ensureUserSessionDocument(
@@ -119,6 +120,11 @@ class FirebaseBillingRepository implements BillingRepository {
         'requestedPlanCode': requestedPlanCode.trim().toUpperCase(),
       if (returnUrl != null && returnUrl.trim().isNotEmpty)
         'returnUrl': returnUrl.trim(),
+      if (locale != null && locale.trim().isNotEmpty) 'locale': locale.trim(),
+      if (orderNote != null && orderNote.trim().isNotEmpty)
+        'orderNote': orderNote.trim(),
+      if (bankCode != null && bankCode.trim().isNotEmpty)
+        'bankCode': bankCode.trim().toUpperCase(),
     });
     final map = _asMap(result.data);
     return BillingCheckoutResult(
@@ -150,10 +156,9 @@ class FirebaseBillingRepository implements BillingRepository {
       firestore: _firestore,
       session: session,
     );
-    await _call('completeCardCheckout').call({
-      'clanId': clanId,
-      'transactionId': transactionId.trim(),
-    });
+    await _call(
+      'completeCardCheckout',
+    ).call({'clanId': clanId, 'transactionId': transactionId.trim()});
   }
 
   @override
@@ -166,10 +171,9 @@ class FirebaseBillingRepository implements BillingRepository {
       firestore: _firestore,
       session: session,
     );
-    await _call('simulateVnpaySettlement').call({
-      'clanId': clanId,
-      'transactionId': transactionId.trim(),
-    });
+    await _call(
+      'simulateVnpaySettlement',
+    ).call({'clanId': clanId, 'transactionId': transactionId.trim()});
   }
 
   HttpsCallable _call(String name) {
@@ -178,18 +182,18 @@ class FirebaseBillingRepository implements BillingRepository {
 
   BillingWorkspaceSnapshot _parseWorkspace(Object? raw) {
     final map = _asMap(raw);
-    final pricing = _asList(map['pricingTiers'])
-        .map((item) => _parsePricing(_asMap(item)))
-        .toList(growable: false);
-    final transactions = _asList(map['transactions'])
-        .map((item) => _parseTransaction(_asMap(item)))
-        .toList(growable: false);
-    final invoices = _asList(map['invoices'])
-        .map((item) => _parseInvoice(_asMap(item)))
-        .toList(growable: false);
-    final auditLogs = _asList(map['auditLogs'])
-        .map((item) => _parseAuditLog(_asMap(item)))
-        .toList(growable: false);
+    final pricing = _asList(
+      map['pricingTiers'],
+    ).map((item) => _parsePricing(_asMap(item))).toList(growable: false);
+    final transactions = _asList(
+      map['transactions'],
+    ).map((item) => _parseTransaction(_asMap(item))).toList(growable: false);
+    final invoices = _asList(
+      map['invoices'],
+    ).map((item) => _parseInvoice(_asMap(item))).toList(growable: false);
+    final auditLogs = _asList(
+      map['auditLogs'],
+    ).map((item) => _parseAuditLog(_asMap(item))).toList(growable: false);
 
     return BillingWorkspaceSnapshot(
       clanId: _readString(map, 'clanId'),
@@ -326,9 +330,7 @@ class FirebaseBillingRepository implements BillingRepository {
       return raw;
     }
     if (raw is Map) {
-      return raw.map(
-        (key, value) => MapEntry(key.toString(), value),
-      );
+      return raw.map((key, value) => MapEntry(key.toString(), value));
     }
     return const {};
   }
@@ -394,7 +396,11 @@ class FirebaseBillingRepository implements BillingRepository {
     return null;
   }
 
-  bool _readBool(Map<String, dynamic> map, String key, {bool fallback = false}) {
+  bool _readBool(
+    Map<String, dynamic> map,
+    String key, {
+    bool fallback = false,
+  }) {
     final value = map[key];
     if (value is bool) {
       return value;
@@ -416,24 +422,25 @@ class FirebaseBillingRepository implements BillingRepository {
     if (raw is! List) {
       return const [30, 14, 7, 3, 1];
     }
-    final values = raw
-        .map((item) {
-          if (item is int) {
-            return item;
-          }
-          if (item is num) {
-            return item.toInt();
-          }
-          if (item is String) {
-            return int.tryParse(item);
-          }
-          return null;
-        })
-        .whereType<int>()
-        .where((value) => value > 0 && value <= 60)
-        .toSet()
-        .toList(growable: false)
-      ..sort((left, right) => right.compareTo(left));
+    final values =
+        raw
+            .map((item) {
+              if (item is int) {
+                return item;
+              }
+              if (item is num) {
+                return item.toInt();
+              }
+              if (item is String) {
+                return int.tryParse(item);
+              }
+              return null;
+            })
+            .whereType<int>()
+            .where((value) => value > 0 && value <= 60)
+            .toSet()
+            .toList(growable: false)
+          ..sort((left, right) => right.compareTo(left));
     return values.isEmpty ? const [30, 14, 7, 3, 1] : values;
   }
 

--- a/mobile/befam/pubspec.lock
+++ b/mobile/befam/pubspec.lock
@@ -1018,6 +1018,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.28"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:

--- a/mobile/befam/pubspec.yaml
+++ b/mobile/befam/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   image_picker: ^1.2.0
   pdf: ^3.11.3
   printing: ^5.14.2
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary\n- keep Billing manager checkout UI VNPay-only with dedicated VNPay pre-checkout form\n- enforce upgrade-only checkout while current paid subscription is active/grace\n- prevent early entitlement switch during pending VNPay checkout\n- apply purchased plan from transaction planCode only after successful VNPay callback\n- add stale pending timeout sweep and audit markers\n- sanitize webhook payload persistence to reduce sensitive data retention\n- fix billing polling refresh loop by using silent refresh and in-flight guard\n\n## Notes\n- card backend routes are kept for backward compatibility\n- VNPay flow remains callback-driven for final payment confirmation