### PR TITLE
ci(ios): force CocoaPods plugin graph for releases

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -855,8 +855,14 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Use CocoaPods for iOS plugin integration
+        run: flutter config --no-enable-swift-package-manager
+
       - name: Install Flutter dependencies
         run: flutter pub get
+
+      - name: Verify iOS CocoaPods plugin graph
+        run: ruby ../../scripts/verify_flutter_ios_pod_graph.rb .
 
       - name: Install CocoaPods dependencies
         working-directory: mobile/befam/ios

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -806,8 +806,14 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Use CocoaPods for iOS plugin integration
+        run: flutter config --no-enable-swift-package-manager
+
       - name: Install Flutter dependencies
         run: flutter pub get
+
+      - name: Verify iOS CocoaPods plugin graph
+        run: ruby ../../scripts/verify_flutter_ios_pod_graph.rb .
 
       - name: Install CocoaPods dependencies
         working-directory: mobile/befam/ios

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -370,8 +370,14 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Use CocoaPods for iOS plugin integration
+        run: flutter config --no-enable-swift-package-manager
+
       - name: Install Flutter dependencies
         run: flutter pub get
+
+      - name: Verify iOS CocoaPods plugin graph
+        run: ruby ../../scripts/verify_flutter_ios_pod_graph.rb .
 
       - name: Install CocoaPods dependencies
         working-directory: mobile/befam/ios

--- a/scripts/verify_flutter_ios_pod_graph.rb
+++ b/scripts/verify_flutter_ios_pod_graph.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'pathname'
+
+app_root = Pathname.new(ARGV.fetch(0, '.')).expand_path
+deps_path = app_root.join('.flutter-plugins-dependencies')
+
+abort("Missing #{deps_path}. Run flutter pub get first.") unless deps_path.file?
+
+deps = JSON.parse(deps_path.read)
+spm_enabled = deps.fetch('swift_package_manager_enabled', {}).fetch('ios', nil)
+ios_plugins = deps.fetch('plugins').fetch('ios')
+plugins_by_name = ios_plugins.to_h { |plugin| [plugin.fetch('name'), plugin] }
+
+required_plugins = %w[google_mobile_ads webview_flutter_wkwebview]
+missing_plugins = required_plugins.reject { |name| plugins_by_name.key?(name) }
+unless missing_plugins.empty?
+  abort("Missing iOS Flutter plugin(s): #{missing_plugins.join(', ')}")
+end
+
+google_mobile_ads = plugins_by_name.fetch('google_mobile_ads')
+webview_wkwebview = plugins_by_name.fetch('webview_flutter_wkwebview')
+google_mobile_ads_dependencies = google_mobile_ads.fetch('dependencies', [])
+
+unless google_mobile_ads_dependencies.include?('webview_flutter_wkwebview')
+  abort('google_mobile_ads no longer declares webview_flutter_wkwebview; review this guard before release.')
+end
+
+unless spm_enabled == false
+  abort("Expected swift_package_manager_enabled.ios=false for CocoaPods release builds; got #{spm_enabled.inspect}.")
+end
+
+webview_path = Pathname.new(webview_wkwebview.fetch('path'))
+webview_path = app_root.join(webview_path) unless webview_path.absolute?
+webview_darwin_dir = webview_path.join('darwin')
+webview_podspec = webview_darwin_dir.join('webview_flutter_wkwebview.podspec')
+webview_package_swift = webview_darwin_dir.join('webview_flutter_wkwebview', 'Package.swift')
+
+unless webview_podspec.file?
+  abort("Missing local webview_flutter_wkwebview podspec at #{webview_podspec}.")
+end
+
+puts "swift_package_manager_enabled.ios=#{spm_enabled.inspect}"
+puts "google_mobile_ads.dependencies=#{google_mobile_ads_dependencies.join(',')}"
+puts "webview_flutter_wkwebview.podspec=#{webview_podspec}"
+puts "webview_flutter_wkwebview.package_swift=#{webview_package_swift.file? ? webview_package_swift : 'not present'}"
+puts 'iOS CocoaPods plugin graph is release-ready.'


### PR DESCRIPTION
## Summary
- Fixes the repeated iOS release `pod install --repo-update` failure where CocoaPods cannot resolve `webview_flutter_wkwebview` required by `google_mobile_ads`.
- The previous fixes proved CocoaPods repo freshness and Dart dependency presence were not the root cause.
- The release workflow now disables Flutter Swift Package Manager for iOS release dependency resolution and verifies the generated plugin graph before CocoaPods runs.

## Changes
- Adds `scripts/verify_flutter_ios_pod_graph.rb` to inspect `.flutter-plugins-dependencies` after `flutter pub get`.
- Fails early if `swift_package_manager_enabled.ios` is not `false` for release builds.
- Verifies `google_mobile_ads` still declares `webview_flutter_wkwebview` and the local webview podspec exists.
- Applies the guard to iOS release jobs in `release-main`, `release-staging`, and `deploy-staging`.

## Issue Link
- Related to #385
- Related to failed release run: https://github.com/phamhungptithcm/gia-pha/actions/runs/28323168689/job/83910590535

## Design Considerations
- Chose a focused CI dependency-manager fix instead of upgrading `google_mobile_ads` or pinning Flutter, both of which have broader release risk.
- Kept CocoaPods as the single iOS plugin integration path for release jobs because `google_mobile_ads` is still resolved through CocoaPods.
- Added a guard so future failures expose Flutter plugin graph state instead of only surfacing CocoaPods resolver output.

## Testing
- Reproduced local failure with `flutter config --enable-swift-package-manager`, `flutter pub get`, and `pod install --repo-update`: same missing `webview_flutter_wkwebview` CocoaPods error.
- Verified fix locally with `flutter config --no-enable-swift-package-manager`, `flutter pub get`, `ruby ../../scripts/verify_flutter_ios_pod_graph.rb .`, and `pod install --repo-update`.
- Ran `ruby -c scripts/verify_flutter_ios_pod_graph.rb`.
- Ran `actionlint -shellcheck= .github/workflows/release-main.yml .github/workflows/release-staging.yml .github/workflows/deploy-staging.yml`.
- Ran `git diff --check` for touched files.
- Ran `cd mobile/befam && flutter analyze`.
- Ran `cd mobile/befam && flutter test`.
- Ran `gitnexus detect-changes --repo gia-pha --scope all`.

## Impact
- Backward compatible with the current Flutter app dependency set.
- No runtime app behavior change.
- No sensitive data added or exposed.
- Operational impact is limited to iOS release/staging release dependency resolution.

## Deployment Notes
- After merge, rerun the production release workflow from `main`.
- This does not submit or publish to App Store or Google Play.
- Rollback is reverting the workflow steps and guard script.

## Observability
- The release logs will now print `swift_package_manager_enabled.ios`, the `google_mobile_ads` plugin dependency edge, and the local `webview_flutter_wkwebview` podspec path before `pod install`.

## Checklist
- [x] Code follows project standards
- [x] Tests added/updated
- [x] No sensitive data exposed
- [x] Backward compatibility verified
- [x] Documentation updated if needed
- [x] Linked GitHub issue included