### PR TITLE
CI: switch Android artifacts to AAB + local CI-like AAB build target

### DIFF
--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -175,7 +175,7 @@ jobs:
             --dart-define=BEFAM_INVALID_CHECKOUT_HOSTS="${invalid_hosts}" \
             "${optional_firebase_defines[@]}"
 
-      - name: Build Android APK
+      - name: Build Android AAB
         env:
           BEFAM_ALLOW_BUNDLED_FIREBASE_OPTIONS: ${{ vars.BEFAM_ALLOW_BUNDLED_FIREBASE_OPTIONS }}
           BEFAM_FIREBASE_PROJECT_ID: ${{ vars.BEFAM_FIREBASE_PROJECT_ID }}
@@ -237,10 +237,29 @@ jobs:
             export ANDROID_KEYSTORE_PASSWORD="$ANDROID_RELEASE_KEYSTORE_PASSWORD"
             export ANDROID_KEY_ALIAS="$ANDROID_RELEASE_KEY_ALIAS"
             export ANDROID_KEY_PASSWORD="$ANDROID_RELEASE_KEY_PASSWORD"
-            flutter build apk --release "${build_common_args[@]}"
+            flutter build appbundle --release "${build_common_args[@]}"
           else
-            echo "Release signing secrets are unavailable in this CI context. Building debug APK."
-            flutter build apk --debug "${build_common_args[@]}"
+            echo "Release signing secrets are unavailable in this CI context. Generating temporary CI signing key for release AAB."
+            temp_keystore_path="$RUNNER_TEMP/android-ci-release.keystore"
+            temp_keystore_password="android"
+            temp_key_alias="ci-upload"
+            temp_key_password="android"
+            keytool -genkeypair \
+              -v \
+              -storetype PKCS12 \
+              -keystore "$temp_keystore_path" \
+              -storepass "$temp_keystore_password" \
+              -alias "$temp_key_alias" \
+              -keyalg RSA \
+              -keysize 2048 \
+              -validity 3650 \
+              -keypass "$temp_key_password" \
+              -dname "CN=BeFam CI, OU=CI, O=BeFam, L=HCMC, S=HCMC, C=VN"
+            export ANDROID_KEYSTORE_PATH="$temp_keystore_path"
+            export ANDROID_KEYSTORE_PASSWORD="$temp_keystore_password"
+            export ANDROID_KEY_ALIAS="$temp_key_alias"
+            export ANDROID_KEY_PASSWORD="$temp_key_password"
+            flutter build appbundle --release "${build_common_args[@]}"
           fi
 
       - name: Build mobile release image

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -66,7 +66,7 @@ jobs:
           cat <<EOF >> dist/release-notes.md
 
           ## Release artifacts
-          - Android APK: \`befam-${RELEASE_VERSION}-android-release.apk\`
+          - Android AAB: \`befam-${RELEASE_VERSION}-android-release.aab\`
           - iOS IPA: \`befam-${RELEASE_VERSION}-ios-release.ipa\`
           - Mobile builder image: \`ghcr.io/${GITHUB_REPOSITORY_OWNER}/befam-mobile-builder:${RELEASE_TAG}\`
           - Firebase tooling image: \`ghcr.io/${GITHUB_REPOSITORY_OWNER}/befam-firebase-tools:${RELEASE_TAG}\`
@@ -135,7 +135,7 @@ jobs:
           echo "$ANDROID_RELEASE_KEYSTORE_BASE64" | base64 --decode > "$keystore_path"
           echo "ANDROID_KEYSTORE_PATH=$keystore_path" >> "$GITHUB_ENV"
 
-      - name: Build Android release APK
+      - name: Build Android release AAB
         env:
           FIREBASE_FUNCTIONS_REGION: ${{ vars.FIREBASE_FUNCTIONS_REGION }}
           APP_TIMEZONE: ${{ vars.APP_TIMEZONE }}
@@ -187,7 +187,7 @@ jobs:
               optional_firebase_defines+=(--dart-define="${key}=${value}")
             fi
           done
-          flutter build apk \
+          flutter build appbundle \
             --release \
             --build-name "${{ needs.prepare-release.outputs.version }}" \
             --build-number "${{ needs.prepare-release.outputs.build_number }}" \
@@ -197,11 +197,11 @@ jobs:
             --dart-define=BEFAM_INVALID_CHECKOUT_HOSTS="${invalid_hosts}" \
             "${optional_firebase_defines[@]}"
 
-      - name: Upload Android release APK
+      - name: Upload Android release AAB
         uses: actions/upload-artifact@v4
         with:
-          name: android-release-apk
-          path: mobile/befam/build/app/outputs/flutter-apk/app-release.apk
+          name: android-release-aab
+          path: mobile/befam/build/app/outputs/bundle/release/app-release.aab
 
   build-ios-release:
     name: Build iOS release IPA
@@ -507,10 +507,10 @@ jobs:
           name: release-notes
           path: dist
 
-      - name: Download Android release APK
+      - name: Download Android release AAB
         uses: actions/download-artifact@v4
         with:
-          name: android-release-apk
+          name: android-release-aab
           path: dist/android
 
       - name: Download signed iOS release IPA
@@ -526,8 +526,8 @@ jobs:
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           title="BeFam ${RELEASE_TAG}"
-          android_asset_path="dist/android/app-release.apk"
-          android_asset_name="befam-${RELEASE_VERSION}-android-release.apk"
+          android_asset_path="dist/android/app-release.aab"
+          android_asset_name="befam-${RELEASE_VERSION}-android-release.aab"
           ios_asset_path="dist/ios/befam-${RELEASE_VERSION}-ios-release.ipa"
           ios_asset_name="befam-${RELEASE_VERSION}-ios-release.ipa"
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ flutter test
 flutter run
 ```
 
+### Android Release (Production Best Practice)
+
+```bash
+cd mobile/befam
+flutter clean
+flutter pub get
+flutter build appbundle --release
+```
+
+Mental model:
+
+- Flutter code -> Gradle -> AAB -> Google Play -> device-specific APK
+- Keep Crashlytics enabled for release builds
+- Avoid `print`-style logging in release code paths
+
 ### Flutter Run Helper Script
 
 Use the helper script when you want a simple guided menu to run on Android, iOS, or Web without manually typing every target/device flag.
@@ -97,8 +112,22 @@ You can still call specific targets directly if needed:
 ```bash
 ./scripts/run_flutter_targets.sh devices
 ./scripts/run_flutter_targets.sh android-sim
+./scripts/run_flutter_targets.sh android-build-aab
+./scripts/run_flutter_targets.sh android-build-aab-ci
 ./scripts/run_flutter_targets.sh ios-device-release
 ./scripts/run_flutter_targets.sh web-server 8080
+```
+
+Android production-style local build (same sequence as CI):
+
+```bash
+./scripts/run_flutter_targets.sh android-build-aab
+```
+
+Optional build metadata override:
+
+```bash
+BEFAM_BUILD_NAME=1.2.3 BEFAM_BUILD_NUMBER=123 ./scripts/run_flutter_targets.sh android-build-aab
 ```
 
 Interactive wizard example:

--- a/docs/05-devops/branching-strategy.md
+++ b/docs/05-devops/branching-strategy.md
@@ -20,7 +20,7 @@ releases.
 - require one approval and passing Branch CI before merge to `staging` or `main`
 - promote `staging` to `main` through the weekly release PR
 - use merge commits for the `staging` to `main` promotion so release history stays aligned
-- let `main` release automation create the semver tag, GitHub release, Android APK asset, unsigned iOS XCArchive asset, and GHCR mobile plus Firebase images
+- let `main` release automation create the semver tag, GitHub release, Android AAB asset, signed iOS IPA asset, and GHCR mobile plus Firebase images
 - let Firebase production deploys run from `main` with GitHub environment-scoped credentials
 
 ## Example

--- a/docs/05-devops/github-workflow.md
+++ b/docs/05-devops/github-workflow.md
@@ -15,7 +15,7 @@ reviews, CI, and release promotion.
 8. use `Closes #123` keywords in the staging PR for stories that are truly complete in that branch
 9. let the weekly release workflow open the `staging` to `main` production PR
 10. approve the release PR and let auto-merge finish the production promotion
-11. publish docs from `main`, deploy Firebase production changes, create the GitHub release, upload the Android APK plus unsigned iOS archive, publish the mobile and Firebase images, and close released stories and epics
+11. publish docs from `main`, deploy Firebase production changes, create the GitHub release, upload the Android AAB plus signed iOS IPA, publish the mobile and Firebase images, and close released stories and epics
 
 ## Pull request checklist
 
@@ -35,7 +35,7 @@ The GitHub setup includes:
 - labels for epics, stories, domains, and agent-driven work
 - a backlog bootstrap script that creates GitHub issues from the source planning doc
 - a production Firebase deployment workflow that reads credentials from the `production` environment
-- a production release workflow that cuts semver tags, writes friendly notes, uploads the Android APK plus unsigned iOS archive, and publishes the mobile and Firebase images
+- a production release workflow that cuts semver tags, writes friendly notes, uploads the Android AAB plus signed iOS IPA, and publishes the mobile and Firebase images
 
 ## Backlog source of truth
 

--- a/docs/07-operations/monitoring.md
+++ b/docs/07-operations/monitoring.md
@@ -61,7 +61,7 @@ When release issues appear:
 
 1. check GitHub Actions workflow run details
 2. verify Firebase deploy credentials and project variables
-3. confirm app build artifact outputs (APK and iOS archive)
+3. confirm app build artifact outputs (Android AAB and iOS IPA)
 4. review function logs for trigger/callable failures
 5. inspect mobile logs for `perf.*` warnings to identify regressions
 6. verify fallback UI occurrence and Crashlytics traces for render failures

--- a/docs/GITHUB_AUTOMATION_AI_PIPELINE.md
+++ b/docs/GITHUB_AUTOMATION_AI_PIPELINE.md
@@ -57,8 +57,8 @@ On `main` pushes:
 - computes next semver tag
 - creates tag when needed
 - generates friendly release notes
-- builds Android release APK
-- builds unsigned iOS archive and zips artifact
+- builds Android release AAB
+- builds signed iOS IPA artifact
 - publishes GitHub release with artifacts
 - builds/pushes GHCR images:
   - `befam-mobile-builder`

--- a/docs/vi/05-devops/release-test-plan.md
+++ b/docs/vi/05-devops/release-test-plan.md
@@ -70,7 +70,7 @@ Tài liệu này là bộ kiểm thử đầy đủ để xác minh BeFam sẵn 
    - `cd mobile/befam && flutter pub get && flutter gen-l10n && flutter analyze && flutter test --dart-define=BEFAM_ALLOW_BUNDLED_FIREBASE_OPTIONS=true`
 4. Build artifact kiểm tra:
    - web release build
-   - Android release APK
+   - Android release AAB
    - iOS release build (local CI/runner nội bộ)
 5. Chạy manual P0 suite (Auth -> Multi-clan -> Core operations -> Billing -> Notifications).
 6. Chạy manual P1 suite (UX edge cases, localization, permission denial, long list/lazy loading).

--- a/scripts/run_flutter_targets.sh
+++ b/scripts/run_flutter_targets.sh
@@ -32,6 +32,15 @@ Targets:
   android-release [device_id]
     - Run Android in release mode (choose device if omitted)
 
+  android-build-aab [extra flutter args...]
+    - CI-like local release build:
+      flutter clean -> flutter pub get -> flutter gen-l10n -> flutter build appbundle --release
+    - Requires release signing envs (or key.properties)
+
+  android-build-aab-ci [extra flutter args...]
+    - Same as android-build-aab, but auto-generates a temporary signing keystore
+      if release signing envs are not available (for quick local test only)
+
   ios-sim [device_id]
     - Run iOS Simulator in debug mode (choose simulator if omitted)
 
@@ -54,6 +63,8 @@ Examples:
   ./scripts/run_flutter_targets.sh
   ./scripts/run_flutter_targets.sh devices
   ./scripts/run_flutter_targets.sh android-sim
+  ./scripts/run_flutter_targets.sh android-build-aab
+  ./scripts/run_flutter_targets.sh android-build-aab-ci
   ./scripts/run_flutter_targets.sh ios-sim ios
   ./scripts/run_flutter_targets.sh ios-device-release
   ./scripts/run_flutter_targets.sh web-server 8080
@@ -64,6 +75,9 @@ Notes:
     unless you override it explicitly in extra Flutter args.
   - Any exported `BEFAM_FIREBASE_*` env value will also be forwarded as `--dart-define`
     so you can point to a different Firebase project without changing source files.
+  - For AAB build targets, you can override version metadata with:
+      BEFAM_BUILD_NAME=1.2.3
+      BEFAM_BUILD_NUMBER=123
 EOF
 }
 
@@ -136,6 +150,8 @@ select_android_target_interactive() {
   local options=(
     "Android simulator/device (Debug)"
     "Android simulator/device (Release)"
+    "Build Android AAB (Release)"
+    "Build Android AAB (CI-like local test)"
     "Back"
   )
   local choice=""
@@ -156,6 +172,14 @@ select_android_target_interactive() {
         return 0
         ;;
       3)
+        echo "android-build-aab"
+        return 0
+        ;;
+      4)
+        echo "android-build-aab-ci"
+        return 0
+        ;;
+      5)
         echo "$(select_target_interactive)"
         return 0
         ;;
@@ -164,6 +188,82 @@ select_android_target_interactive() {
         ;;
     esac
   done
+}
+
+prepare_android_release_signing() {
+  local allow_temp_signing="${1:-false}"
+
+  if [[ -n "${ANDROID_KEYSTORE_PATH:-}" ]] && \
+     [[ -n "${ANDROID_KEYSTORE_PASSWORD:-}" ]] && \
+     [[ -n "${ANDROID_KEY_ALIAS:-}" ]] && \
+     [[ -n "${ANDROID_KEY_PASSWORD:-}" ]] && \
+     [[ -f "${ANDROID_KEYSTORE_PATH}" ]]; then
+    return 0
+  fi
+
+  if [[ -n "${ANDROID_RELEASE_KEYSTORE_BASE64:-}" ]] && \
+     [[ -n "${ANDROID_RELEASE_KEYSTORE_PASSWORD:-}" ]] && \
+     [[ -n "${ANDROID_RELEASE_KEY_ALIAS:-}" ]] && \
+     [[ -n "${ANDROID_RELEASE_KEY_PASSWORD:-}" ]]; then
+    local decoded_keystore_path
+    decoded_keystore_path="$(mktemp "${TMPDIR:-/tmp}/befam-android-release-XXXXXX.keystore")"
+    echo "$ANDROID_RELEASE_KEYSTORE_BASE64" | base64 --decode > "$decoded_keystore_path"
+    export ANDROID_KEYSTORE_PATH="$decoded_keystore_path"
+    export ANDROID_KEYSTORE_PASSWORD="$ANDROID_RELEASE_KEYSTORE_PASSWORD"
+    export ANDROID_KEY_ALIAS="$ANDROID_RELEASE_KEY_ALIAS"
+    export ANDROID_KEY_PASSWORD="$ANDROID_RELEASE_KEY_PASSWORD"
+    return 0
+  fi
+
+  if [[ "$allow_temp_signing" == "true" ]]; then
+    require_cmd keytool
+    local temp_keystore_path
+    temp_keystore_path="$(mktemp "${TMPDIR:-/tmp}/befam-android-ci-XXXXXX.keystore")"
+    keytool -genkeypair \
+      -v \
+      -storetype PKCS12 \
+      -keystore "$temp_keystore_path" \
+      -storepass "android" \
+      -alias "ci-upload" \
+      -keyalg RSA \
+      -keysize 2048 \
+      -validity 3650 \
+      -keypass "android" \
+      -dname "CN=BeFam Local CI, OU=CI, O=BeFam, L=HCMC, S=HCMC, C=VN" >/dev/null 2>&1
+    export ANDROID_KEYSTORE_PATH="$temp_keystore_path"
+    export ANDROID_KEYSTORE_PASSWORD="android"
+    export ANDROID_KEY_ALIAS="ci-upload"
+    export ANDROID_KEY_PASSWORD="android"
+    return 0
+  fi
+
+  echo "Missing Android release signing configuration." >&2
+  echo "Provide one of these options before building AAB:" >&2
+  echo "  1) ANDROID_KEYSTORE_PATH + ANDROID_KEYSTORE_PASSWORD + ANDROID_KEY_ALIAS + ANDROID_KEY_PASSWORD" >&2
+  echo "  2) ANDROID_RELEASE_KEYSTORE_BASE64 + ANDROID_RELEASE_KEYSTORE_PASSWORD + ANDROID_RELEASE_KEY_ALIAS + ANDROID_RELEASE_KEY_PASSWORD" >&2
+  return 1
+}
+
+build_android_aab_release() {
+  local allow_temp_signing="${1:-false}"
+  shift || true
+
+  cd "$APP_DIR"
+  flutter clean
+  flutter pub get
+  flutter gen-l10n
+  prepare_android_release_signing "$allow_temp_signing"
+
+  local build_name="${BEFAM_BUILD_NAME:-0.0.0}"
+  local build_number="${BEFAM_BUILD_NUMBER:-1}"
+  flutter build appbundle \
+    --release \
+    --build-name "$build_name" \
+    --build-number "$build_number" \
+    "${BEFAM_DART_DEFINE_ARGS[@]}" \
+    "$@"
+
+  echo "AAB generated at: $APP_DIR/build/app/outputs/bundle/release/app-release.aab"
 }
 
 select_ios_target_interactive() {
@@ -450,6 +550,14 @@ case "$TARGET" in
     cd "$APP_DIR"
     flutter pub get
     flutter run --release -d "$DEVICE_ID" "${BEFAM_DART_DEFINE_ARGS[@]}" "$@"
+    ;;
+
+  android-build-aab)
+    build_android_aab_release "false" "$@"
+    ;;
+
+  android-build-aab-ci)
+    build_android_aab_release "true" "$@"
     ;;
 
   ios-sim)


### PR DESCRIPTION
## Summary\n- switch Android release workflow artifacts from APK to AAB\n- update branch CI Android build to appbundle (release AAB)\n- add local helper targets: `android-build-aab` and `android-build-aab-ci` in `run_flutter_targets.sh`\n- align README and DevOps docs to AAB + signed IPA terminology\n\n## Notes\n- only these CI/script/docs files are included in this PR\n- unrelated local changes were intentionally left uncommitted