### PR TITLE
fix(billing): allow non-admin clan members to read entitlement

### DIFF
--- a/firebase/functions/src/billing/callables.ts
+++ b/firebase/functions/src/billing/callables.ts
@@ -201,7 +201,6 @@ export const resolveBillingEntitlement = onCall(
       uid: auth.uid,
       token: auth.token,
       data: request.data,
-      requireManageRole: true,
     });
 
     const ensured = await ensureSubscriptionForClan({


### PR DESCRIPTION
## Summary\n- fix permission scope on  so non-admin clan members can still load summary view\n- keep manage actions (checkout/preferences/workspace admin data) role-gated\n\n## Validation\n- npm run lint (functions)\n- npm test (functions contract tests)