### PR TITLE
feat: complete GOV-003/004/005 scholarship governance workflow

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -409,7 +409,7 @@ service cloud.firestore {
     match /scholarshipApprovalLogs/{logId} {
       allow read: if
         hasClanAccess(resource.data.clanId) &&
-        (isClanSettingsAdmin() || isScholarshipCouncilHead());
+        (isClanAdmin() || isScholarshipCouncilHead());
       allow write: if false;
     }
 

--- a/firebase/functions/src/governance/callables.ts
+++ b/firebase/functions/src/governance/callables.ts
@@ -52,95 +52,126 @@ export const assignGovernanceRole = onCall(
     const nextRole = requireSupportedRole(request.data, 'role');
     const reason = stringOrNull((request.data as Record<string, unknown>)?.reason);
 
-    const memberSnapshot = await membersCollection.doc(memberId).get();
-    if (!memberSnapshot.exists || memberSnapshot.data() == null) {
-      throw new HttpsError('not-found', 'Target member was not found.');
-    }
-    const member = memberSnapshot.data() as MemberRecord;
-    const clanId = stringOrNull(member.clanId);
-    if (clanId == null) {
-      throw new HttpsError(
-        'failed-precondition',
-        'Target member does not belong to a clan context.',
-      );
-    }
-    ensureClanAccess(auth.token, clanId);
+    const assignmentResult = await db.runTransaction(async (transaction) => {
+      const memberRef = membersCollection.doc(memberId);
+      const memberSnapshot = await transaction.get(memberRef);
+      if (!memberSnapshot.exists || memberSnapshot.data() == null) {
+        throw new HttpsError('not-found', 'Target member was not found.');
+      }
 
-    const previousRole = stringOrNull(member.primaryRole)?.toUpperCase() ?? GOVERNANCE_ROLES.member;
-
-    if (
-      nextRole === GOVERNANCE_ROLES.scholarshipCouncilHead &&
-      previousRole !== GOVERNANCE_ROLES.scholarshipCouncilHead
-    ) {
-      const councilSnapshot = await membersCollection
-        .where('clanId', '==', clanId)
-        .where('primaryRole', '==', GOVERNANCE_ROLES.scholarshipCouncilHead)
-        .limit(4)
-        .get();
-      const activeSeats = councilSnapshot.docs.filter((doc) => {
-        const status = stringOrNull((doc.data() as MemberRecord).status)?.toLowerCase();
-        return status == null || status === 'active';
-      }).length;
-      if (activeSeats >= 3) {
+      const member = memberSnapshot.data() as MemberRecord;
+      const clanId = stringOrNull(member.clanId);
+      if (clanId == null) {
         throw new HttpsError(
           'failed-precondition',
-          'Scholarship Council Head seats are full (max 3 active).',
+          'Target member does not belong to a clan context.',
         );
       }
-    }
+      ensureClanAccess(auth.token, clanId);
 
-    await membersCollection.doc(memberId).set(
-      {
-        primaryRole: nextRole,
-        updatedAt: FieldValue.serverTimestamp(),
-        updatedBy: actorMemberId,
-      },
-      { merge: true },
-    );
+      const previousRole =
+        stringOrNull(member.primaryRole)?.toUpperCase() ?? GOVERNANCE_ROLES.member;
+      const isRoleChanged = previousRole !== nextRole;
+      if (!isRoleChanged) {
+        return {
+          memberId,
+          clanId,
+          previousRole,
+          nextRole,
+          status: 'unchanged' as const,
+        };
+      }
 
-    const assignmentRef = roleAssignmentsCollection.doc();
-    await assignmentRef.set({
-      id: assignmentRef.id,
-      clanId,
-      memberId,
-      previousRole,
-      nextRole,
-      actorMemberId,
-      actorRole: tokenPrimaryRole(auth.token),
-      reason,
-      createdAt: FieldValue.serverTimestamp(),
-    });
+      const isActiveMember = isActiveStatus(member.status);
+      const isSeatTransition = (
+        previousRole === GOVERNANCE_ROLES.scholarshipCouncilHead ||
+        nextRole === GOVERNANCE_ROLES.scholarshipCouncilHead
+      );
 
-    const auditRef = auditLogsCollection.doc();
-    await auditRef.set({
-      id: auditRef.id,
-      clanId,
-      action: 'governance_role_assigned',
-      entityType: 'member',
-      entityId: memberId,
-      uid: auth.uid,
-      memberId: actorMemberId,
-      before: { primaryRole: previousRole },
-      after: { primaryRole: nextRole },
-      reason,
-      createdAt: FieldValue.serverTimestamp(),
+      if (isSeatTransition && isActiveMember) {
+        const councilSnapshot = await transaction.get(
+          membersCollection
+            .where('clanId', '==', clanId)
+            .where('primaryRole', '==', GOVERNANCE_ROLES.scholarshipCouncilHead),
+        );
+
+        const activeSeatCount = councilSnapshot.docs.filter((doc) => {
+          return isActiveStatus((doc.data() as MemberRecord).status);
+        }).length;
+
+        const isCurrentlySeatHolder = previousRole === GOVERNANCE_ROLES.scholarshipCouncilHead;
+        const isNextSeatHolder = nextRole === GOVERNANCE_ROLES.scholarshipCouncilHead;
+        const projectedSeatCount = activeSeatCount + (
+          isNextSeatHolder ? 1 : 0
+        ) - (
+          isCurrentlySeatHolder ? 1 : 0
+        );
+
+        if (projectedSeatCount > 3) {
+          throw new HttpsError(
+            'failed-precondition',
+            'Scholarship Council Head seats are full. Maximum 3 active seats are allowed.',
+          );
+        }
+      }
+
+      transaction.set(
+        memberRef,
+        {
+          primaryRole: nextRole,
+          updatedAt: FieldValue.serverTimestamp(),
+          updatedBy: actorMemberId,
+        },
+        { merge: true },
+      );
+
+      const assignmentRef = roleAssignmentsCollection.doc();
+      transaction.set(assignmentRef, {
+        id: assignmentRef.id,
+        clanId,
+        memberId,
+        previousRole,
+        nextRole,
+        actorMemberId,
+        actorRole: tokenPrimaryRole(auth.token),
+        reason,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+
+      const auditRef = auditLogsCollection.doc();
+      transaction.set(auditRef, {
+        id: auditRef.id,
+        clanId,
+        action: 'governance_role_assigned',
+        entityType: 'member',
+        entityId: memberId,
+        uid: auth.uid,
+        memberId: actorMemberId,
+        before: { primaryRole: previousRole },
+        after: { primaryRole: nextRole },
+        reason,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+
+      return {
+        memberId,
+        clanId,
+        previousRole,
+        nextRole,
+        status: 'updated' as const,
+      };
     });
 
     logInfo('assignGovernanceRole succeeded', {
       uid: auth.uid,
-      clanId,
-      memberId,
-      previousRole,
-      nextRole,
+      clanId: assignmentResult.clanId,
+      memberId: assignmentResult.memberId,
+      previousRole: assignmentResult.previousRole,
+      nextRole: assignmentResult.nextRole,
+      status: assignmentResult.status,
     });
 
-    return {
-      memberId,
-      clanId,
-      previousRole,
-      nextRole,
-      status: 'updated',
-    };
+    return assignmentResult;
   },
 );
 
@@ -265,6 +296,11 @@ function requireSupportedRole(data: unknown, key: string): string {
     );
   }
   return value;
+}
+
+function isActiveStatus(value: unknown): boolean {
+  const normalized = stringOrNull(value)?.toLowerCase();
+  return normalized == null || normalized === 'active';
 }
 
 function normalizeFirestoreValue(value: unknown): unknown {

--- a/firebase/functions/src/scholarship/callables.ts
+++ b/firebase/functions/src/scholarship/callables.ts
@@ -88,7 +88,6 @@ export const reviewScholarshipSubmission = onCall(
     const councilSnapshot = await membersCollection
       .where('clanId', '==', clanId)
       .where('primaryRole', '==', GOVERNANCE_ROLES.scholarshipCouncilHead)
-      .limit(6)
       .get();
     const activeCouncilMemberIds = councilSnapshot.docs
       .filter((doc) => {
@@ -103,10 +102,10 @@ export const reviewScholarshipSubmission = onCall(
         'Only active Scholarship Council Heads can review submissions.',
       );
     }
-    if (activeCouncilMemberIds.length > 3) {
+    if (activeCouncilMemberIds.length !== 3) {
       throw new HttpsError(
         'failed-precondition',
-        'Council configuration invalid: more than 3 active council heads.',
+        'Council configuration invalid: exactly 3 active council heads are required for 2-of-3 voting.',
       );
     }
 
@@ -158,6 +157,13 @@ export const reviewScholarshipSubmission = onCall(
       } else if (rejectionCount >= 2) {
         nextStatus = 'rejected';
       }
+      const finalDecisionReason = nextStatus === 'pending'
+        ? null
+        : resolveFinalDecisionReason({
+          status: nextStatus,
+          latestNote: note,
+          votes: nextVotes,
+        });
 
       transaction.set(
         submissionRef,
@@ -166,8 +172,8 @@ export const reviewScholarshipSubmission = onCall(
           approvalCount,
           rejectionCount,
           status: nextStatus,
-          finalDecisionReason: nextStatus === 'pending' ? null : note ?? null,
-          reviewNote: nextStatus === 'pending' ? null : note ?? null,
+          finalDecisionReason,
+          reviewNote: finalDecisionReason,
           reviewedBy: nextStatus === 'pending' ? null : memberId,
           reviewedAt: nextStatus === 'pending' ? null : FieldValue.serverTimestamp(),
           updatedAt: FieldValue.serverTimestamp(),
@@ -193,7 +199,7 @@ export const reviewScholarshipSubmission = onCall(
           decision: nextStatus,
           actorMemberId: memberId,
           actorRole,
-          note,
+          note: finalDecisionReason,
         });
       }
 
@@ -284,6 +290,36 @@ function normalizeVotes(input: SubmissionRecord['approvalVotes']): Array<{
     });
   }
   return votes;
+}
+
+function resolveFinalDecisionReason(input: {
+  status: 'approved' | 'rejected';
+  latestNote: string | null;
+  votes: Array<{
+    memberId: string;
+    decision: 'approve' | 'reject';
+    createdAt: string;
+    note: string | null;
+  }>;
+}): string | null {
+  const latest = stringOrNull(input.latestNote);
+  if (latest != null) {
+    return latest;
+  }
+
+  const decision = input.status === 'approved' ? 'approve' : 'reject';
+  for (let index = input.votes.length - 1; index >= 0; index -= 1) {
+    const vote = input.votes[index];
+    if (vote.decision !== decision) {
+      continue;
+    }
+    const resolved = stringOrNull(vote.note);
+    if (resolved != null) {
+      return resolved;
+    }
+  }
+
+  return null;
 }
 
 function requireNonEmptyString(data: unknown, key: string): string {

--- a/mobile/befam/lib/core/services/debug_genealogy_store.dart
+++ b/mobile/befam/lib/core/services/debug_genealogy_store.dart
@@ -162,6 +162,86 @@ class DebugGenealogyStore {
         isMinor: false,
         authUid: null,
       ),
+      'member_council_001': const MemberProfile(
+        id: 'member_council_001',
+        clanId: clanId,
+        branchId: 'branch_demo_001',
+        fullName: 'Phạm Thành Nam',
+        normalizedFullName: 'phạm thành nam',
+        nickName: 'Nam',
+        gender: 'male',
+        birthDate: '1986-03-18',
+        deathDate: null,
+        phoneE164: '+84901111001',
+        email: 'pham.thanh.nam@befam.vn',
+        addressText: 'Đà Nẵng, Việt Nam',
+        jobTitle: 'Kỹ sư xây dựng',
+        avatarUrl: null,
+        bio:
+            'Thành viên hội đồng học bổng phụ trách đánh giá hồ sơ khối kỹ thuật.',
+        socialLinks: MemberSocialLinks(),
+        parentIds: [],
+        childrenIds: [],
+        spouseIds: [],
+        generation: 8,
+        primaryRole: 'SCHOLARSHIP_COUNCIL_HEAD',
+        status: 'active',
+        isMinor: false,
+        authUid: 'debug:+84901111001',
+      ),
+      'member_council_002': const MemberProfile(
+        id: 'member_council_002',
+        clanId: clanId,
+        branchId: 'branch_demo_002',
+        fullName: 'Nguyễn Thu Hà',
+        normalizedFullName: 'nguyễn thu hà',
+        nickName: 'Hà',
+        gender: 'female',
+        birthDate: '1988-09-11',
+        deathDate: null,
+        phoneE164: '+84901111002',
+        email: 'nguyen.thu.ha@befam.vn',
+        addressText: 'Huế, Việt Nam',
+        jobTitle: 'Giáo viên trung học',
+        avatarUrl: null,
+        bio: 'Thành viên hội đồng học bổng phụ trách xét tiêu chí học thuật.',
+        socialLinks: MemberSocialLinks(),
+        parentIds: [],
+        childrenIds: [],
+        spouseIds: [],
+        generation: 8,
+        primaryRole: 'SCHOLARSHIP_COUNCIL_HEAD',
+        status: 'active',
+        isMinor: false,
+        authUid: 'debug:+84901111002',
+      ),
+      'member_council_003': const MemberProfile(
+        id: 'member_council_003',
+        clanId: clanId,
+        branchId: 'branch_demo_003',
+        fullName: 'Lê Quốc Bảo',
+        normalizedFullName: 'lê quốc bảo',
+        nickName: 'Bảo',
+        gender: 'male',
+        birthDate: '1985-12-05',
+        deathDate: null,
+        phoneE164: '+84901111003',
+        email: 'le.quoc.bao@befam.vn',
+        addressText: 'Quảng Nam, Việt Nam',
+        jobTitle: 'Chuyên viên quản lý đất đai xã',
+        avatarUrl: null,
+        bio:
+            'Thành viên hội đồng học bổng phụ trách thẩm định hồ sơ minh chứng.',
+        socialLinks: MemberSocialLinks(),
+        parentIds: [],
+        childrenIds: [],
+        spouseIds: [],
+        generation: 8,
+        primaryRole: 'SCHOLARSHIP_COUNCIL_HEAD',
+        status: 'active',
+        isMinor: false,
+        authUid: 'debug:+84901111003',
+      ),
     };
     final branches = <String, BranchProfile>{
       'branch_demo_001': const BranchProfile(
@@ -794,9 +874,7 @@ void _seedProductionLikeLineages({
 
       final maleFullName = config.maleNames[generation - 1];
       final femaleFullName = config.femaleNames[generation - 1];
-      final maleRole = config.key == 'a' && generation == 7
-          ? 'SCHOLARSHIP_COUNCIL_HEAD'
-          : (generation == 8 ? 'BRANCH_ADMIN' : 'MEMBER');
+      final maleRole = generation == 8 ? 'BRANCH_ADMIN' : 'MEMBER';
 
       members[maleId] = MemberProfile(
         id: maleId,

--- a/mobile/befam/lib/features/scholarship/presentation/scholarship_controller.dart
+++ b/mobile/befam/lib/features/scholarship/presentation/scholarship_controller.dart
@@ -96,6 +96,7 @@ class ScholarshipController extends ChangeNotifier {
   bool get canSubmitAchievements => permissions.canSubmitSubmissions;
   bool get canReviewSubmissions => permissions.canReviewQueue;
   bool get canViewApprovalHistory => permissions.canViewApprovalHistory;
+  bool get isCouncilVotingConfigured => _councilHeadMemberIds.length == 3;
 
   bool hasCurrentReviewerVoted(AchievementSubmission submission) {
     final memberId = _session.memberId?.trim() ?? '';

--- a/mobile/befam/lib/features/scholarship/presentation/scholarship_workspace_page.dart
+++ b/mobile/befam/lib/features/scholarship/presentation/scholarship_workspace_page.dart
@@ -445,6 +445,17 @@ class _ScholarshipWorkspacePageState extends State<ScholarshipWorkspacePage> {
       );
       return;
     }
+    if (errorHint.contains('council_configuration_invalid') ||
+        errorHint.contains('council configuration invalid') ||
+        errorHint.contains('exactly 3 active council heads')) {
+      _showResultSnackBar(
+        l10n.pick(
+          vi: 'Hội đồng học bổng phải có đúng 3 Trưởng hội đồng đang hoạt động để áp dụng quy tắc 2/3.',
+          en: 'Scholarship council must have exactly 3 active heads for the 2-of-3 workflow.',
+        ),
+      );
+      return;
+    }
 
     _showResultSnackBar(
       l10n.pick(
@@ -768,6 +779,18 @@ class _ScholarshipWorkspacePageState extends State<ScholarshipWorkspacePage> {
                                       en: 'Scholarship submissions are finalized automatically at 2 approvals (or 2 rejections).',
                                     ),
                                   ),
+                                  if (!_controller
+                                      .isCouncilVotingConfigured) ...[
+                                    const SizedBox(height: 4),
+                                    Text(
+                                      l10n.pick(
+                                        vi: 'Cấu hình hiện tại chưa hợp lệ cho quy tắc 2/3. Cần đúng 3 Trưởng hội đồng hoạt động.',
+                                        en: 'Current council setup is not valid for the 2-of-3 rule. Exactly 3 active council heads are required.',
+                                      ),
+                                      style: theme.textTheme.bodySmall
+                                          ?.copyWith(color: colorScheme.error),
+                                    ),
+                                  ],
                                 ],
                               ),
                             ),
@@ -1062,6 +1085,13 @@ class _ScholarshipWorkspacePageState extends State<ScholarshipWorkspacePage> {
                                       en: 'Your session cannot review scholarship submissions.',
                                     ),
                                   )
+                                : !_controller.isCouncilVotingConfigured
+                                ? _InlineEmpty(
+                                    message: l10n.pick(
+                                      vi: 'Hội đồng học bổng phải có đúng 3 Trưởng hội đồng đang hoạt động trước khi bỏ phiếu.',
+                                      en: 'Scholarship council must have exactly 3 active heads before voting.',
+                                    ),
+                                  )
                                 : reviewQueue.isEmpty
                                 ? _InlineEmpty(
                                     message: l10n.pick(
@@ -1120,6 +1150,8 @@ class _ScholarshipWorkspacePageState extends State<ScholarshipWorkspacePage> {
                                                         onPressed:
                                                             _controller
                                                                     .isReviewing ||
+                                                                !_controller
+                                                                    .isCouncilVotingConfigured ||
                                                                 _controller
                                                                     .hasCurrentReviewerVoted(
                                                                       submission,
@@ -1153,6 +1185,8 @@ class _ScholarshipWorkspacePageState extends State<ScholarshipWorkspacePage> {
                                                         onPressed:
                                                             _controller
                                                                     .isReviewing ||
+                                                                !_controller
+                                                                    .isCouncilVotingConfigured ||
                                                                 _controller
                                                                     .hasCurrentReviewerVoted(
                                                                       submission,
@@ -1220,10 +1254,24 @@ class _ScholarshipWorkspacePageState extends State<ScholarshipWorkspacePage> {
                                               '${_approvalActionLabel(context, log.action)} • ${_approvalDecisionLabel(context, log.decision)}',
                                             ),
                                             subtitle: Text(
-                                              l10n.pick(
-                                                vi: 'Hồ sơ ${log.submissionId} • ${_controller.memberName(log.actorMemberId)}',
-                                                en: 'Submission ${log.submissionId} • ${_controller.memberName(log.actorMemberId)}',
-                                              ),
+                                              [
+                                                l10n.pick(
+                                                  vi: 'Hồ sơ ${log.submissionId} • ${_controller.memberName(log.actorMemberId)}',
+                                                  en: 'Submission ${log.submissionId} • ${_controller.memberName(log.actorMemberId)}',
+                                                ),
+                                                _formatApprovalLogTimestamp(
+                                                  context,
+                                                  log.createdAtIso,
+                                                ),
+                                                if (log.note
+                                                        ?.trim()
+                                                        .isNotEmpty ==
+                                                    true)
+                                                  l10n.pick(
+                                                    vi: 'Ghi chú: ${log.note}',
+                                                    en: 'Note: ${log.note}',
+                                                  ),
+                                              ].join('\n'),
                                             ),
                                           ),
                                       ],
@@ -1419,6 +1467,24 @@ class ScholarshipProgramDetailPage extends StatelessWidget {
                                             if (controller
                                                     .canReviewSubmissions &&
                                                 submission.isPending) ...[
+                                              if (!controller
+                                                  .isCouncilVotingConfigured) ...[
+                                                const SizedBox(height: 4),
+                                                Text(
+                                                  l10n.pick(
+                                                    vi: 'Tạm khóa bỏ phiếu vì hội đồng chưa đủ 3 Trưởng hội đồng hoạt động.',
+                                                    en: 'Voting is temporarily locked because the council does not have 3 active heads.',
+                                                  ),
+                                                  style: theme
+                                                      .textTheme
+                                                      .bodySmall
+                                                      ?.copyWith(
+                                                        color: theme
+                                                            .colorScheme
+                                                            .error,
+                                                      ),
+                                                ),
+                                              ],
                                               const SizedBox(height: 10),
                                               Row(
                                                 children: [
@@ -1429,9 +1495,13 @@ class ScholarshipProgramDetailPage extends StatelessWidget {
                                                       ),
                                                       onPressed:
                                                           controller
-                                                              .hasCurrentReviewerVoted(
-                                                                submission,
-                                                              )
+                                                                  .isReviewing ||
+                                                              !controller
+                                                                  .isCouncilVotingConfigured ||
+                                                              controller
+                                                                  .hasCurrentReviewerVoted(
+                                                                    submission,
+                                                                  )
                                                           ? null
                                                           : () {
                                                               onReviewSubmission(
@@ -1456,9 +1526,13 @@ class ScholarshipProgramDetailPage extends StatelessWidget {
                                                       ),
                                                       onPressed:
                                                           controller
-                                                              .hasCurrentReviewerVoted(
-                                                                submission,
-                                                              )
+                                                                  .isReviewing ||
+                                                              !controller
+                                                                  .isCouncilVotingConfigured ||
+                                                              controller
+                                                                  .hasCurrentReviewerVoted(
+                                                                    submission,
+                                                                  )
                                                           ? null
                                                           : () {
                                                               onReviewSubmission(
@@ -2676,6 +2750,20 @@ String _approvalDecisionLabel(BuildContext context, String? decision) {
     null || '' => l10n.pick(vi: 'không có', en: 'n/a'),
     _ => decision!.toUpperCase(),
   };
+}
+
+String _formatApprovalLogTimestamp(BuildContext context, String value) {
+  final l10n = context.l10n;
+  final parsed = DateTime.tryParse(value)?.toLocal();
+  if (parsed == null) {
+    return l10n.pick(vi: 'Thời gian: không xác định', en: 'Time: unknown');
+  }
+
+  final twoDigits = (int number) => number.toString().padLeft(2, '0');
+  final rendered =
+      '${twoDigits(parsed.day)}/${twoDigits(parsed.month)}/${parsed.year} '
+      '${twoDigits(parsed.hour)}:${twoDigits(parsed.minute)}';
+  return l10n.pick(vi: 'Thời gian: $rendered', en: 'Time: $rendered');
 }
 
 String? _nullableText(String value) {

--- a/mobile/befam/lib/features/scholarship/services/debug_scholarship_repository.dart
+++ b/mobile/befam/lib/features/scholarship/services/debug_scholarship_repository.dart
@@ -92,16 +92,7 @@ class DebugScholarshipRepository implements ScholarshipRepository {
         if (member.clanId == clanId) member.id: member.fullName,
     };
 
-    final councilHeadMemberIds = _genealogyStore.members.values
-        .where(
-          (member) =>
-              member.clanId == clanId &&
-              member.primaryRole.trim().toUpperCase() ==
-                  GovernanceRoles.scholarshipCouncilHead &&
-              member.status.trim().toLowerCase() == 'active',
-        )
-        .map((member) => member.id)
-        .toList(growable: false);
+    final councilHeadMemberIds = _activeCouncilHeadMemberIds(clanId);
 
     final approvalLogs = _store.approvalLogs.values
         .where((entry) => entry.clanId == clanId)
@@ -365,6 +356,18 @@ class DebugScholarshipRepository implements ScholarshipRepository {
         ScholarshipRepositoryErrorCode.permissionDenied,
       );
     }
+    final councilHeadMemberIds = _activeCouncilHeadMemberIds(clanId);
+    if (!councilHeadMemberIds.contains(reviewerMemberId)) {
+      throw const ScholarshipRepositoryException(
+        ScholarshipRepositoryErrorCode.permissionDenied,
+      );
+    }
+    if (councilHeadMemberIds.length != 3) {
+      throw const ScholarshipRepositoryException(
+        ScholarshipRepositoryErrorCode.validationFailed,
+        'council_configuration_invalid',
+      );
+    }
 
     final existing = _store.submissions[submissionId];
     if (existing == null || existing.clanId != clanId) {
@@ -454,6 +457,19 @@ class DebugScholarshipRepository implements ScholarshipRepository {
     }
 
     return updated;
+  }
+
+  List<String> _activeCouncilHeadMemberIds(String clanId) {
+    return _genealogyStore.members.values
+        .where(
+          (member) =>
+              member.clanId == clanId &&
+              member.primaryRole.trim().toUpperCase() ==
+                  GovernanceRoles.scholarshipCouncilHead &&
+              member.status.trim().toLowerCase() == 'active',
+        )
+        .map((member) => member.id)
+        .toList(growable: false);
   }
 }
 

--- a/mobile/befam/lib/features/scholarship/services/firebase_scholarship_repository.dart
+++ b/mobile/befam/lib/features/scholarship/services/firebase_scholarship_repository.dart
@@ -117,8 +117,12 @@ class FirebaseScholarshipRepository implements ScholarshipRepository {
 
     final councilHeadMemberIds = results[3].docs
         .where((doc) {
-          final role = (doc.data()['primaryRole'] as String?)?.trim().toUpperCase();
-          final status = (doc.data()['status'] as String?)?.trim().toLowerCase();
+          final role = (doc.data()['primaryRole'] as String?)
+              ?.trim()
+              .toUpperCase();
+          final status = (doc.data()['status'] as String?)
+              ?.trim()
+              .toLowerCase();
           return role == GovernanceRoles.scholarshipCouncilHead &&
               (status == null || status.isEmpty || status == 'active');
         })
@@ -444,6 +448,14 @@ class FirebaseScholarshipRepository implements ScholarshipRepository {
         throw ScholarshipRepositoryException(
           ScholarshipRepositoryErrorCode.validationFailed,
           'duplicate_vote',
+        );
+      }
+      final normalizedMessage = (error.message ?? '').toLowerCase();
+      if (error.code == 'failed-precondition' &&
+          normalizedMessage.contains('exactly 3 active council heads')) {
+        throw ScholarshipRepositoryException(
+          ScholarshipRepositoryErrorCode.validationFailed,
+          'council_configuration_invalid',
         );
       }
       if (error.code == 'permission-denied') {

--- a/mobile/befam/test/features/scholarship/scholarship_repository_test.dart
+++ b/mobile/befam/test/features/scholarship/scholarship_repository_test.dart
@@ -7,6 +7,7 @@ import 'package:befam/features/scholarship/models/achievement_submission_draft.d
 import 'package:befam/features/scholarship/models/award_level_draft.dart';
 import 'package:befam/features/scholarship/models/scholarship_program_draft.dart';
 import 'package:befam/features/scholarship/services/debug_scholarship_repository.dart';
+import 'package:befam/features/scholarship/services/scholarship_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -56,6 +57,7 @@ void main() {
     expect(snapshot.programs, isNotEmpty);
     expect(snapshot.awardLevels, isNotEmpty);
     expect(snapshot.submissions, isNotEmpty);
+    expect(snapshot.councilHeadMemberIds, hasLength(3));
     expect(
       snapshot.submissions.any((submission) => submission.status == 'pending'),
       isTrue,
@@ -221,5 +223,56 @@ void main() {
     expect(rejected.status, 'rejected');
     expect(rejected.rejectionCount, 2);
     expect(rejected.reviewNote, 'Second rejection vote.');
+
+    final refreshed = await repository.loadWorkspace(session: clanAdminSession);
+    final rejectedLogs = refreshed.approvalLogs
+        .where((entry) => entry.submissionId == submissionForRejection.id)
+        .toList(growable: false);
+    expect(rejectedLogs.where((entry) => entry.action == 'vote').length, 2);
+    expect(
+      rejectedLogs.where((entry) => entry.action == 'finalized').length,
+      1,
+    );
+    expect(
+      rejectedLogs.firstWhere((entry) => entry.action == 'finalized').note,
+      'Second rejection vote.',
+    );
+  });
+
+  test('prevents duplicate votes by the same council head', () async {
+    final repository = DebugScholarshipRepository.seeded();
+    final councilHead = buildCouncilSession(
+      memberId: 'member_council_001',
+      phoneE164: '+84901111001',
+    );
+    final snapshot = await repository.loadWorkspace(
+      session: buildClanAdminSession(),
+    );
+    final pending = snapshot.submissions.firstWhere(
+      (submission) => submission.status == 'pending',
+    );
+
+    await repository.reviewSubmission(
+      session: councilHead,
+      submissionId: pending.id,
+      approved: true,
+      reviewNote: 'Initial vote.',
+    );
+
+    expect(
+      () => repository.reviewSubmission(
+        session: councilHead,
+        submissionId: pending.id,
+        approved: true,
+        reviewNote: 'Duplicate vote.',
+      ),
+      throwsA(
+        isA<ScholarshipRepositoryException>().having(
+          (error) => error.message,
+          'message',
+          'duplicate_vote',
+        ),
+      ),
+    );
   });
 }


### PR DESCRIPTION
## Summary
- enforce Scholarship Council Head assignment cap with transaction-safe validation (max 3 active seats)
- enforce 2-of-3 scholarship voting with strict council configuration checks and duplicate-vote prevention
- persist clearer final decision reason and append-only approval activity logs for audit visibility
- align Firestore read permissions for scholarship approval logs with authorized governance roles
- sync debug/local datasets and scholarship UI handling to reflect production voting constraints

## Testing
- npm run lint (firebase/functions)
- flutter test test/features/scholarship/scholarship_repository_test.dart test/features/scholarship/scholarship_flow_widget_test.dart test/features/security/security_permissions_test.dart

Closes #230
Closes #231
Closes #232