### PR TITLE
fix(billing): allow direct Apple server notifications

### DIFF
--- a/docs/en/05-devops/production-configuration.md
+++ b/docs/en/05-devops/production-configuration.md
@@ -112,7 +112,8 @@ Required when `OTP_PROVIDER=twilio`:
 Optional secrets:
 - `CARD_WEBHOOK_SECRET`
 - `BILLING_CONTACT_NOTICE_WEBHOOK_TOKEN`
-- `APPLE_IAP_WEBHOOK_BEARER_TOKEN`
+- `APPLE_IAP_WEBHOOK_BEARER_TOKEN` (leave unset for direct App Store Server
+  Notifications; Apple authenticates via the signed JWS payload)
 - `GOOGLE_IAP_WEBHOOK_BEARER_TOKEN`
 
 Required when `AI_ASSIST_ENABLED=true`:

--- a/docs/vi/05-devops/production-configuration.md
+++ b/docs/vi/05-devops/production-configuration.md
@@ -112,7 +112,8 @@ Bắt buộc khi `OTP_PROVIDER=twilio`:
 Secret tùy chọn:
 - `CARD_WEBHOOK_SECRET`
 - `BILLING_CONTACT_NOTICE_WEBHOOK_TOKEN`
-- `APPLE_IAP_WEBHOOK_BEARER_TOKEN`
+- `APPLE_IAP_WEBHOOK_BEARER_TOKEN` (để trống khi dùng trực tiếp App Store
+  Server Notifications; Apple xác thực bằng signed JWS payload)
 - `GOOGLE_IAP_WEBHOOK_BEARER_TOKEN`
 
 Secret bắt buộc khi `AI_ASSIST_ENABLED=true`:

--- a/docs/vi/05-devops/service-inventory.md
+++ b/docs/vi/05-devops/service-inventory.md
@@ -56,7 +56,7 @@ Legend:
 | Google Play IAP verify (Android) | Khuyên dùng (nếu test IAP) | Bắt buộc | `GOOGLE_PLAY_PACKAGE_NAME`, `BILLING_IAP_ALLOW_TEST_MOCK` | [ ] | [ ] |
 | Apple IAP verify (iOS) | Khuyên dùng (nếu test IAP) | Bắt buộc | `APPLE_SHARED_SECRET`, `BILLING_IAP_APPLE_VERIFY_*` | [ ] | [ ] |
 | Google RTDN qua Pub/Sub (Android subscription webhook) | Khuyên dùng | Bắt buộc | `GOOGLE_IAP_RTDN_AUDIENCE`, `GOOGLE_IAP_RTDN_SERVICE_ACCOUNT_EMAIL` | [ ] | [ ] |
-| Webhook auth token cho IAP | Tùy chọn (fallback qua secret chung) | Khuyên dùng | `APPLE_IAP_WEBHOOK_BEARER_TOKEN`, `GOOGLE_IAP_WEBHOOK_BEARER_TOKEN`, fallback `BILLING_WEBHOOK_SECRET` | [ ] | [ ] |
+| Webhook auth token cho IAP | Tùy chọn | Khuyên dùng | `GOOGLE_IAP_WEBHOOK_BEARER_TOKEN` fallback `BILLING_WEBHOOK_SECRET`; `APPLE_IAP_WEBHOOK_BEARER_TOKEN` chỉ dùng khi có proxy/caller thêm Bearer header | [ ] | [ ] |
 | URL store hiển thị trên web/app | Tùy chọn | Khuyên dùng | `BEFAM_IOS_APP_STORE_URL`, `BEFAM_ANDROID_PLAY_STORE_URL` | [ ] | [ ] |
 | Twilio Verify (OTP nhà mạng) | Tùy chọn | Tùy chọn (bắt buộc nếu `OTP_PROVIDER=twilio`) | `OTP_PROVIDER`, `OTP_TWILIO_VERIFY_SERVICE_SID`, `OTP_TWILIO_ACCOUNT_SID`, `OTP_TWILIO_AUTH_TOKEN` | [ ] | [ ] |
 | FCM Push notification | Khuyên dùng | Khuyên dùng | `NOTIFICATION_PUSH_ENABLED` + cấu hình Firebase Messaging của app | [ ] | [ ] |

--- a/firebase/functions/src/billing/iap-webhooks.ts
+++ b/firebase/functions/src/billing/iap-webhooks.ts
@@ -50,7 +50,10 @@ export const appleIapWebhook = onRequest(
     }
     try {
       const expectedToken = getAppleIapWebhookBearerToken();
-      if (!isAuthorizedWithSharedBearer(request, expectedToken)) {
+      if (
+        expectedToken.length > 0 &&
+        !isAuthorizedWithSharedBearer(request, expectedToken)
+      ) {
         response.status(401).json({ ok: false, message: 'Unauthorized' });
         return;
       }

--- a/firebase/functions/src/config/runtime.ts
+++ b/firebase/functions/src/config/runtime.ts
@@ -225,7 +225,7 @@ export function getAppleSharedSecret(): string {
 }
 
 export function getAppleIapWebhookBearerToken(): string {
-  return readEnvString('APPLE_IAP_WEBHOOK_BEARER_TOKEN', getBillingWebhookSecret());
+  return readEnvString('APPLE_IAP_WEBHOOK_BEARER_TOKEN');
 }
 
 export function getGooglePlayPackageName(): string {

--- a/scripts/github-production.env.example
+++ b/scripts/github-production.env.example
@@ -122,6 +122,8 @@ BEFAM_ADMOB_IOS_REWARDED_UNIT_ID=ca-app-pub-xxxxxxxxxxxxxxxx/ios-rewarded-unit-i
 
 # Optional secrets
 BILLING_CONTACT_NOTICE_WEBHOOK_TOKEN=
+# Leave empty for direct App Store Server Notifications; Apple authenticates via
+# the signed JWS payload and does not send a custom Bearer header.
 APPLE_IAP_WEBHOOK_BEARER_TOKEN=
 GOOGLE_IAP_WEBHOOK_BEARER_TOKEN=
 


### PR DESCRIPTION
## Summary
- Fixes the production Apple IAP webhook path so App Store Server Notifications can call it directly.
- Prevents `BILLING_WEBHOOK_SECRET` from being treated as a required Apple Bearer token.
- Keeps Google RTDN fallback bearer behavior unchanged.

## Changes
- `appleIapWebhook` only checks Bearer auth when `APPLE_IAP_WEBHOOK_BEARER_TOKEN` is explicitly configured.
- `getAppleIapWebhookBearerToken` no longer falls back to `BILLING_WEBHOOK_SECRET`.
- Updated production env/docs notes to leave the Apple Bearer token empty for direct App Store Server Notifications.

## Issue Link
Related to App Store Connect publish readiness blocker: App Store Server Notification URL was not set, and the current production endpoint returns `401` without a custom Bearer header.

## Design Considerations
- App Store Server Notifications authenticate through Apple's signed JWS payload, which the webhook already verifies.
- Direct App Store Connect configuration provides a URL, not a custom Authorization header.
- A dedicated Apple Bearer token remains supported for proxy/custom callers by explicitly setting `APPLE_IAP_WEBHOOK_BEARER_TOKEN`.

## Testing
- `cd firebase/functions && npm run build`
- `cd firebase/functions && npm test`
- `git diff --check`
- `npx gitnexus detect-changes --repo gia-pha --scope all` reported LOW risk.
- `graphify update .` rebuilt graph output but exited with existing CLI `NameError: _os`; no tracked graph files changed.

## Impact
- Backward compatible for direct Apple Server Notifications.
- If a proxy intentionally sends Apple notifications with Bearer auth, keep `APPLE_IAP_WEBHOOK_BEARER_TOKEN` configured and calls still require it.
- Google RTDN auth behavior is unchanged.

## Deployment Notes
- Merge and deploy Firebase Functions to production before setting/testing the App Store Server Notification URL.
- Production URL from configured vars: `https://asia-southeast1-befam-b43bd.cloudfunctions.net/appleIapWebhook`.

## Observability
- Existing structured webhook logs remain unchanged.

## Checklist
- [x] Code follows project standards
- [x] Tests added/updated where applicable
- [x] No sensitive data exposed
- [x] Backward compatibility verified
- [x] Documentation updated if needed
- [x] Linked GitHub issue included where available