### PR TITLE
ci(ios): refresh CocoaPods specs during release builds

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -860,7 +860,7 @@ jobs:
 
       - name: Install CocoaPods dependencies
         working-directory: mobile/befam/ios
-        run: pod install
+        run: pod install --repo-update
 
       - name: Generate localization files
         run: flutter gen-l10n

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -811,7 +811,7 @@ jobs:
 
       - name: Install CocoaPods dependencies
         working-directory: mobile/befam/ios
-        run: pod install
+        run: pod install --repo-update
 
       - name: Generate localization files
         run: flutter gen-l10n

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -375,7 +375,7 @@ jobs:
 
       - name: Install CocoaPods dependencies
         working-directory: mobile/befam/ios
-        run: pod install
+        run: pod install --repo-update
 
       - name: Generate localization files
         run: flutter gen-l10n


### PR DESCRIPTION
## Summary
- Fixes the iOS release job failing at `pod install` while resolving `webview_flutter_wkwebview`, a transitive CocoaPods dependency of `google_mobile_ads`.
- The production release workflow currently builds Android successfully but cannot package the signed iOS IPA until CocoaPods resolves specs on clean macOS runners.
- Uses CocoaPods' built-in repo refresh during install for the affected iOS release workflows.

## Changes
- Updated `.github/workflows/release-main.yml` to run `pod install --repo-update`.
- Updated `.github/workflows/release-staging.yml` to run `pod install --repo-update`.
- Updated `.github/workflows/deploy-staging.yml` to run `pod install --repo-update` for the staging iOS release test build.
- No app source, signing material, secrets, or store submission settings changed.

## Issue Link
- Related to failed GitHub Actions job: https://github.com/phamhungptithcm/gia-pha/actions/runs/28305059520/job/83865832559
- Supersedes PR #383, which became stacked after PR #382 was merged into its branch.

## Design Considerations
- Kept the fix at the workflow layer because the Dart dependency graph and lockfile already include `webview_flutter_wkwebview`.
- Applied the same install behavior to staging and production iOS release paths to prevent environment drift.
- Did not change app dependencies or Podfile structure because local CocoaPods installation succeeds once specs are refreshed.

## Testing
- `git diff --check`
- `cd mobile/befam/ios && COCOAPODS_DISABLE_STATS=true pod install --repo-update`
- `gitnexus detect-changes --repo gia-pha --scope staged`
- `actionlint -shellcheck= .github/workflows/release-main.yml .github/workflows/release-staging.yml .github/workflows/deploy-staging.yml`
- Also ran full `actionlint` on the same files; it reported pre-existing ShellCheck SC2129 style warnings in unrelated script blocks.

## Impact
- Backward compatible CI-only change.
- May add time to iOS release jobs because CocoaPods refreshes specs before install.
- No security or privacy impact; no secrets are read, written, or exposed by this change.
- Operational impact is limited to iOS release/staging build preparation.

## Deployment Notes
- After merge, rerun the production release workflow or trigger a new release build to regenerate the iOS IPA.
- No DB migrations, feature flags, signing changes, or rollback steps required.
- Rollback is reverting the workflow command to `pod install` if needed.

## Observability
- No logging, metrics, dashboards, or alerts changed.
- GitHub Actions job logs will show CocoaPods updating specs before dependency analysis.

## Checklist
- [x] Code follows project standards
- [x] Tests added/updated
- [x] No sensitive data exposed
- [x] Backward compatibility verified
- [x] Documentation updated if needed
- [x] Linked GitHub issue included
