### PR TITLE
fix(hosting): stop immutable caching for Flutter entrypoint files

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -44,7 +44,61 @@
         ]
       },
       {
-        "source": "**/*.@(js|css|png|jpg|jpeg|gif|svg|woff|woff2|ttf)",
+        "source": "/flutter_bootstrap.js",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/main.dart.js",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/flutter.js",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/flutter_service_worker.js",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/manifest.json",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      },
+      {
+        "source": "/icons/**",
         "headers": [
           {
             "key": "Cache-Control",


### PR DESCRIPTION
## Root cause
Browser cache was serving stale Flutter entrypoint files (`flutter_bootstrap.js`, `main.dart.js`, etc.) from disk cache because Hosting headers applied `immutable` to all JS/CSS files.

## Fix
Update Firebase Hosting headers in `firebase.json`:
- keep `no-cache` for app entry files:
  - `/index.html`
  - `/flutter_bootstrap.js`
  - `/main.dart.js`
  - `/flutter.js`
  - `/flutter_service_worker.js`
  - `/manifest.json`
- keep long-lived immutable caching only for static assets:
  - `/assets/**`
  - `/icons/**`

## Expected outcome
New deployments propagate correctly without users being stuck on stale JS bundles.
