### PR TITLE
fix(billing): show subscription from user scope

### DIFF
--- a/firebase/functions/src/billing/callables.ts
+++ b/firebase/functions/src/billing/callables.ts
@@ -246,6 +246,7 @@ export const resolveBillingEntitlement = onCall(
   { region: APP_REGION },
   async (request) => {
     const auth = requireAuth(request);
+    const now = new Date();
     const scope = await resolveBillingScopeContext({
       uid: auth.uid,
       token: auth.token,
@@ -256,17 +257,26 @@ export const resolveBillingEntitlement = onCall(
       clanId: scope.clanId,
       ownerUid: scope.ownerUid,
       actorUid: auth.uid,
+      now,
+    });
+    const resolvedMemberCount = await resolveWorkspaceMemberCount({
+      scope,
+      fallbackMemberCount: ensured.memberCount,
+      now,
     });
     const entitlement = buildEntitlementFromSubscription(ensured.subscription);
 
     return {
       clanId: scope.clanId,
       scope: serializeBillingScope(scope),
-      subscription: serializeSubscription(ensured.subscription),
+      subscription: serializeSubscription({
+        ...ensured.subscription,
+        memberCount: resolvedMemberCount,
+      }),
       entitlement,
       pricingTiers: BILLING_PRICING_TIERS,
       settings: ensured.settings,
-      memberCount: ensured.memberCount,
+      memberCount: resolvedMemberCount,
     };
   },
 );
@@ -275,6 +285,7 @@ export const loadBillingWorkspace = onCall(
   { region: APP_REGION },
   async (request) => {
     const auth = requireAuth(request);
+    const now = new Date();
     const scope = await resolveBillingScopeContext({
       uid: auth.uid,
       token: auth.token,
@@ -295,6 +306,12 @@ export const loadBillingWorkspace = onCall(
       clanId: scope.clanId,
       ownerUid: scope.ownerUid,
       actorUid: auth.uid,
+      now,
+    });
+    const resolvedMemberCount = await resolveWorkspaceMemberCount({
+      scope,
+      fallbackMemberCount: ensured.memberCount,
+      now,
     });
     const [transactionsSnapshot, invoicesSnapshot, auditSnapshot] =
       await Promise.all([
@@ -318,12 +335,15 @@ export const loadBillingWorkspace = onCall(
     return {
       clanId: scope.clanId,
       scope: serializeBillingScope(scope),
-      subscription: serializeSubscription(ensured.subscription),
+      subscription: serializeSubscription({
+        ...ensured.subscription,
+        memberCount: resolvedMemberCount,
+      }),
       entitlement: buildEntitlementFromSubscription(ensured.subscription),
       settings: ensured.settings,
       checkoutFlow: buildCheckoutFlowConfig(runtimeConfig),
       pricingTiers: BILLING_PRICING_TIERS,
-      memberCount: ensured.memberCount,
+      memberCount: resolvedMemberCount,
       transactions: transactionsSnapshot.docs.map((doc) => ({
         id: doc.id,
         ...normalizeFirestoreJson(doc.data()),
@@ -888,6 +908,25 @@ function serializeBillingScope(
     clanStatus: scope.clanStatus,
     viewerIsOwner: scope.viewerIsOwner,
   };
+}
+
+async function resolveWorkspaceMemberCount({
+  scope,
+  fallbackMemberCount,
+  now,
+}: {
+  scope: BillingScopeContext;
+  fallbackMemberCount: number;
+  now: Date;
+}): Promise<number> {
+  if (!isPersonalBillingScope(scope.clanId, scope.ownerUid)) {
+    return fallbackMemberCount;
+  }
+  const policy = await resolveOwnerBillingPolicy({
+    ownerUid: scope.ownerUid,
+    now,
+  });
+  return policy.totalMemberCount;
 }
 
 function isSubscriptionActiveAndValid(

--- a/mobile/befam/lib/features/billing/services/firebase_billing_repository.dart
+++ b/mobile/befam/lib/features/billing/services/firebase_billing_repository.dart
@@ -37,7 +37,7 @@ class FirebaseBillingRepository implements BillingRepository {
   Future<BillingViewerSummary> loadViewerSummary({
     required AuthSession session,
   }) async {
-    final clanId = _sessionClanId(session);
+    final scopeId = _sessionBillingScopeId(session);
     await _ensureSessionDocumentBestEffort(session);
     final result = await _call(
       'resolveBillingEntitlement',
@@ -48,10 +48,10 @@ class FirebaseBillingRepository implements BillingRepository {
     ).map((item) => _parsePricing(_asMap(item))).toList(growable: false);
     final ownerUidFallback = session.uid.trim();
     return BillingViewerSummary(
-      clanId: _readString(map, 'clanId', fallback: clanId),
+      clanId: _readString(map, 'clanId', fallback: scopeId),
       scope: _parseScope(
         _asMap(map['scope']),
-        fallbackClanId: clanId,
+        fallbackClanId: scopeId,
         fallbackOwnerUid: ownerUidFallback,
       ),
       subscription: _parseSubscription(_asMap(map['subscription'])),
@@ -105,7 +105,7 @@ class FirebaseBillingRepository implements BillingRepository {
     String? bankCode,
     String? contactPhone,
   }) async {
-    final clanId = _sessionClanId(session);
+    final scopeId = _sessionBillingScopeId(session);
     final normalizedContactPhone =
         PhoneNumberFormatter.tryParseE164(contactPhone) ?? contactPhone?.trim();
     await _ensureSessionDocumentBestEffort(session);
@@ -128,7 +128,7 @@ class FirebaseBillingRepository implements BillingRepository {
     ).call(_scopePayload(session, payload));
     final map = _asMap(result.data);
     return BillingCheckoutResult(
-      clanId: _readString(map, 'clanId', fallback: clanId),
+      clanId: _readString(map, 'clanId', fallback: scopeId),
       paymentMethod: _readString(map, 'paymentMethod', fallback: paymentMethod),
       planCode: _readString(map, 'planCode', fallback: 'FREE'),
       amountVnd: _readInt(map, 'amountVnd'),
@@ -187,12 +187,8 @@ class FirebaseBillingRepository implements BillingRepository {
     AuthSession session, [
     Map<String, dynamic>? payload,
   ]) {
-    final clanId = (session.clanId ?? '').trim();
     final uid = session.uid.trim();
     final base = <String, dynamic>{...?payload};
-    if (clanId.isNotEmpty) {
-      return <String, dynamic>{'clanId': clanId, ...base};
-    }
     return <String, dynamic>{'ownerUid': uid, ...base};
   }
 
@@ -382,11 +378,7 @@ class FirebaseBillingRepository implements BillingRepository {
     );
   }
 
-  String _sessionClanId(AuthSession session) {
-    final clanId = (session.clanId ?? '').trim();
-    if (clanId.isNotEmpty) {
-      return clanId;
-    }
+  String _sessionBillingScopeId(AuthSession session) {
     final uid = session.uid.trim();
     if (uid.isEmpty) {
       throw const BillingRepositoryException(


### PR DESCRIPTION
## Summary
- fix billing page data source to always resolve subscription by authenticated user scope (ownerUid)
- prevent clan context from overriding current user plan display
- return member count from owner policy for personal scope in billing callables so workspace numbers stay meaningful for owners

## Validation
- flutter analyze
- flutter test test/features/billing/billing_workspace_page_test.dart
- flutter test test/features/billing/billing_repository_test.dart
- npm run lint (firebase/functions)

## Business rule
- plan follows user account
- clan enforcement still follows clan creator/owner plan