### PR TITLE
fix(web): disable wasm dry-run in hosting build

### DIFF
--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -129,6 +129,7 @@ jobs:
           invalid_hosts="${BEFAM_INVALID_CHECKOUT_HOSTS:-example.com}"
           flutter build web \
             --release \
+            --no-wasm-dry-run \
             --dart-define=BEFAM_FIREBASE_FUNCTIONS_REGION="${befam_region}" \
             --dart-define=BEFAM_DEFAULT_TIMEZONE="${befam_timezone}" \
             --dart-define=BEFAM_INVALID_CHECKOUT_HOSTS="${invalid_hosts}"

--- a/.github/workflows/deploy-web-hosting.yml
+++ b/.github/workflows/deploy-web-hosting.yml
@@ -54,6 +54,7 @@ jobs:
           invalid_hosts="${BEFAM_INVALID_CHECKOUT_HOSTS:-example.com}"
           flutter build web \
             --release \
+            --no-wasm-dry-run \
             --dart-define=BEFAM_FIREBASE_FUNCTIONS_REGION="${befam_region}" \
             --dart-define=BEFAM_DEFAULT_TIMEZONE="${befam_timezone}" \
             --dart-define=BEFAM_INVALID_CHECKOUT_HOSTS="${invalid_hosts}"


### PR DESCRIPTION
## Why
Production hosting trả về HTTP 200 nhưng render trắng ở một số môi trường vì Flutter web build tạo thêm build entry rỗng (`{}`) trong `flutter_bootstrap.js`.

## Change
- thêm `--no-wasm-dry-run` vào bước build web trong:
  - `.github/workflows/deploy-web-hosting.yml`
  - `.github/workflows/branch-ci.yml`

## Result
Bundle web chỉ còn build entry hợp lệ `dart2js`, tránh việc bootstrap chọn nhầm entry rỗng gây trắng trang.
