### PR TITLE
fix(web): add Firebase web options to prevent blank bootstrap screen

### DIFF
--- a/mobile/befam/lib/app/bootstrap/app_bootstrap.dart
+++ b/mobile/befam/lib/app/bootstrap/app_bootstrap.dart
@@ -57,12 +57,12 @@ class AppBootstrap {
           );
         } catch (error, stackTrace) {
           AppLogger.error('Firebase bootstrap failed.', error, stackTrace);
+          final fallbackOptions = _resolveFallbackOptions();
 
           return AppBootstrapResult(
             status: FirebaseSetupStatus.failed(
-              projectId: DefaultFirebaseOptions.currentPlatform.projectId,
-              storageBucket:
-                  DefaultFirebaseOptions.currentPlatform.storageBucket ?? '',
+              projectId: fallbackOptions.projectId,
+              storageBucket: fallbackOptions.storageBucket ?? '',
               errorMessage: error.toString(),
             ),
             crashReportingService: const CrashReportingService.disabled(),
@@ -70,5 +70,13 @@ class AppBootstrap {
         }
       },
     );
+  }
+
+  static FirebaseOptions _resolveFallbackOptions() {
+    try {
+      return DefaultFirebaseOptions.currentPlatform;
+    } catch (_) {
+      return DefaultFirebaseOptions.android;
+    }
   }
 }

--- a/mobile/befam/lib/firebase_options.dart
+++ b/mobile/befam/lib/firebase_options.dart
@@ -17,10 +17,7 @@ import 'package:flutter/foundation.dart'
 class DefaultFirebaseOptions {
   static FirebaseOptions get currentPlatform {
     if (kIsWeb) {
-      throw UnsupportedError(
-        'DefaultFirebaseOptions have not been configured for web - '
-        'you can reconfigure this by running the FlutterFire CLI again.',
-      );
+      return web;
     }
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
@@ -64,5 +61,15 @@ class DefaultFirebaseOptions {
     projectId: 'be-fam-3ab23',
     storageBucket: 'be-fam-3ab23.firebasestorage.app',
     iosBundleId: 'com.familyclanapp.befam',
+  );
+
+  static const FirebaseOptions web = FirebaseOptions(
+    apiKey: 'AIzaSyAlgXje7988QYRaw9nMfDV1bhdUunp9iLA',
+    appId: '1:1036543448581:web:f77cd11f4b98df29422e6c',
+    messagingSenderId: '1036543448581',
+    projectId: 'be-fam-3ab23',
+    authDomain: 'be-fam-3ab23.firebaseapp.com',
+    storageBucket: 'be-fam-3ab23.firebasestorage.app',
+    measurementId: 'G-WWK58KXM3D',
   );
 }


### PR DESCRIPTION
## Root cause
Web app crashed at startup because `DefaultFirebaseOptions.currentPlatform` threw `UnsupportedError` for web.

## Changes
- add Firebase Web app config to `mobile/befam/lib/firebase_options.dart`
- harden bootstrap failure fallback in `mobile/befam/lib/app/bootstrap/app_bootstrap.dart` so fallback options resolution does not throw

## Local validation
- `flutter run -d chrome --web-port 4300`
- Startup log now shows: `Firebase bootstrap ready for be-fam-3ab23.`
- No `DefaultFirebaseOptions have not been configured for web` crash
